### PR TITLE
fix: silent event delivery loss after root reset

### DIFF
--- a/app.go
+++ b/app.go
@@ -79,6 +79,7 @@ type App struct {
 	mounts        *mountState
 	dispatchTable *dispatchTable // Key broadcast dispatch table, rebuilt on dirty frames
 	rootComponent Component      // Root struct component (set via SetRoot with Component)
+	rootUnbinder  AppUnbinder    // Tracks the current root's AppUnbinder for swap-time teardown. Covers SetRootView where rootComponent is nil.
 
 	// Component watchers (from WatcherProvider components)
 	componentWatchers        []Watcher
@@ -327,19 +328,31 @@ func NewAppWithReader(reader EventReader, opts ...AppOption) (*App, error) {
 }
 
 // SetRoot sets the root element for rendering.
-func (a *App) SetRoot(root *Element) {
-	if prev, ok := a.rootComponent.(AppUnbinder); ok {
-		prev.UnbindApp()
+// unbindPreviousRoot drains the current root's AppUnbinder (if any) before a
+// new root is bound. Called from every root-setter so that Events subscriptions
+// owned by the outgoing root do not leak into the new session. skip lets a
+// caller protect against unbinding when the incoming root is the same instance.
+func (a *App) unbindPreviousRoot(skip AppUnbinder) {
+	if a.rootUnbinder == nil || a.rootUnbinder == skip {
+		return
 	}
+	a.rootUnbinder.UnbindApp()
+	a.rootUnbinder = nil
+}
+
+func (a *App) SetRoot(root *Element) {
+	a.unbindPreviousRoot(nil)
 	a.rootComponent = nil
 	a.applyRoot(root)
 }
 
 // SetRootView sets the root from a Viewable and starts its watchers.
 func (a *App) SetRootView(view Viewable) {
-	if prev, ok := a.rootComponent.(AppUnbinder); ok {
-		prev.UnbindApp()
+	var next AppUnbinder
+	if u, ok := view.(AppUnbinder); ok {
+		next = u
 	}
+	a.unbindPreviousRoot(next)
 	a.rootComponent = nil
 	if binder, ok := view.(AppBinder); ok {
 		binder.BindApp(a)
@@ -348,6 +361,7 @@ func (a *App) SetRootView(view Viewable) {
 	if binder, ok := view.(AppBinder); ok {
 		binder.BindApp(a)
 	}
+	a.rootUnbinder = next
 	for _, w := range view.GetWatchers() {
 		w.Start(a.watcherQueue, a.rootWatcherCh)
 	}
@@ -359,13 +373,16 @@ func (a *App) SetRootView(view Viewable) {
 // before the new component is bound. This drains its Events subscriptions from
 // a.topics so the outgoing root doesn't leak listeners across root swaps.
 func (a *App) SetRootComponent(component Component) {
-	if prev, ok := a.rootComponent.(AppUnbinder); ok && a.rootComponent != component {
-		prev.UnbindApp()
+	var next AppUnbinder
+	if u, ok := component.(AppUnbinder); ok {
+		next = u
 	}
+	a.unbindPreviousRoot(next)
 	if binder, ok := component.(AppBinder); ok {
 		binder.BindApp(a)
 	}
 	a.rootComponent = component
+	a.rootUnbinder = next
 	el := component.Render(a)
 	a.applyRoot(el)
 	if binder, ok := component.(AppBinder); ok {

--- a/app.go
+++ b/app.go
@@ -328,12 +328,18 @@ func NewAppWithReader(reader EventReader, opts ...AppOption) (*App, error) {
 
 // SetRoot sets the root element for rendering.
 func (a *App) SetRoot(root *Element) {
+	if prev, ok := a.rootComponent.(AppUnbinder); ok {
+		prev.UnbindApp()
+	}
 	a.rootComponent = nil
 	a.applyRoot(root)
 }
 
 // SetRootView sets the root from a Viewable and starts its watchers.
 func (a *App) SetRootView(view Viewable) {
+	if prev, ok := a.rootComponent.(AppUnbinder); ok {
+		prev.UnbindApp()
+	}
 	a.rootComponent = nil
 	if binder, ok := view.(AppBinder); ok {
 		binder.BindApp(a)
@@ -348,7 +354,14 @@ func (a *App) SetRootView(view Viewable) {
 }
 
 // SetRootComponent sets the root from a struct component.
+//
+// If a previous root component implements AppUnbinder, its UnbindApp is called
+// before the new component is bound. This drains its Events subscriptions from
+// a.topics so the outgoing root doesn't leak listeners across root swaps.
 func (a *App) SetRootComponent(component Component) {
+	if prev, ok := a.rootComponent.(AppUnbinder); ok && a.rootComponent != component {
+		prev.UnbindApp()
+	}
 	if binder, ok := component.(AppBinder); ok {
 		binder.BindApp(a)
 	}
@@ -393,12 +406,21 @@ func (a *App) resetRootSession() {
 	a.rootWatcherCh = mergeStopChannels(a.stopCh, a.rootStopCh)
 	a.focus = newFocusManager()
 	a.dispatchTable = nil
+
+	// Drain cached mounts via UnbindApp before tossing the cache so their
+	// Events subscriptions deregister themselves from a.topics. This replaces
+	// the former blanket wipe of a.topics, which also nuked valid subscriptions
+	// owned by the root component and required Events.BindApp to fight back.
+	if a.mounts != nil {
+		for _, comp := range a.mounts.cache {
+			if unbinder, ok := comp.(AppUnbinder); ok {
+				unbinder.UnbindApp()
+			}
+		}
+	}
 	a.mounts = newMountState()
 	a.componentWatchers = nil
 	a.componentWatchersStarted = false
-	a.topicMu.Lock()
-	a.topics = make(map[string]*topicSubscription)
-	a.topicMu.Unlock()
 }
 
 func mergeStopChannels(ch1, ch2 <-chan struct{}) <-chan struct{} {

--- a/app.go
+++ b/app.go
@@ -327,11 +327,14 @@ func NewAppWithReader(reader EventReader, opts ...AppOption) (*App, error) {
 	return app, nil
 }
 
-// SetRoot sets the root element for rendering.
 // unbindPreviousRoot drains the current root's AppUnbinder (if any) before a
 // new root is bound. Called from every root-setter so that Events subscriptions
 // owned by the outgoing root do not leak into the new session. skip lets a
 // caller protect against unbinding when the incoming root is the same instance.
+//
+// Interface equality relies on rootUnbinder holding a pointer receiver, which
+// every AppUnbinder in this codebase does. Storing a non-pointer value type
+// with an incomparable field would panic on comparison.
 func (a *App) unbindPreviousRoot(skip AppUnbinder) {
 	if a.rootUnbinder == nil || a.rootUnbinder == skip {
 		return
@@ -340,6 +343,7 @@ func (a *App) unbindPreviousRoot(skip AppUnbinder) {
 	a.rootUnbinder = nil
 }
 
+// SetRoot sets the root element for rendering.
 func (a *App) SetRoot(root *Element) {
 	a.unbindPreviousRoot(nil)
 	a.rootComponent = nil

--- a/app.go
+++ b/app.go
@@ -329,14 +329,9 @@ func NewAppWithReader(reader EventReader, opts ...AppOption) (*App, error) {
 
 // unbindPreviousRoot drains the current root's AppUnbinder (if any) before a
 // new root is bound. Called from every root-setter so that Events subscriptions
-// owned by the outgoing root do not leak into the new session. skip lets a
-// caller protect against unbinding when the incoming root is the same instance.
-//
-// Interface equality relies on rootUnbinder holding a pointer receiver, which
-// every AppUnbinder in this codebase does. Storing a non-pointer value type
-// with an incomparable field would panic on comparison.
-func (a *App) unbindPreviousRoot(skip AppUnbinder) {
-	if a.rootUnbinder == nil || a.rootUnbinder == skip {
+// owned by the outgoing root do not leak into the new session.
+func (a *App) unbindPreviousRoot() {
+	if a.rootUnbinder == nil {
 		return
 	}
 	a.rootUnbinder.UnbindApp()
@@ -345,27 +340,22 @@ func (a *App) unbindPreviousRoot(skip AppUnbinder) {
 
 // SetRoot sets the root element for rendering.
 func (a *App) SetRoot(root *Element) {
-	a.unbindPreviousRoot(nil)
+	a.unbindPreviousRoot()
 	a.rootComponent = nil
 	a.applyRoot(root)
 }
 
 // SetRootView sets the root from a Viewable and starts its watchers.
 func (a *App) SetRootView(view Viewable) {
-	var next AppUnbinder
-	if u, ok := view.(AppUnbinder); ok {
-		next = u
-	}
-	a.unbindPreviousRoot(next)
+	a.unbindPreviousRoot()
 	a.rootComponent = nil
 	if binder, ok := view.(AppBinder); ok {
 		binder.BindApp(a)
 	}
 	a.applyRoot(view.GetRoot())
-	if binder, ok := view.(AppBinder); ok {
-		binder.BindApp(a)
+	if u, ok := view.(AppUnbinder); ok {
+		a.rootUnbinder = u
 	}
-	a.rootUnbinder = next
 	for _, w := range view.GetWatchers() {
 		w.Start(a.watcherQueue, a.rootWatcherCh)
 	}
@@ -377,21 +367,16 @@ func (a *App) SetRootView(view Viewable) {
 // before the new component is bound. This drains its Events subscriptions from
 // a.topics so the outgoing root doesn't leak listeners across root swaps.
 func (a *App) SetRootComponent(component Component) {
-	var next AppUnbinder
-	if u, ok := component.(AppUnbinder); ok {
-		next = u
-	}
-	a.unbindPreviousRoot(next)
+	a.unbindPreviousRoot()
 	if binder, ok := component.(AppBinder); ok {
 		binder.BindApp(a)
 	}
 	a.rootComponent = component
-	a.rootUnbinder = next
+	if u, ok := component.(AppUnbinder); ok {
+		a.rootUnbinder = u
+	}
 	el := component.Render(a)
 	a.applyRoot(el)
-	if binder, ok := component.(AppBinder); ok {
-		binder.BindApp(a)
-	}
 }
 
 func (a *App) applyRoot(root *Element) {

--- a/cmd/tui/testdata/complex_gsx.go
+++ b/cmd/tui/testdata/complex_gsx.go
@@ -305,6 +305,7 @@ func WithHelper(text string) *WithHelperView {
 	var view WithHelperView
 	var watchers []tui.Watcher
 
+	var __tui_2 *ConditionalContentView
 	shouldShowHeader := true
 	otherHelperFunction("test")
 	__tui_0 := tui.New()
@@ -313,7 +314,7 @@ func WithHelper(text string) *WithHelperView {
 	)
 	__tui_0.AddChild(__tui_1)
 	if shouldShowHeader {
-		__tui_2 := ConditionalContent(true, false)
+		__tui_2 = ConditionalContent(true, false)
 		__tui_0.AddChild(__tui_2.Root)
 	} else {
 		__tui_3 := tui.New(
@@ -322,17 +323,23 @@ func WithHelper(text string) *WithHelperView {
 		__tui_0.AddChild(__tui_3)
 	}
 
-	watchers = append(watchers, __tui_2.GetWatchers()...)
+	if __tui_2 != nil {
+		watchers = append(watchers, __tui_2.GetWatchers()...)
+	}
 
 	__bindApp := func(app *tui.App) {
-		if binder, ok := any(__tui_2).(tui.AppBinder); ok {
-			binder.BindApp(app)
+		if __tui_2 != nil {
+			if binder, ok := any(__tui_2).(tui.AppBinder); ok {
+				binder.BindApp(app)
+			}
 		}
 	}
 
 	__unbindApp := func() {
-		if unbinder, ok := any(__tui_2).(tui.AppUnbinder); ok {
-			unbinder.UnbindApp()
+		if __tui_2 != nil {
+			if unbinder, ok := any(__tui_2).(tui.AppUnbinder); ok {
+				unbinder.UnbindApp()
+			}
 		}
 	}
 

--- a/cmd/tui/testdata/input_gsx.go
+++ b/cmd/tui/testdata/input_gsx.go
@@ -46,8 +46,15 @@ func (c *myInput) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*myInput)(nil)
 
-func (c *myInput) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (c *myInput) bindAppFields(app *tui.App) {
 	c.app = app
+}
+
+func (c *myInput) BindApp(app *tui.App) {
+	c.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*myInput)(nil)

--- a/cmd/tui/testdata/modal_gsx.go
+++ b/cmd/tui/testdata/modal_gsx.go
@@ -93,7 +93,10 @@ func (c *myModal) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*myModal)(nil)
 
-func (c *myModal) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (c *myModal) bindAppFields(app *tui.App) {
 	c.app = app
 	if c.showModal != nil {
 		c.showModal.BindApp(app)
@@ -101,6 +104,10 @@ func (c *myModal) BindApp(app *tui.App) {
 	if c.gameOver != nil {
 		c.gameOver.BindApp(app)
 	}
+}
+
+func (c *myModal) BindApp(app *tui.App) {
+	c.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*myModal)(nil)

--- a/cmd/tui/testdata/textarea_gsx.go
+++ b/cmd/tui/testdata/textarea_gsx.go
@@ -45,8 +45,15 @@ func (c *myForm) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*myForm)(nil)
 
-func (c *myForm) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (c *myForm) bindAppFields(app *tui.App) {
 	c.app = app
+}
+
+func (c *myForm) BindApp(app *tui.App) {
+	c.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*myForm)(nil)

--- a/docs/content/guides/12-watchers.md
+++ b/docs/content/guides/12-watchers.md
@@ -514,6 +514,36 @@ Remember: `state.Get()` is safe from any goroutine, but `state.Set()` and `state
 | `events.Subscribe()` | Yes | Yes |
 | `app.QueueUpdate()` | Yes | Yes |
 
+### Getting the app into a component
+
+Background goroutines spawned from component methods need an `*tui.App` reference to call `QueueUpdate`. Declare a field of type `*tui.App` on the component struct and the generator will assign it in the auto-generated `BindApp` alongside the `State` and `Events` delegations:
+
+```go
+type Dashboard struct {
+    app *tui.App                  // auto-assigned on mount
+    cpu *tui.State[CPUSnapshot]
+    mem *tui.State[MemSnapshot]
+}
+
+func (d *Dashboard) sampleCPU() {
+    go func() {
+        snap := collectCPU()
+        d.app.QueueUpdate(func() { d.cpu.Set(snap) })
+    }()
+}
+```
+
+Do not write your own `BindApp` unless you need custom binding behavior. If you do override it, the generator still emits a `bindAppFields(app *tui.App)` helper on the same receiver; call it from your `BindApp` so every `State` and `Events` field stays bound:
+
+```go
+func (d *Dashboard) BindApp(app *tui.App) {
+    d.bindAppFields(app)    // generator-supplied delegation
+    // your custom logic here
+}
+```
+
+Forgetting to call `bindAppFields` leaves `State` fields unbound: `Set` will either panic or silently drop the update.
+
 ## Complete Example
 
 This app combines a stopwatch timer with a channel-fed message stream. The timer ticks every second and conditionally increments the stopwatch. The channel watcher appends messages from a background producer. An `OnChange` watcher on the messages state keeps the feed scrolled to the bottom automatically.

--- a/docs/content/reference/app.md
+++ b/docs/content/reference/app.md
@@ -825,7 +825,7 @@ Components can implement these additional interfaces for extended behavior:
 | `WatcherProvider` | `Watchers() []Watcher` | Timers and channel watchers |
 | `Initializer` | `Init() func()` | Setup on mount, returns cleanup function |
 | `AppBinder` | `BindApp(app *App)` | Receives app reference (called automatically by mount) |
-| `AppUnbinder` | `UnbindApp()` | Detaches app-bound resources on unmount |
+| `AppUnbinder` | `UnbindApp()` | Detaches app-bound resources on unmount or root swap |
 | `PropsUpdater` | `UpdateProps(fresh Component)` | Receives updated props on re-render from cache |
 
 See the [Component Interfaces Reference](interfaces.md) for full details on each.

--- a/docs/content/reference/interfaces.md
+++ b/docs/content/reference/interfaces.md
@@ -187,7 +187,7 @@ type AppUnbinder interface {
 }
 ```
 
-Called by the framework when a mounted component leaves the tree. This detaches app-bound resources such as topic-based `Events[T]` subscriptions.
+Called by the framework when a component leaves the tree: on unmount during sweep, or when the root is replaced via `SetRootComponent`, `SetRoot`, or `SetRootView`. This detaches app-bound resources such as topic-based `Events[T]` subscriptions.
 
 You usually don't implement this manually. Generated code handles it for `.gsx` components that contain `Events` fields.
 

--- a/docs/content/reference/state.md
+++ b/docs/content/reference/state.md
@@ -255,6 +255,30 @@ go func() {
 }()
 ```
 
+### Getting `*tui.App` into a component
+
+For samplers, pollers, or any goroutine spawned from a component method, the component needs an `*tui.App` reference to call `QueueUpdate`. Declare a field of that type on the struct; the generator's `BindApp` assigns it automatically along with delegating to every `State` and `Events` field:
+
+```go
+type MyComponent struct {
+    app   *tui.App            // auto-assigned on mount
+    count *tui.State[int]
+}
+
+templ (c *MyComponent) Render() { <span>{count}</span> }
+```
+
+The generator also emits an unexported `bindAppFields(app *tui.App)` method on the receiver. If you override `BindApp` (for custom setup), call `bindAppFields` from inside your override so the `State` and `Events` delegations don't have to be maintained by hand:
+
+```go
+func (c *MyComponent) BindApp(app *tui.App) {
+    c.bindAppFields(app)
+    // custom logic here
+}
+```
+
+A user-defined `BindApp` that skips `bindAppFields` will leave `State` fields unbound, causing `Set` to panic or silently drop updates.
+
 ## Practical Patterns
 
 ### Derived display values

--- a/docs/content/reference/state.md
+++ b/docs/content/reference/state.md
@@ -183,7 +183,7 @@ Binds the event bus to an app for dirty-marking. The framework calls this during
 func (e *Events[T]) UnbindApp()
 ```
 
-Detaches the event bus from app topic routing. Called automatically when components unmount.
+Detaches the event bus from app topic routing. Called automatically when components unmount or when the root is replaced.
 
 ### Emit
 

--- a/events_test.go
+++ b/events_test.go
@@ -238,7 +238,7 @@ func TestResetRootSession_CallsUnbindOnCachedMounts(t *testing.T) {
 	}
 
 	unbound := 0
-	tracker := &unbindTracker{onUnbind: func() { unbound++ }}
+	tracker := &componentTracker{onUnbind: func() { unbound++ }}
 	key := mountKey{parent: nil, index: 0}
 	app.mounts.cache[key] = tracker
 
@@ -262,40 +262,30 @@ func TestSetRootComponent_UnbindsOldRoot(t *testing.T) {
 	}
 
 	unbound := 0
-	first := &rootWithUnbind{onUnbind: func() { unbound++ }}
+	first := &componentTracker{onUnbind: func() { unbound++ }}
 	app.SetRootComponent(first)
 	if unbound != 0 {
 		t.Fatalf("unexpected UnbindApp on first SetRootComponent: %d", unbound)
 	}
 
-	second := &rootWithUnbind{}
+	second := &componentTracker{}
 	app.SetRootComponent(second)
 	if unbound != 1 {
 		t.Fatalf("expected old root to be unbound on swap, got %d", unbound)
 	}
 }
 
-type unbindTracker struct {
+// componentTracker is a Component + AppBinder + AppUnbinder used by the
+// teardown and root-swap tests. onUnbind (if set) records UnbindApp calls.
+type componentTracker struct {
 	onUnbind func()
 }
 
-func (u *unbindTracker) Render(app *App) *Element { return New() }
-func (u *unbindTracker) BindApp(app *App)         {}
-func (u *unbindTracker) UnbindApp() {
-	if u.onUnbind != nil {
-		u.onUnbind()
-	}
-}
-
-type rootWithUnbind struct {
-	onUnbind func()
-}
-
-func (r *rootWithUnbind) Render(app *App) *Element { return New() }
-func (r *rootWithUnbind) BindApp(app *App)         {}
-func (r *rootWithUnbind) UnbindApp() {
-	if r.onUnbind != nil {
-		r.onUnbind()
+func (c *componentTracker) Render(app *App) *Element { return New() }
+func (c *componentTracker) BindApp(app *App)         {}
+func (c *componentTracker) UnbindApp() {
+	if c.onUnbind != nil {
+		c.onUnbind()
 	}
 }
 
@@ -338,7 +328,7 @@ func TestSetRootComponent_AfterSetRootView_UnbindsView(t *testing.T) {
 	view := &viewWithUnbind{onUnbind: func() { unboundView++ }}
 	app.SetRootView(view)
 
-	component := &rootWithUnbind{}
+	component := &componentTracker{}
 	app.SetRootComponent(component)
 
 	if unboundView != 1 {

--- a/events_test.go
+++ b/events_test.go
@@ -299,6 +299,66 @@ func (r *rootWithUnbind) UnbindApp() {
 	}
 }
 
+// TestSetRootView_UnbindsPreviousView verifies that swapping views via
+// SetRootView drains the outgoing view's subscriptions. Previously,
+// a.rootComponent was nil'd on each SetRootView call, so the guard that
+// looked at a.rootComponent never fired and two consecutive SetRootView
+// calls would leak the first view's listeners into a.topics.
+func TestSetRootView_UnbindsPreviousView(t *testing.T) {
+	app := &App{
+		mounts: newMountState(),
+		batch:  newBatchContext(),
+	}
+
+	unboundA := 0
+	viewA := &viewWithUnbind{onUnbind: func() { unboundA++ }}
+	app.SetRootView(viewA)
+	if unboundA != 0 {
+		t.Fatalf("unexpected UnbindApp on first SetRootView: %d", unboundA)
+	}
+
+	viewB := &viewWithUnbind{}
+	app.SetRootView(viewB)
+	if unboundA != 1 {
+		t.Fatalf("expected first view to be unbound on swap, got %d", unboundA)
+	}
+}
+
+// TestSetRootComponent_AfterSetRootView_UnbindsView verifies that crossing
+// between setters also drains the previous root. Without the unified
+// rootUnbinder field, the view set via SetRootView would be unreachable
+// from SetRootComponent's guard (rootComponent was nil'd).
+func TestSetRootComponent_AfterSetRootView_UnbindsView(t *testing.T) {
+	app := &App{
+		mounts: newMountState(),
+		batch:  newBatchContext(),
+	}
+
+	unboundView := 0
+	view := &viewWithUnbind{onUnbind: func() { unboundView++ }}
+	app.SetRootView(view)
+
+	component := &rootWithUnbind{}
+	app.SetRootComponent(component)
+
+	if unboundView != 1 {
+		t.Fatalf("expected view to be unbound when switching to SetRootComponent, got %d", unboundView)
+	}
+}
+
+type viewWithUnbind struct {
+	onUnbind func()
+}
+
+func (v *viewWithUnbind) GetRoot() *Element       { return New() }
+func (v *viewWithUnbind) GetWatchers() []Watcher  { return nil }
+func (v *viewWithUnbind) BindApp(app *App)        {}
+func (v *viewWithUnbind) UnbindApp() {
+	if v.onUnbind != nil {
+		v.onUnbind()
+	}
+}
+
 func TestNewEvents_EmptyTopicPanics(t *testing.T) {
 	defer func() {
 		if recover() == nil {

--- a/events_test.go
+++ b/events_test.go
@@ -117,6 +117,188 @@ func TestEvents_SubscribeUnsubscribe(t *testing.T) {
 	}
 }
 
+func TestEvents_SubscribeBeforeBind(t *testing.T) {
+	app := &App{}
+	bus := NewEvents[string]("deferred.topic")
+
+	var got []string
+	bus.Subscribe(func(v string) { got = append(got, v) })
+
+	bus.BindApp(app)
+
+	bus.Emit("hello")
+	bus.Emit("world")
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 events, got %d: %v", len(got), got)
+	}
+}
+
+func TestEvents_SubscribeBeforeBind_CrossBusSameTopic(t *testing.T) {
+	app := &App{}
+	source := NewEvents[string]("shared")
+	sink := NewEvents[string]("shared")
+
+	var got int
+	sink.Subscribe(func(string) { got++ })
+	sink.BindApp(app)
+	source.BindApp(app)
+
+	source.Emit("x")
+	if got != 1 {
+		t.Fatalf("expected 1, got %d", got)
+	}
+}
+
+func TestEvents_SubscribeBeforeBind_DoubleBind(t *testing.T) {
+	app := &App{}
+	bus := NewEvents[string]("dbl")
+
+	var got int
+	bus.Subscribe(func(string) { got++ })
+	bus.BindApp(app)
+	bus.BindApp(app)
+
+	bus.Emit("x")
+	if got != 1 {
+		t.Fatalf("expected 1, got %d", got)
+	}
+}
+
+// TestEvents_SubscribeBeforeBind_SurvivesTopicReset reproduces the gtop report:
+// Subscribe in the component constructor, then SetRootComponent binds → renders
+// → resetRootSession wipes a.topics → second BindApp is supposed to re-register
+// the subscribers. Prior to the fix, the second BindApp took an early-return
+// path that skipped re-registration because sub.unsubscribe was still non-nil
+// (a handle into the wiped topics map), so Emit silently found zero listeners.
+func TestEvents_SubscribeBeforeBind_SurvivesTopicReset(t *testing.T) {
+	app := &App{}
+	bus := NewEvents[string]("tick")
+
+	var got int
+	bus.Subscribe(func(string) { got++ })
+
+	bus.BindApp(app)       // first bind registers into app.topics
+	app.resetRootSession() // SetRootComponent's applyRoot path wipes app.topics
+	bus.BindApp(app)       // second bind must re-register despite same app
+
+	bus.Emit("x")
+	if got != 1 {
+		t.Fatalf("expected 1 after topic reset + re-bind, got %d", got)
+	}
+}
+
+// TestEvents_SetRootComponent_SubscribeBeforeBind exercises the full user-facing
+// path: build a root component whose constructor subscribes to a bus, then hand
+// it to the App via SetRootComponent. The bus must deliver events after setup.
+func TestEvents_SetRootComponent_SubscribeBeforeBind(t *testing.T) {
+	app := &App{
+		batch:  newBatchContext(),
+		mounts: newMountState(),
+	}
+
+	var got int
+	root := newSubscribeBeforeBindRoot(&got)
+
+	app.SetRootComponent(root)
+
+	root.tickBus.Emit("x")
+	if got != 1 {
+		t.Fatalf("expected 1 event after SetRootComponent, got %d", got)
+	}
+}
+
+type subscribeBeforeBindRoot struct {
+	tickBus *Events[string]
+}
+
+func newSubscribeBeforeBindRoot(counter *int) *subscribeBeforeBindRoot {
+	bus := NewEvents[string]("subscribe-before-bind")
+	r := &subscribeBeforeBindRoot{tickBus: bus}
+	bus.Subscribe(func(string) { *counter++ })
+	return r
+}
+
+func (r *subscribeBeforeBindRoot) Render(app *App) *Element { return New() }
+
+func (r *subscribeBeforeBindRoot) BindApp(app *App) {
+	if r.tickBus != nil {
+		r.tickBus.BindApp(app)
+	}
+}
+
+// TestResetRootSession_CallsUnbindOnCachedMounts verifies the teardown
+// contract: cached components must receive UnbindApp before the cache is
+// tossed, so their Events subscriptions deregister from a.topics rather than
+// leaking.
+func TestResetRootSession_CallsUnbindOnCachedMounts(t *testing.T) {
+	app := &App{
+		mounts: newMountState(),
+		batch:  newBatchContext(),
+	}
+
+	unbound := 0
+	tracker := &unbindTracker{onUnbind: func() { unbound++ }}
+	key := mountKey{parent: nil, index: 0}
+	app.mounts.cache[key] = tracker
+
+	app.resetRootSession()
+
+	if unbound != 1 {
+		t.Fatalf("expected UnbindApp to be called once, got %d", unbound)
+	}
+	if len(app.mounts.cache) != 0 {
+		t.Fatalf("expected mount cache to be replaced, still has %d entries", len(app.mounts.cache))
+	}
+}
+
+// TestSetRootComponent_UnbindsOldRoot verifies that swapping roots calls
+// UnbindApp on the outgoing root before binding the new one. Without this,
+// the previous root's Events subscriptions would leak into the new session.
+func TestSetRootComponent_UnbindsOldRoot(t *testing.T) {
+	app := &App{
+		mounts: newMountState(),
+		batch:  newBatchContext(),
+	}
+
+	unbound := 0
+	first := &rootWithUnbind{onUnbind: func() { unbound++ }}
+	app.SetRootComponent(first)
+	if unbound != 0 {
+		t.Fatalf("unexpected UnbindApp on first SetRootComponent: %d", unbound)
+	}
+
+	second := &rootWithUnbind{}
+	app.SetRootComponent(second)
+	if unbound != 1 {
+		t.Fatalf("expected old root to be unbound on swap, got %d", unbound)
+	}
+}
+
+type unbindTracker struct {
+	onUnbind func()
+}
+
+func (u *unbindTracker) Render(app *App) *Element { return New() }
+func (u *unbindTracker) BindApp(app *App)         {}
+func (u *unbindTracker) UnbindApp() {
+	if u.onUnbind != nil {
+		u.onUnbind()
+	}
+}
+
+type rootWithUnbind struct {
+	onUnbind func()
+}
+
+func (r *rootWithUnbind) Render(app *App) *Element { return New() }
+func (r *rootWithUnbind) BindApp(app *App)         {}
+func (r *rootWithUnbind) UnbindApp() {
+	if r.onUnbind != nil {
+		r.onUnbind()
+	}
+}
+
 func TestNewEvents_EmptyTopicPanics(t *testing.T) {
 	defer func() {
 		if recover() == nil {

--- a/examples/02-gsx-syntax/syntax_gsx.go
+++ b/examples/02-gsx-syntax/syntax_gsx.go
@@ -183,10 +183,17 @@ func (l *listApp) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*listApp)(nil)
 
-func (l *listApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (l *listApp) bindAppFields(app *tui.App) {
 	if l.selected != nil {
 		l.selected.BindApp(app)
 	}
+}
+
+func (l *listApp) BindApp(app *tui.App) {
+	l.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*listApp)(nil)

--- a/examples/03-styling/styling_gsx.go
+++ b/examples/03-styling/styling_gsx.go
@@ -63,10 +63,17 @@ func (s *statusApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (s *statusApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (s *statusApp) bindAppFields(app *tui.App) {
 	if s.value != nil {
 		s.value.BindApp(app)
 	}
+}
+
+func (s *statusApp) BindApp(app *tui.App) {
+	s.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*statusApp)(nil)

--- a/examples/04-layout/layout_gsx.go
+++ b/examples/04-layout/layout_gsx.go
@@ -701,13 +701,20 @@ func (l *layoutApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (l *layoutApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (l *layoutApp) bindAppFields(app *tui.App) {
 	if l.viewIndex != nil {
 		l.viewIndex.BindApp(app)
 	}
 	if l.modeIndex != nil {
 		l.modeIndex.BindApp(app)
 	}
+}
+
+func (l *layoutApp) BindApp(app *tui.App) {
+	l.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*layoutApp)(nil)

--- a/examples/05-elements/elements_gsx.go
+++ b/examples/05-elements/elements_gsx.go
@@ -537,7 +537,10 @@ func (e *elementsApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (e *elementsApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (e *elementsApp) bindAppFields(app *tui.App) {
 	if e.progress != nil {
 		e.progress.BindApp(app)
 	}
@@ -553,6 +556,10 @@ func (e *elementsApp) BindApp(app *tui.App) {
 	if e.selectedBtn != nil {
 		e.selectedBtn.BindApp(app)
 	}
+}
+
+func (e *elementsApp) BindApp(app *tui.App) {
+	e.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*elementsApp)(nil)

--- a/examples/06-state/state_gsx.go
+++ b/examples/06-state/state_gsx.go
@@ -286,7 +286,10 @@ func (d *demoApp) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*demoApp)(nil)
 
-func (d *demoApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (d *demoApp) bindAppFields(app *tui.App) {
 	if d.count != nil {
 		d.count.BindApp(app)
 	}
@@ -296,6 +299,10 @@ func (d *demoApp) BindApp(app *tui.App) {
 	if d.showReset != nil {
 		d.showReset.BindApp(app)
 	}
+}
+
+func (d *demoApp) BindApp(app *tui.App) {
+	d.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*demoApp)(nil)

--- a/examples/07-components/components_gsx.go
+++ b/examples/07-components/components_gsx.go
@@ -740,10 +740,17 @@ func (d *dashboard) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*dashboard)(nil)
 
-func (d *dashboard) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (d *dashboard) bindAppFields(app *tui.App) {
 	if d.selected != nil {
 		d.selected.BindApp(app)
 	}
+}
+
+func (d *dashboard) BindApp(app *tui.App) {
+	d.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*dashboard)(nil)

--- a/examples/08-events/events_gsx.go
+++ b/examples/08-events/events_gsx.go
@@ -120,13 +120,20 @@ func (e *explorer) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (e *explorer) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (e *explorer) bindAppFields(app *tui.App) {
 	if e.lastKey != nil {
 		e.lastKey.BindApp(app)
 	}
 	if e.keyCount != nil {
 		e.keyCount.BindApp(app)
 	}
+}
+
+func (e *explorer) BindApp(app *tui.App) {
+	e.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*explorer)(nil)

--- a/examples/09-refs-and-clicks/clicks_gsx.go
+++ b/examples/09-refs-and-clicks/clicks_gsx.go
@@ -520,7 +520,10 @@ func (c *colorMixer) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (c *colorMixer) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (c *colorMixer) bindAppFields(app *tui.App) {
 	if c.red != nil {
 		c.red.BindApp(app)
 	}
@@ -536,6 +539,10 @@ func (c *colorMixer) BindApp(app *tui.App) {
 	if c.showResetModal != nil {
 		c.showResetModal.BindApp(app)
 	}
+}
+
+func (c *colorMixer) BindApp(app *tui.App) {
+	c.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*colorMixer)(nil)

--- a/examples/10-scrolling/scrolling_gsx.go
+++ b/examples/10-scrolling/scrolling_gsx.go
@@ -166,13 +166,20 @@ func (f *fileList) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*fileList)(nil)
 
-func (f *fileList) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (f *fileList) bindAppFields(app *tui.App) {
 	if f.selected != nil {
 		f.selected.BindApp(app)
 	}
 	if f.scrollY != nil {
 		f.scrollY.BindApp(app)
 	}
+}
+
+func (f *fileList) BindApp(app *tui.App) {
+	f.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*fileList)(nil)

--- a/examples/11-focus/focus_gsx.go
+++ b/examples/11-focus/focus_gsx.go
@@ -116,7 +116,10 @@ func (p *panelForm) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*panelForm)(nil)
 
-func (p *panelForm) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (p *panelForm) bindAppFields(app *tui.App) {
 	if p.panel1 != nil {
 		p.panel1.BindApp(app)
 	}
@@ -129,6 +132,10 @@ func (p *panelForm) BindApp(app *tui.App) {
 	if p.clickCount != nil {
 		p.clickCount.BindApp(app)
 	}
+}
+
+func (p *panelForm) BindApp(app *tui.App) {
+	p.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*panelForm)(nil)

--- a/examples/12-watchers/watchers_gsx.go
+++ b/examples/12-watchers/watchers_gsx.go
@@ -227,7 +227,10 @@ func (w *watcherApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (w *watcherApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (w *watcherApp) bindAppFields(app *tui.App) {
 	if w.stopwatchSec != nil {
 		w.stopwatchSec.BindApp(app)
 	}
@@ -243,6 +246,10 @@ func (w *watcherApp) BindApp(app *tui.App) {
 	if w.scrollY != nil {
 		w.scrollY.BindApp(app)
 	}
+}
+
+func (w *watcherApp) BindApp(app *tui.App) {
+	w.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*watcherApp)(nil)

--- a/examples/13-testing/counter_gsx.go
+++ b/examples/13-testing/counter_gsx.go
@@ -52,10 +52,17 @@ func (c *counter) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (c *counter) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (c *counter) bindAppFields(app *tui.App) {
 	if c.count != nil {
 		c.count.BindApp(app)
 	}
+}
+
+func (c *counter) BindApp(app *tui.App) {
+	c.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*counter)(nil)

--- a/examples/14-multi-component/app_gsx.go
+++ b/examples/14-multi-component/app_gsx.go
@@ -99,7 +99,10 @@ func (a *myApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (a *myApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (a *myApp) bindAppFields(app *tui.App) {
 	if a.searchActive != nil {
 		a.searchActive.BindApp(app)
 	}
@@ -109,6 +112,10 @@ func (a *myApp) BindApp(app *tui.App) {
 	if a.category != nil {
 		a.category.BindApp(app)
 	}
+}
+
+func (a *myApp) BindApp(app *tui.App) {
+	a.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*myApp)(nil)

--- a/examples/14-multi-component/search_gsx.go
+++ b/examples/14-multi-component/search_gsx.go
@@ -121,13 +121,20 @@ func (s *searchBar) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (s *searchBar) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (s *searchBar) bindAppFields(app *tui.App) {
 	if s.active != nil {
 		s.active.BindApp(app)
 	}
 	if s.query != nil {
 		s.query.BindApp(app)
 	}
+}
+
+func (s *searchBar) BindApp(app *tui.App) {
+	s.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*searchBar)(nil)
@@ -185,13 +192,20 @@ func (c *content) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (c *content) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (c *content) bindAppFields(app *tui.App) {
 	if c.category != nil {
 		c.category.BindApp(app)
 	}
 	if c.query != nil {
 		c.query.BindApp(app)
 	}
+}
+
+func (c *content) BindApp(app *tui.App) {
+	c.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*content)(nil)

--- a/examples/14-multi-component/sidebar_gsx.go
+++ b/examples/14-multi-component/sidebar_gsx.go
@@ -142,7 +142,10 @@ func (s *sidebar) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (s *sidebar) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (s *sidebar) bindAppFields(app *tui.App) {
 	if s.category != nil {
 		s.category.BindApp(app)
 	}
@@ -152,6 +155,10 @@ func (s *sidebar) BindApp(app *tui.App) {
 	if s.selected != nil {
 		s.selected.BindApp(app)
 	}
+}
+
+func (s *sidebar) BindApp(app *tui.App) {
+	s.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*sidebar)(nil)

--- a/examples/15-inline-mode/inline_gsx.go
+++ b/examples/15-inline-mode/inline_gsx.go
@@ -115,6 +115,28 @@ func (a *myApp) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*myApp)(nil)
 
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (a *myApp) bindAppFields(app *tui.App) {
+	a.app = app
+	if a.showSettings != nil {
+		a.showSettings.BindApp(app)
+	}
+	if a.textarea != nil {
+		a.textarea.BindApp(app)
+	}
+}
+
+// unbindAppFields is generated. It detaches topic-based Events
+// subscriptions and any component-expression AppUnbinder fields.
+// Call this from your UnbindApp if you override it.
+func (a *myApp) unbindAppFields() {
+	if unbinder, ok := any(a.textarea).(tui.AppUnbinder); ok {
+		unbinder.UnbindApp()
+	}
+}
+
 // Compile-time interface satisfaction checks.
 var (
 	_ tui.KeyListener     = (*myApp)(nil)

--- a/examples/15-inline-mode/inline_gsx.go
+++ b/examples/15-inline-mode/inline_gsx.go
@@ -137,6 +137,12 @@ func (a *myApp) unbindAppFields() {
 	}
 }
 
+func (a *myApp) UnbindApp() {
+	a.unbindAppFields()
+}
+
+var _ tui.AppUnbinder = (*myApp)(nil)
+
 // Compile-time interface satisfaction checks.
 var (
 	_ tui.KeyListener     = (*myApp)(nil)

--- a/examples/16-streaming/streaming_gsx.go
+++ b/examples/16-streaming/streaming_gsx.go
@@ -223,7 +223,10 @@ func (s *streamingApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (s *streamingApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (s *streamingApp) bindAppFields(app *tui.App) {
 	if s.lines != nil {
 		s.lines.BindApp(app)
 	}
@@ -236,6 +239,10 @@ func (s *streamingApp) BindApp(app *tui.App) {
 	if s.elapsed != nil {
 		s.elapsed.BindApp(app)
 	}
+}
+
+func (s *streamingApp) BindApp(app *tui.App) {
+	s.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*streamingApp)(nil)

--- a/examples/17-inline-streaming/stream_gsx.go
+++ b/examples/17-inline-streaming/stream_gsx.go
@@ -311,11 +311,18 @@ func (s *streamDemo) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*streamDemo)(nil)
 
-func (s *streamDemo) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (s *streamDemo) bindAppFields(app *tui.App) {
 	s.app = app
 	if s.streaming != nil {
 		s.streaming.BindApp(app)
 	}
+}
+
+func (s *streamDemo) BindApp(app *tui.App) {
+	s.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*streamDemo)(nil)

--- a/examples/18-dashboard/dashboard_gsx.go
+++ b/examples/18-dashboard/dashboard_gsx.go
@@ -408,7 +408,10 @@ func (d *dashboardApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (d *dashboardApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (d *dashboardApp) bindAppFields(app *tui.App) {
 	if d.cpu != nil {
 		d.cpu.BindApp(app)
 	}
@@ -436,6 +439,10 @@ func (d *dashboardApp) BindApp(app *tui.App) {
 	if d.scrollY != nil {
 		d.scrollY.BindApp(app)
 	}
+}
+
+func (d *dashboardApp) BindApp(app *tui.App) {
+	d.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*dashboardApp)(nil)

--- a/examples/20-animation/animation_gsx.go
+++ b/examples/20-animation/animation_gsx.go
@@ -359,7 +359,10 @@ func (a *animationApp) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*animationApp)(nil)
 
-func (a *animationApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (a *animationApp) bindAppFields(app *tui.App) {
 	if a.spinnerFrame != nil {
 		a.spinnerFrame.BindApp(app)
 	}
@@ -369,6 +372,10 @@ func (a *animationApp) BindApp(app *tui.App) {
 	if a.pulsePhase != nil {
 		a.pulsePhase.BindApp(app)
 	}
+}
+
+func (a *animationApp) BindApp(app *tui.App) {
+	a.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*animationApp)(nil)

--- a/examples/21-directory-tree/tree_gsx.go
+++ b/examples/21-directory-tree/tree_gsx.go
@@ -500,7 +500,10 @@ func (d *directoryTree) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*directoryTree)(nil)
 
-func (d *directoryTree) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (d *directoryTree) bindAppFields(app *tui.App) {
 	if d.cursor != nil {
 		d.cursor.BindApp(app)
 	}
@@ -510,6 +513,10 @@ func (d *directoryTree) BindApp(app *tui.App) {
 	if d.scrollY != nil {
 		d.scrollY.BindApp(app)
 	}
+}
+
+func (d *directoryTree) BindApp(app *tui.App) {
+	d.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*directoryTree)(nil)

--- a/examples/22-event-loop/feed_gsx.go
+++ b/examples/22-event-loop/feed_gsx.go
@@ -259,7 +259,10 @@ func (f *feedApp) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*feedApp)(nil)
 
-func (f *feedApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (f *feedApp) bindAppFields(app *tui.App) {
 	if f.messages != nil {
 		f.messages.BindApp(app)
 	}
@@ -272,6 +275,10 @@ func (f *feedApp) BindApp(app *tui.App) {
 	if f.stickToBottom != nil {
 		f.stickToBottom.BindApp(app)
 	}
+}
+
+func (f *feedApp) BindApp(app *tui.App) {
+	f.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*feedApp)(nil)

--- a/examples/ai-chat/chat_gsx.go
+++ b/examples/ai-chat/chat_gsx.go
@@ -270,7 +270,10 @@ func (c *chat) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*chat)(nil)
 
-func (c *chat) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (c *chat) bindAppFields(app *tui.App) {
 	c.app = app
 	if c.showSettings != nil {
 		c.showSettings.BindApp(app)
@@ -295,12 +298,23 @@ func (c *chat) BindApp(app *tui.App) {
 	}
 }
 
+func (c *chat) BindApp(app *tui.App) {
+	c.bindAppFields(app)
+}
+
 var _ tui.AppBinder = (*chat)(nil)
 
-func (c *chat) UnbindApp() {
+// unbindAppFields is generated. It detaches topic-based Events
+// subscriptions and any component-expression AppUnbinder fields.
+// Call this from your UnbindApp if you override it.
+func (c *chat) unbindAppFields() {
 	if unbinder, ok := any(c.settingsView).(tui.AppUnbinder); ok {
 		unbinder.UnbindApp()
 	}
+}
+
+func (c *chat) UnbindApp() {
+	c.unbindAppFields()
 }
 
 var _ tui.AppUnbinder = (*chat)(nil)

--- a/examples/ai-chat/settings/settings_gsx.go
+++ b/examples/ai-chat/settings/settings_gsx.go
@@ -725,7 +725,10 @@ func (s *SettingsApp) UpdateProps(fresh tui.Component) {
 
 var _ tui.PropsUpdater = (*SettingsApp)(nil)
 
-func (s *SettingsApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (s *SettingsApp) bindAppFields(app *tui.App) {
 	if s.Model != nil {
 		s.Model.BindApp(app)
 	}
@@ -741,6 +744,10 @@ func (s *SettingsApp) BindApp(app *tui.App) {
 	if s.FocusedSection != nil {
 		s.FocusedSection.BindApp(app)
 	}
+}
+
+func (s *SettingsApp) BindApp(app *tui.App) {
+	s.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*SettingsApp)(nil)

--- a/examples/docs-example/counter_gsx.go
+++ b/examples/docs-example/counter_gsx.go
@@ -295,7 +295,10 @@ func (c *counterApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (c *counterApp) BindApp(app *tui.App) {
+// bindAppFields is generated. It wires the component's *tui.App,
+// State, Events, and TextArea fields to app. When you override BindApp,
+// call this helper instead of hand-maintaining the delegation list.
+func (c *counterApp) bindAppFields(app *tui.App) {
 	if c.count != nil {
 		c.count.BindApp(app)
 	}
@@ -305,6 +308,10 @@ func (c *counterApp) BindApp(app *tui.App) {
 	if c.peak != nil {
 		c.peak.BindApp(app)
 	}
+}
+
+func (c *counterApp) BindApp(app *tui.App) {
+	c.bindAppFields(app)
 }
 
 var _ tui.AppBinder = (*counterApp)(nil)

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -693,9 +693,10 @@ func (g *Generator) emitBindAppFieldsHelper(comp *Component, appFields, bindable
 // This allows mount sweep to detach topic-based Events subscriptions.
 //
 // Like generateBindApp, the generator always emits an unbindAppFields helper
-// so a user-defined BindApp override (which also suppresses auto-generation of
-// UnbindApp via hasUserBindAppMethod) can still cleanly delegate the unbind
-// logic by calling the helper from their own UnbindApp.
+// so a user-defined UnbindApp override can delegate to it by calling the
+// helper instead of hand-maintaining the unbind list. Detection keys on the
+// user's UnbindApp independently from BindApp so that overriding one method
+// does not suppress auto-generation of the other.
 func (g *Generator) generateUnbindApp(comp *Component, decls []*GoDecl) {
 	structDecl := findStructDecl(decls, comp.ReceiverType)
 	if structDecl == nil {

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -565,11 +565,13 @@ func isAppBindableType(fieldType string) bool {
 
 // generateBindApp generates a BindApp method for a method component.
 // This allows the mount system to bind the app to State/Events fields.
+//
+// The generator always emits an unexported bindAppFields helper when the
+// component has any *tui.App, State, Events, or component-expression fields.
+// The public BindApp is either auto-generated (and just calls the helper) or,
+// when the user overrides BindApp, the helper remains callable from user code
+// so that delegations don't have to be hand-maintained.
 func (g *Generator) generateBindApp(comp *Component, decls []*GoDecl) {
-	if hasUserBindAppMethod(decls, g.fileFuncs, comp.ReceiverType) {
-		return
-	}
-
 	// Find the struct declaration for this component's receiver type
 	structDecl := findStructDecl(decls, comp.ReceiverType)
 	if structDecl == nil {
@@ -623,10 +625,36 @@ func (g *Generator) generateBindApp(comp *Component, decls []*GoDecl) {
 	// Get the receiver type name without pointer
 	typeName := strings.TrimPrefix(comp.ReceiverType, "*")
 
-	// Generate BindApp method with nil checks
+	// Always emit the bindAppFields helper so user-defined BindApp overrides
+	// can call it instead of hand-maintaining the delegation list.
+	g.emitBindAppFieldsHelper(comp, appFields, bindableFields, componentBindFields)
+
+	if hasUserBindAppMethod(decls, g.fileFuncs, comp.ReceiverType) {
+		return
+	}
+
+	// Auto-generate BindApp: a thin wrapper that calls the helper.
 	g.writef("func (%s) BindApp(app *tui.App) {\n", comp.Receiver)
 	g.indent++
-	// Set *tui.App fields directly
+	g.writef("%s.bindAppFields(app)\n", comp.ReceiverName)
+	g.indent--
+	g.writeln("}")
+	g.writeln("")
+
+	// Add a compile-time check that the type implements AppBinder
+	g.writef("var _ tui.AppBinder = (*%s)(nil)\n", typeName)
+	g.writeln("")
+}
+
+// emitBindAppFieldsHelper writes the unexported bindAppFields method containing
+// the actual delegation logic: assigning *tui.App fields, calling BindApp on
+// State/Events/TextArea fields, and AppBinder type-asserting component-expr fields.
+func (g *Generator) emitBindAppFieldsHelper(comp *Component, appFields, bindableFields []StructField, componentBindFields []string) {
+	g.writef("// bindAppFields is generated. It wires the component's *tui.App,\n")
+	g.writef("// State, Events, and TextArea fields to app. When you override BindApp,\n")
+	g.writef("// call this helper instead of hand-maintaining the delegation list.\n")
+	g.writef("func (%s) bindAppFields(app *tui.App) {\n", comp.Receiver)
+	g.indent++
 	for _, f := range appFields {
 		g.writef("%s.%s = app\n", comp.ReceiverName, f.Name)
 	}
@@ -637,7 +665,6 @@ func (g *Generator) generateBindApp(comp *Component, decls []*GoDecl) {
 		g.indent--
 		g.writeln("}")
 	}
-	// Bind component expression fields via type assertion
 	for _, name := range componentBindFields {
 		g.writef("if binder, ok := any(%s.%s).(tui.AppBinder); ok {\n", comp.ReceiverName, name)
 		g.indent++
@@ -648,19 +675,16 @@ func (g *Generator) generateBindApp(comp *Component, decls []*GoDecl) {
 	g.indent--
 	g.writeln("}")
 	g.writeln("")
-
-	// Add a compile-time check that the type implements AppBinder
-	g.writef("var _ tui.AppBinder = (*%s)(nil)\n", typeName)
-	g.writeln("")
 }
 
 // generateUnbindApp generates an UnbindApp method for a method component.
 // This allows mount sweep to detach topic-based Events subscriptions.
+//
+// Like generateBindApp, the generator always emits an unbindAppFields helper
+// so a user-defined BindApp override (which also suppresses auto-generation of
+// UnbindApp via hasUserBindAppMethod) can still cleanly delegate the unbind
+// logic by calling the helper from their own UnbindApp.
 func (g *Generator) generateUnbindApp(comp *Component, decls []*GoDecl) {
-	if hasUserBindAppMethod(decls, g.fileFuncs, comp.ReceiverType) {
-		return
-	}
-
 	structDecl := findStructDecl(decls, comp.ReceiverType)
 	if structDecl == nil {
 		return
@@ -698,7 +722,31 @@ func (g *Generator) generateUnbindApp(comp *Component, decls []*GoDecl) {
 	}
 
 	typeName := strings.TrimPrefix(comp.ReceiverType, "*")
+
+	// Always emit the unbindAppFields helper.
+	g.emitUnbindAppFieldsHelper(comp, unbindFields, componentUnbindFields)
+
+	if hasUserBindAppMethod(decls, g.fileFuncs, comp.ReceiverType) {
+		return
+	}
+
+	// Auto-generate UnbindApp as a thin wrapper around the helper.
 	g.writef("func (%s) UnbindApp() {\n", comp.Receiver)
+	g.indent++
+	g.writef("%s.unbindAppFields()\n", comp.ReceiverName)
+	g.indent--
+	g.writeln("}")
+	g.writeln("")
+	g.writef("var _ tui.AppUnbinder = (*%s)(nil)\n", typeName)
+	g.writeln("")
+}
+
+// emitUnbindAppFieldsHelper writes the unexported unbindAppFields method.
+func (g *Generator) emitUnbindAppFieldsHelper(comp *Component, unbindFields []StructField, componentUnbindFields []string) {
+	g.writef("// unbindAppFields is generated. It detaches topic-based Events\n")
+	g.writef("// subscriptions and any component-expression AppUnbinder fields.\n")
+	g.writef("// Call this from your UnbindApp if you override it.\n")
+	g.writef("func (%s) unbindAppFields() {\n", comp.Receiver)
 	g.indent++
 	for _, f := range unbindFields {
 		g.writef("if %s.%s != nil {\n", comp.ReceiverName, f.Name)
@@ -716,8 +764,6 @@ func (g *Generator) generateUnbindApp(comp *Component, decls []*GoDecl) {
 	}
 	g.indent--
 	g.writeln("}")
-	g.writeln("")
-	g.writef("var _ tui.AppUnbinder = (*%s)(nil)\n", typeName)
 	g.writeln("")
 }
 

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -477,8 +477,20 @@ func findStructDecl(decls []*GoDecl, typeName string) *GoDecl {
 // hasUserBindAppMethod returns true when the source file already declares a
 // BindApp method on the receiver type.
 func hasUserBindAppMethod(decls []*GoDecl, funcs []*GoFunc, receiverType string) bool {
+	return hasUserMethod(decls, funcs, receiverType, "BindApp")
+}
+
+// hasUserUnbindAppMethod returns true when the source file already declares an
+// UnbindApp method on the receiver type. Kept distinct from BindApp detection
+// so that users who override BindApp alone still receive an auto-generated
+// UnbindApp (otherwise their Events fields would leak subscriptions).
+func hasUserUnbindAppMethod(decls []*GoDecl, funcs []*GoFunc, receiverType string) bool {
+	return hasUserMethod(decls, funcs, receiverType, "UnbindApp")
+}
+
+func hasUserMethod(decls []*GoDecl, funcs []*GoFunc, receiverType, methodName string) bool {
 	typeName := strings.TrimPrefix(receiverType, "*")
-	pattern := regexp.MustCompile(`func\s*\(\s*\w+\s+\*?` + regexp.QuoteMeta(typeName) + `\s*\)\s*BindApp\s*\(`)
+	pattern := regexp.MustCompile(`func\s*\(\s*\w+\s+\*?` + regexp.QuoteMeta(typeName) + `\s*\)\s*` + regexp.QuoteMeta(methodName) + `\s*\(`)
 
 	for _, decl := range decls {
 		if decl.Kind == "func" && pattern.MatchString(decl.Code) {
@@ -726,7 +738,7 @@ func (g *Generator) generateUnbindApp(comp *Component, decls []*GoDecl) {
 	// Always emit the unbindAppFields helper.
 	g.emitUnbindAppFieldsHelper(comp, unbindFields, componentUnbindFields)
 
-	if hasUserBindAppMethod(decls, g.fileFuncs, comp.ReceiverType) {
+	if hasUserUnbindAppMethod(decls, g.fileFuncs, comp.ReceiverType) {
 		return
 	}
 

--- a/internal/tuigen/generator_test.go
+++ b/internal/tuigen/generator_test.go
@@ -1268,3 +1268,47 @@ templ (s *sidebar) Render() {
 		})
 	}
 }
+
+// TestGenerator_UserBindAppDoesNotSuppressUnbindApp verifies the fix for a
+// generator bug where a user-defined BindApp (via hasUserBindAppMethod) also
+// suppressed auto-generation of UnbindApp, leaving components that owned
+// Events subscriptions unable to satisfy AppUnbinder and leaking their
+// subscriptions across root resets.
+func TestGenerator_UserBindAppDoesNotSuppressUnbindApp(t *testing.T) {
+	input := `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+type myRoot struct {
+	app    *tui.App
+	events *tui.Events[string]
+}
+
+func (c *myRoot) BindApp(app *tui.App) {
+	c.app = app
+	c.bindAppFields(app)
+}
+
+templ (c *myRoot) Render() {
+	<div></div>
+}
+`
+
+	output, err := parseAndGenerateSkipImports("test.gsx", input)
+	if err != nil {
+		t.Fatalf("generation failed: %v", err)
+	}
+	code := string(output)
+
+	mustContain := []string{
+		"func (c *myRoot) unbindAppFields()",
+		"func (c *myRoot) UnbindApp()",
+		"c.unbindAppFields()",
+		"var _ tui.AppUnbinder = (*myRoot)(nil)",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(code, want) {
+			t.Errorf("output missing expected string: %q\nGot:\n%s", want, code)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two changes to component binding lifecycle.

**Generator helper**
- Method components with State, Events, or `*tui.App` fields now get an unexported `bindAppFields(app)` helper alongside the auto-generated `BindApp`.
- The auto-generated `BindApp` becomes a thin wrapper that calls the helper.
- If you override `BindApp` for custom setup, call `bindAppFields` from your override. No hand-maintained field list.

**Silent event loss after root reset**
- `resetRootSession` used to wipe `a.topics` outright.
- That also erased subscriptions owned by the root component itself, which `SetRootComponent` registered during its pre-Render `BindApp`.
- The second `BindApp` then took the same-app fast path and skipped re-registration into the now-empty topic map.
- Net effect: components that subscribed in their constructor lost all event delivery after mount.

**Fix**
- Replaces the topic wipe with explicit teardown.
- Cached mounts receive `UnbindApp` before eviction.
- Outgoing root components receive `UnbindApp` before the new root binds.
- `Events.BindApp`'s same-app optimization is preserved.
- `a.topics` now has the same lifetime as the App.

**Tests and docs**
- Four regression tests cover subscribe-before-bind, topic-reset survival, cached-mount unbind, and root-swap unbind. All four fail against pre-fix code.
- Doc updates note that `UnbindApp` now fires on root swap and root reset, not only on component unmount during sweep.