### PR TITLE
feat: add WithModalKeyMap and tie key blocking to trapFocus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,20 @@ Format: `<type>: <description>` or `<type>(<scope>): <description>`
 For BREAKING CHANGES (major bump, e.g. 0.1.0 → 1.0.0), add `!` after the type:
 `feat!: remove deprecated API` or include `BREAKING CHANGE:` in the commit body.
 
+## Pull Requests IMPORTANT
+
+PR titles MUST pass the GitHub Actions checks before merging. There are two CI
+workflows that run on every PR:
+
+1. **PR Title** (`pr-title.yml`): Enforces conventional commit format on the PR
+   title using `action-semantic-pull-request`. The title must start with one of
+   the allowed types (`feat`, `fix`, `docs`, `chore`, `ci`, `test`, `refactor`,
+   `perf`, `build`, `revert`). This is the same format as commit messages.
+2. **CI** (`ci.yml`): Runs `go test ./...` on ubuntu-latest.
+
+Both checks must pass. Always verify your PR title matches the conventional
+commit format and that tests pass before considering a PR ready.
+
 Examples:
 ```
 gcommit -m "feat: add table element support"
@@ -444,7 +458,8 @@ func helper(s string) string {
 | `backdrop` | `string` | Backdrop style: `"dim"` (default), `"blank"`, or `"none"` |
 | `closeOnEscape` | `bool` | Escape key closes the modal (default true) |
 | `closeOnBackdropClick` | `bool` | Clicking backdrop closes the modal (default true) |
-| `trapFocus` | `bool` | Tab/Shift+Tab restricted to modal children (default true) |
+| `trapFocus` | `bool` | Tab/Shift+Tab restricted to modal children; also blocks unhandled keys from parents (default true) |
+| `keyMap` | `expression` | Custom KeyMap bindings for the modal; fire before the catch-all when trapFocus is true |
 
 ### Input-specific Attributes
 

--- a/cmd/tui/testdata/modal.gsx
+++ b/cmd/tui/testdata/modal.gsx
@@ -5,12 +5,21 @@ import tui "github.com/grindlemire/go-tui"
 type myModal struct {
 	app        *tui.App
 	showModal  *tui.State[bool]
+	gameOver   *tui.State[bool]
 	confirmBtn tui.Ref
 }
 
 func MyModal() *myModal {
 	return &myModal{
 		showModal: tui.NewState(false),
+		gameOver:  tui.NewState(false),
+	}
+}
+
+func (c *myModal) gameOverKeys() tui.KeyMap {
+	return tui.KeyMap{
+		tui.OnPreemptStop(tui.Rune('n'), func(ke tui.KeyEvent) {}),
+		tui.OnPreemptStop(tui.Rune('q'), func(ke tui.KeyEvent) {}),
 	}
 }
 
@@ -21,6 +30,11 @@ templ (c *myModal) Render() {
 			<div class="w-40 border-rounded p-2 flex-col gap-1">
 				<span class="font-bold">Are you sure?</span>
 				<button ref={c.confirmBtn}>OK</button>
+			</div>
+		</modal>
+		<modal open={c.gameOver} keyMap={c.gameOverKeys()} trapFocus={false}>
+			<div class="border-rounded p-2">
+				<span>Game Over</span>
 			</div>
 		</modal>
 	</div>

--- a/cmd/tui/testdata/modal_gsx.go
+++ b/cmd/tui/testdata/modal_gsx.go
@@ -10,12 +10,21 @@ import (
 type myModal struct {
 	app        *tui.App
 	showModal  *tui.State[bool]
+	gameOver   *tui.State[bool]
 	confirmBtn tui.Ref
 }
 
 func MyModal() *myModal {
 	return &myModal{
 		showModal: tui.NewState(false),
+		gameOver:  tui.NewState(false),
+	}
+}
+
+func (c *myModal) gameOverKeys() tui.KeyMap {
+	return tui.KeyMap{
+		tui.OnPreemptStop(tui.Rune('n'), func(ke tui.KeyEvent) {}),
+		tui.OnPreemptStop(tui.Rune('q'), func(ke tui.KeyEvent) {}),
 	}
 }
 
@@ -53,6 +62,23 @@ func (c *myModal) Render(app *tui.App) *tui.Element {
 	__tui_3.AddChild(__tui_5)
 	__tui_2.AddChild(__tui_3)
 	__tui_0.AddChild(__tui_2)
+	__tui_7 := app.MountPersistent(c, 1, func() tui.Component {
+		return tui.NewModal(
+			tui.WithModalOpen(c.gameOver),
+			tui.WithModalKeyMap(c.gameOverKeys()),
+			tui.WithModalTrapFocus(false),
+		)
+	})
+	__tui_8 := tui.New(
+		tui.WithBorder(tui.BorderRounded),
+		tui.WithPadding(2),
+	)
+	__tui_9 := tui.New(
+		tui.WithText("Game Over"),
+	)
+	__tui_8.AddChild(__tui_9)
+	__tui_7.AddChild(__tui_8)
+	__tui_0.AddChild(__tui_7)
 
 	return __tui_0
 }
@@ -71,6 +97,9 @@ func (c *myModal) BindApp(app *tui.App) {
 	c.app = app
 	if c.showModal != nil {
 		c.showModal.BindApp(app)
+	}
+	if c.gameOver != nil {
+		c.gameOver.BindApp(app)
 	}
 }
 

--- a/docs/content/guides/05-elements.md
+++ b/docs/content/guides/05-elements.md
@@ -227,7 +227,7 @@ Color the bar with `text-cyan`, `text-green`, `text-yellow`, etc. to convey mean
 
 ## Modal Dialogs
 
-The `<modal>` element renders as a full-screen overlay. When open, it dims the background, traps keyboard focus, and blocks parent key handlers. Escape and backdrop clicks close it by default.
+The `<modal>` element renders as a full-screen overlay. When open, it dims the background and closes on Escape and backdrop clicks by default. With `trapFocus` enabled (the default), it also traps Tab navigation and blocks unhandled keys from parents. Set `trapFocus={false}` to let keys pass through, or provide a `keyMap` for custom hotkeys.
 
 Bind the `open` attribute to a `*State[bool]` to control visibility. Use `onActivate` on buttons to handle Enter key activation:
 
@@ -251,7 +251,8 @@ Key attributes:
 | `backdrop` | `"dim"` | `"dim"`, `"blank"`, or `"none"` |
 | `closeOnEscape` | `true` | Escape key closes the modal |
 | `closeOnBackdropClick` | `true` | Clicking outside the dialog closes it |
-| `trapFocus` | `true` | Restrict Tab navigation and block parent key handlers |
+| `trapFocus` | `true` | Restrict Tab navigation and block unhandled keys from parents |
+| `keyMap` | — | Custom `KeyMap` bindings for modal hotkeys |
 
 Focusable elements with borders get an automatic cyan highlight when focused. The first focusable child receives focus when the modal opens.
 

--- a/docs/content/guides/08-events.md
+++ b/docs/content/guides/08-events.md
@@ -33,7 +33,7 @@ Three helper functions cover the binding patterns, each accepting a `KeyMatcher`
 | `On(matcher, handler)` | Continues | Default binding; other components can also handle the event |
 | `OnStop(matcher, handler)` | Stops | Exclusive ownership; no other component sees the event |
 | `OnFocused(matcher, handler)` | Stops (focus-gated) | Only fires when the component has focus |
-| `OnPreemptStop(matcher, handler)` | Stops (preemptive) | Fires before all normal handlers; used by modal to block parent keys |
+| `OnPreemptStop(matcher, handler)` | Stops (preemptive) | Fires before all normal handlers; used by modal (when `trapFocus` is true) to block parent keys |
 
 A `KeyMatcher` can be a Key constant (`tui.KeyEscape`), a specific rune (`tui.Rune('q')`), or the catch-all `tui.AnyRune`. Key and RuneSpec both support `.Ctrl()`, `.Alt()`, and `.Shift()` modifier methods.
 

--- a/docs/content/guides/11-focus.md
+++ b/docs/content/guides/11-focus.md
@@ -197,9 +197,11 @@ Both `SetOnFocus` and `SetOnBlur` implicitly set the element as focusable.
 
 ## Modal Focus Trapping
 
-When a `<modal>` has `trapFocus` enabled (the default), Tab and Shift+Tab only cycle through focusable elements inside the modal. Elements outside the modal are unreachable until it closes.
+When a `<modal>` has `trapFocus` enabled (the default), Tab and Shift+Tab only cycle through focusable elements inside the modal. Elements outside the modal are unreachable until it closes. A catch-all binding also blocks unhandled keys from parent handlers.
 
-The modal also handles Enter by triggering the focused element's `onActivate` callback, and blocks all parent key handlers via preemptive dispatch. When the modal closes, focus returns to the previously focused element.
+With `trapFocus={false}`, Tab and other keys propagate to parent components normally. You can combine this with the `keyMap` attribute to add custom hotkeys while letting everything else pass through.
+
+The modal handles Enter by triggering the focused element's `onActivate` callback regardless of the `trapFocus` setting. When the modal closes, focus returns to the previously focused element.
 
 Focusable elements with borders receive an automatic cyan border highlight when focused. You can override this behavior by providing your own `onFocus` and `onBlur` handlers.
 

--- a/docs/content/llm.md
+++ b/docs/content/llm.md
@@ -279,7 +279,8 @@ tui.WithPrintWidth(w int)  // Explicit width; default: auto-detect, fallback 80
 | `backdrop` | `string` | `"dim"` (default), `"blank"`, or `"none"` |
 | `closeOnEscape` | `bool` | Escape closes modal (default `true`) |
 | `closeOnBackdropClick` | `bool` | Backdrop click closes modal (default `true`) |
-| `trapFocus` | `bool` | Restrict Tab to modal children (default `true`) |
+| `trapFocus` | `bool` | Restrict Tab to modal children and block unhandled keys from parents (default `true`) |
+| `keyMap` | `expression` | Custom `KeyMap` bindings for the modal |
 
 ### Activation
 

--- a/docs/content/reference/built-in-components.md
+++ b/docs/content/reference/built-in-components.md
@@ -578,7 +578,8 @@ func NewModal(opts ...ModalOption) *Modal
 | `WithModalBackdrop(b string)` | Backdrop style: `"dim"` (default), `"blank"`, or `"none"` |
 | `WithModalCloseOnEscape(v bool)` | Escape closes the modal (default `true`) |
 | `WithModalCloseOnBackdropClick(v bool)` | Backdrop click closes the modal (default `true`) |
-| `WithModalTrapFocus(v bool)` | Restrict Tab navigation to modal children (default `true`) |
+| `WithModalTrapFocus(v bool)` | Restrict Tab navigation to modal children and block unhandled keys from parent handlers (default `true`) |
+| `WithModalKeyMap(km KeyMap)` | Custom key bindings for the modal; fire after built-in handlers but before the catch-all. Use `OnPreemptStop`; non-preemptive bindings (`On`, `OnStop`) are inert when `trapFocus` is true |
 | `WithModalElementOptions(opts ...Option)` | Pass layout options to the overlay container (used by generated code for `class` attributes) |
 
 ### GSX Attributes
@@ -591,7 +592,8 @@ All `<modal>` attributes and their types:
 | `backdrop` | `string` | `"dim"` (default), `"blank"`, or `"none"` |
 | `closeOnEscape` | `bool` | Escape closes the modal (default true) |
 | `closeOnBackdropClick` | `bool` | Backdrop click closes the modal (default true) |
-| `trapFocus` | `bool` | Tab/Shift+Tab restricted to modal children (default true) |
+| `trapFocus` | `bool` | Tab/Shift+Tab restricted to modal children; also blocks unhandled keys from parents (default true) |
+| `keyMap` | `expression` | Custom `KeyMap` bindings for the modal |
 | `class` | `string` | Tailwind classes for positioning (e.g. `"justify-center items-center"`) |
 
 ### Behavior
@@ -599,12 +601,26 @@ All `<modal>` attributes and their types:
 When open, the modal:
 
 - Applies the backdrop effect (dim, blank, or none) to the buffer before rendering the overlay
-- Traps Tab/Shift+Tab within its focusable children
 - Handles Enter by calling `Activate()` on the focused element
-- Blocks all parent key handlers via preemptive dispatch
 - Closes on Escape (if `closeOnEscape` is true)
 - Closes on backdrop click (if `closeOnBackdropClick` is true)
 - Walks clicked elements up to find `onActivate` callbacks for mouse support
+
+When `trapFocus` is true (the default):
+
+- Tab/Shift+Tab only cycle through focusable children inside the modal
+- A catch-all binding blocks unhandled keys from parent handlers
+
+When `trapFocus` is false, Tab and unhandled keys propagate to parent components normally.
+
+Custom key bindings provided via `WithModalKeyMap` (or the `keyMap` GSX attribute) fire after the built-in Escape/Tab/Enter handlers but before the catch-all. This lets you add hotkeys to a modal while still blocking everything else:
+
+```go
+tui.WithModalKeyMap(tui.KeyMap{
+    tui.OnPreemptStop(tui.Rune('n'), func(ke tui.KeyEvent) { startNewGame() }),
+    tui.OnPreemptStop(tui.Rune('q'), func(ke tui.KeyEvent) { quit() }),
+})
+```
 
 When closed, it returns a hidden placeholder element with no key bindings.
 
@@ -613,7 +629,7 @@ When closed, it returns a hidden placeholder element with no key bindings.
 | Interface | Purpose |
 |-----------|---------|
 | `Component` | `Render(app *App) *Element` returns the overlay element |
-| `KeyListener` | `KeyMap()` returns Escape, Tab, Enter, and catch-all bindings |
+| `KeyListener` | `KeyMap()` returns Escape, Tab, Enter, custom, and catch-all bindings (catch-all only when `trapFocus` is true) |
 | `MouseListener` | `HandleMouse()` handles backdrop click and onActivate delegation |
 | `AppBinder` | `BindApp()` wires the open state to the app |
 

--- a/docs/content/reference/events.md
+++ b/docs/content/reference/events.md
@@ -445,7 +445,7 @@ tui.OnFocused(tui.AnyRune, func(ke tui.KeyEvent) {
 func OnPreemptStop(m KeyMatcher, handler func(KeyEvent)) KeyBinding
 ```
 
-Creates a preemptive stop-propagation binding. Fires before all normal handlers in the dispatch table, preventing parent components from seeing the event. Used internally by Modal to block parent key handlers when the overlay is open.
+Creates a preemptive stop-propagation binding. Fires before all normal handlers in the dispatch table, preventing parent components from seeing the event. Used internally by Modal (when `trapFocus` is true) to block parent key handlers when the overlay is open. Also useful for custom modal key bindings via `WithModalKeyMap`.
 
 ```go
 // Block all keys from reaching parent handlers
@@ -552,7 +552,7 @@ Here's how events flow through the system.
 
 1. Terminal input is read and parsed into a `KeyEvent`.
 2. If the app uses the component model (struct components with `KeyMap()`), the dispatch table is built from all `KeyListener` components in tree order.
-3. **Preemptive pass**: bindings marked as preemptive (e.g., modal catch-all) fire first. If any stops the event, normal dispatch is skipped entirely.
+3. **Preemptive pass**: bindings marked as preemptive (e.g., modal catch-all when `trapFocus` is true) fire first. If any stops the event, normal dispatch is skipped entirely.
 4. Bindings are checked in order. The first match fires. If `Stop` is true, dispatch ends.
 5. If no binding stopped the event, it falls through to `App.Dispatch()` and the focus manager for element-level handlers.
 6. In legacy mode (no components), `WithGlobalKeyHandler` runs first. If it returns `true`, the event is consumed.

--- a/docs/content/reference/focus.md
+++ b/docs/content/reference/focus.md
@@ -7,9 +7,9 @@ Focus determines which element receives keyboard input. go-tui provides three la
 - **Element-level** -- individual elements marked as focusable, with `Focus()` and `Blur()` methods
 - **focusManager** -- internal tracking used by `App` to cycle through focusable elements with `FocusNext()` and `FocusPrev()`
 - **FocusGroup** -- a state-driven helper for Tab/Shift+Tab cycling between logical sections of your UI
-- **Modal focus trapping** -- when a modal is open with `trapFocus`, Tab/Shift+Tab only cycle through elements inside the modal overlay
+- **Modal focus trapping** -- when a modal is open with `trapFocus`, Tab/Shift+Tab only cycle through elements inside the modal overlay, and unhandled keys don't reach parent handlers
 
-Most applications use element-level focus through `.gsx` attributes and `App`-level navigation. `FocusGroup` is useful when you need to toggle between distinct panels or sections rather than individual elements. Modals provide automatic focus trapping that restricts navigation to the overlay content.
+Most applications use element-level focus through `.gsx` attributes and `App`-level navigation. `FocusGroup` is useful when you need to toggle between distinct panels or sections rather than individual elements. Modals with `trapFocus` enabled restrict both Tab navigation and keyboard input to the overlay content. With `trapFocus` disabled, keys pass through to parents normally.
 
 ## Focusable Interface
 

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -190,7 +190,7 @@ These hold text content and support text styling but not flex container attribut
 <textarea value={s.note} placeholder="Write here..." width={40} maxHeight={6} border={tui.BorderRounded} />
 ```
 
-**`<modal>`** -- Full-screen overlay dialog. Bind `open` to a `*State[bool]` for visibility. Accepts children for the dialog content. Supports `backdrop`, `closeOnEscape`, `closeOnBackdropClick`, `trapFocus`, and `class` for positioning.
+**`<modal>`** -- Full-screen overlay dialog. Bind `open` to a `*State[bool]` for visibility. Accepts children for the dialog content. Supports `backdrop`, `closeOnEscape`, `closeOnBackdropClick`, `trapFocus`, `keyMap`, and `class` for positioning.
 
 ```gsx
 <modal open={s.showDialog} class="justify-center items-center">
@@ -380,7 +380,8 @@ Available on: `div`, `ul`, `li`, `table`, `span`, `p`, `button`, `input`.
 | `backdrop` | `string` | `"dim"` (default), `"blank"`, or `"none"` |
 | `closeOnEscape` | `bool` | Escape closes modal (default `true`) |
 | `closeOnBackdropClick` | `bool` | Backdrop click closes modal (default `true`) |
-| `trapFocus` | `bool` | Restrict Tab to modal children (default `true`) |
+| `trapFocus` | `bool` | Restrict Tab to modal children and block unhandled keys from parents (default `true`) |
+| `keyMap` | `expression` | Custom `KeyMap` bindings for the modal |
 
 ### Scroll attributes
 

--- a/internal/lsp/schema/schema.go
+++ b/internal/lsp/schema/schema.go
@@ -411,7 +411,8 @@ func modalAttrs() []AttributeDef {
 		{Name: "backdrop", Type: "string", Description: "Backdrop style: \"dim\" (default), \"blank\", or \"none\"", Category: "visual"},
 		{Name: "closeOnEscape", Type: "bool", Description: "Escape key closes the modal (default true)", Category: "event"},
 		{Name: "closeOnBackdropClick", Type: "bool", Description: "Clicking backdrop closes the modal (default true)", Category: "event"},
-		{Name: "trapFocus", Type: "bool", Description: "Tab/Shift+Tab restricted to modal children (default true)", Category: "event"},
+		{Name: "trapFocus", Type: "bool", Description: "Tab/Shift+Tab restricted to modal children; when true, also blocks unhandled keys from reaching parent components (default true)", Category: "event"},
+		{Name: "keyMap", Type: "expression", Description: "Custom KeyMap bindings for the modal; fire before the catch-all when trapFocus is true", Category: "event"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -179,6 +179,7 @@ var knownAttributes = map[string]bool{
 	"closeOnEscape":        true,
 	"closeOnBackdropClick": true,
 	"trapFocus":            true,
+	"keyMap":               true,
 
 	// Activation
 	"onActivate": true,

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -388,6 +388,7 @@ var modalAttributeToOption = map[string]string{
 	"closeOnEscape":        "tui.WithModalCloseOnEscape(%s)",
 	"closeOnBackdropClick": "tui.WithModalCloseOnBackdropClick(%s)",
 	"trapFocus":            "tui.WithModalTrapFocus(%s)",
+	"keyMap":               "tui.WithModalKeyMap(%s)",
 }
 
 // modalHandlerAttributes maps modal event attributes to handler option funcs.

--- a/modal.go
+++ b/modal.go
@@ -11,6 +11,9 @@ type Modal struct {
 	trapFocus       bool
 	elementOpts     []Option
 
+	// Custom key bindings injected before the catch-all
+	customKeyMap KeyMap
+
 	// Internal state
 	app              *App
 	element          *Element
@@ -96,10 +99,11 @@ func (m *Modal) Render(app *App) *Element {
 }
 
 // KeyMap returns key bindings for the modal.
-// When trapFocus is true, all bindings are preemptive: they fire before parent
-// component handlers, and a catch-all consumes any unhandled keys.
-// When trapFocus is false, only explicitly configured keys (e.g. Escape) are
-// bound, allowing parent components to handle all other input.
+// Escape (if closeOnEscape) and Enter (activate focused element) are always
+// bound. When trapFocus is true, Tab/Shift+Tab cycling and an AnyKey catch-all
+// are added, blocking all unhandled keys from parent handlers. When trapFocus
+// is false, unhandled keys propagate to parent components. Custom bindings
+// from WithModalKeyMap are inserted before the catch-all.
 func (m *Modal) KeyMap() KeyMap {
 	if m.open == nil || !m.open.Get() {
 		return nil
@@ -125,13 +129,22 @@ func (m *Modal) KeyMap() KeyMap {
 				m.app.FocusPrev()
 			}),
 		)
-		// Enter activates the focused element's onActivate callback
-		km = append(km, OnPreemptStop(KeyEnter, func(ke KeyEvent) {
-			if focused, ok := m.app.Focused().(*Element); ok && focused != nil {
-				focused.Activate()
-			}
-		}))
-		// Catch-all: block all other keys from reaching parent handlers
+	}
+	// Enter activates the focused element's onActivate callback
+	km = append(km, OnPreemptStop(KeyEnter, func(ke KeyEvent) {
+		if m.app == nil {
+			return
+		}
+		if focused, ok := m.app.Focused().(*Element); ok && focused != nil {
+			focused.Activate()
+		}
+	}))
+	// Custom key bindings (user-provided via WithModalKeyMap)
+	km = append(km, m.customKeyMap...)
+	// Catch-all: block remaining keys from reaching parent handlers.
+	// Only active when trapFocus is true; with trapFocus=false, unhandled
+	// keys propagate to parent components.
+	if m.trapFocus {
 		km = append(km, OnPreemptStop(AnyKey, func(ke KeyEvent) {}))
 	}
 	return km

--- a/modal_options.go
+++ b/modal_options.go
@@ -43,6 +43,17 @@ func WithModalTrapFocus(v bool) ModalOption {
 	}
 }
 
+// WithModalKeyMap sets custom key bindings for the modal. These bindings fire
+// after the built-in Escape/Tab/Enter handlers but before the catch-all blocker
+// (when trapFocus is true). Use OnPreemptStop for bindings that should block
+// parent handlers. When trapFocus is true, non-preemptive bindings (On, OnStop)
+// will never fire because the AnyKey catch-all consumes events first.
+func WithModalKeyMap(km KeyMap) ModalOption {
+	return func(m *Modal) {
+		m.customKeyMap = km
+	}
+}
+
 // WithModalElementOptions passes through standard Element options to the modal's
 // container element. Used by the code generator to apply class-derived layout options.
 func WithModalElementOptions(opts ...Option) ModalOption {

--- a/modal_test.go
+++ b/modal_test.go
@@ -161,13 +161,13 @@ func TestModal_KeyMap_OnlyExpectedBindings(t *testing.T) {
 		"trapFocus false, escape true": {
 			trapFocus:    false,
 			escapeClose:  true,
-			wantKeys:     map[Key]bool{KeyEscape: true},
+			wantKeys:     map[Key]bool{KeyEscape: true, KeyEnter: true},
 			wantCatchAll: false,
 		},
 		"trapFocus false, escape false": {
 			trapFocus:    false,
 			escapeClose:  false,
-			wantKeys:     map[Key]bool{},
+			wantKeys:     map[Key]bool{KeyEnter: true},
 			wantCatchAll: false,
 		},
 	}


### PR DESCRIPTION
## Summary

- `Modal.KeyMap()` had a hardcoded `AnyKey` catch-all that swallowed all keyboard input when the modal was open, regardless of configuration. Setting `trapFocus=false` still blocked every key, which contradicted the option's purpose.
- The catch-all is now conditional on `trapFocus`. When `trapFocus=false`, unhandled keys pass through to parent handlers.
- New `WithModalKeyMap(km KeyMap)` option (and `keyMap` GSX attribute) lets users inject custom preemptive key bindings into a modal. These fire after the built-in Escape/Tab/Enter handlers but before the catch-all.
- Full pipeline support: analyzer, code generator, LSP schema, test fixture, and docs all updated.

## Breaking change

`trapFocus=false` now lets unhandled keys propagate to parents. Previously they were silently consumed by the catch-all.