### PR TITLE
fix: update image URLs in example docs

### DIFF
--- a/examples/01-getting-started/README.md
+++ b/examples/01-getting-started/README.md
@@ -4,7 +4,7 @@ A minimal go-tui app: one component with gradient text and a quit handler. Cover
 
 ## Screenshot
 
-![Getting Started](../../docs/public/guides/01.png)
+![Getting Started](../../docs/images/guides/01.png)
 
 ## Run
 

--- a/examples/02-gsx-syntax/README.md
+++ b/examples/02-gsx-syntax/README.md
@@ -4,7 +4,7 @@ Demonstrates `.gsx` file structure including the `templ` keyword, component defi
 
 ## Screenshot
 
-![GSX Syntax](../../docs/public/guides/02.png)
+![GSX Syntax](../../docs/images/guides/02.png)
 
 ## Run
 

--- a/examples/03-styling/README.md
+++ b/examples/03-styling/README.md
@@ -4,7 +4,7 @@ Shows the Tailwind-inspired class system for colors, text decorations, borders, 
 
 ## Screenshot
 
-![Styling](../../docs/public/guides/03.png)
+![Styling](../../docs/images/guides/03.png)
 
 ## Run
 

--- a/examples/04-layout/README.md
+++ b/examples/04-layout/README.md
@@ -4,7 +4,7 @@ Demonstrates the flexbox layout engine with row and column directions, justify a
 
 ## Screenshot
 
-![Layout](../../docs/public/guides/04.png)
+![Layout](../../docs/images/guides/04.png)
 
 ## Run
 

--- a/examples/05-elements/README.md
+++ b/examples/05-elements/README.md
@@ -4,7 +4,7 @@ Showcases the built-in HTML-like elements (`<div>`, `<span>`, `<button>`, `<inpu
 
 ## Screenshot
 
-![Elements](../../docs/public/guides/05.png)
+![Elements](../../docs/images/guides/05.png)
 
 ## Run
 

--- a/examples/06-state/README.md
+++ b/examples/06-state/README.md
@@ -4,7 +4,7 @@ Demonstrates reactive state with `State[T]`, using `.Get()` in render and `.Set(
 
 ## Screenshot
 
-![State](../../docs/public/guides/06.png)
+![State](../../docs/images/guides/06.png)
 
 ## Run
 

--- a/examples/07-components/README.md
+++ b/examples/07-components/README.md
@@ -4,7 +4,7 @@ Demonstrates the two kinds of components: pure templ functions for stateless reu
 
 ## Screenshot
 
-![Components](../../docs/public/guides/07.png)
+![Components](../../docs/images/guides/07.png)
 
 ## Run
 

--- a/examples/08-events/README.md
+++ b/examples/08-events/README.md
@@ -4,7 +4,7 @@ Shows keyboard and mouse event handling through the `KeyListener` interface, `Ke
 
 ## Screenshot
 
-![Events](../../docs/public/guides/08.png)
+![Events](../../docs/images/guides/08.png)
 
 ## Run
 

--- a/examples/09-refs-and-clicks/README.md
+++ b/examples/09-refs-and-clicks/README.md
@@ -4,7 +4,7 @@ Demonstrates element references (`Ref`, `RefList`, `RefMap[K]`) for binding to r
 
 ## Screenshot
 
-![Refs and Clicks](../../docs/public/guides/09.png)
+![Refs and Clicks](../../docs/images/guides/09.png)
 
 ## Run
 

--- a/examples/10-scrolling/README.md
+++ b/examples/10-scrolling/README.md
@@ -4,7 +4,7 @@ Shows scrollable containers for content that overflows its bounds, with keyboard
 
 ## Screenshot
 
-![Scrolling](../../docs/public/guides/10.png)
+![Scrolling](../../docs/images/guides/10.png)
 
 ## Run
 

--- a/examples/11-focus/README.md
+++ b/examples/11-focus/README.md
@@ -4,7 +4,7 @@ Demonstrates focus management for keyboard input routing, including focusable el
 
 ## Screenshot
 
-![Focus](../../docs/public/guides/11.png)
+![Focus](../../docs/images/guides/11.png)
 
 ## Run
 

--- a/examples/12-watchers/README.md
+++ b/examples/12-watchers/README.md
@@ -4,7 +4,7 @@ Shows background operations through the `WatcherProvider` interface: interval ti
 
 ## Screenshot
 
-![Watchers](../../docs/public/guides/12.png)
+![Watchers](../../docs/images/guides/12.png)
 
 ## Run
 

--- a/examples/14-multi-component/README.md
+++ b/examples/14-multi-component/README.md
@@ -4,7 +4,7 @@ Shows how to structure multi-file applications with shared `State[T]` passed bet
 
 ## Screenshot
 
-![Multi-Component](../../docs/public/guides/14.png)
+![Multi-Component](../../docs/images/guides/14.png)
 
 ## Run
 

--- a/examples/15-inline-mode/README.md
+++ b/examples/15-inline-mode/README.md
@@ -4,7 +4,7 @@ Demonstrates inline rendering where the UI occupies a fixed number of rows at th
 
 ## Screenshot
 
-![Inline Mode](../../docs/public/guides/15.png)
+![Inline Mode](../../docs/images/guides/15.png)
 
 ## Run
 

--- a/examples/16-streaming/README.md
+++ b/examples/16-streaming/README.md
@@ -4,7 +4,7 @@ Builds a live data viewer that receives streaming data from a Go channel, with s
 
 ## Screenshot
 
-![Streaming](../../docs/public/guides/16.png)
+![Streaming](../../docs/images/guides/16.png)
 
 ## Run
 

--- a/examples/17-inline-streaming/README.md
+++ b/examples/17-inline-streaming/README.md
@@ -4,7 +4,7 @@ Shows `StreamAbove()` for streaming text character-by-character into the history
 
 ## Screenshot
 
-![Inline Streaming](../../docs/public/guides/17.png)
+![Inline Streaming](../../docs/images/guides/17.png)
 
 ## Run
 

--- a/examples/18-dashboard/README.md
+++ b/examples/18-dashboard/README.md
@@ -4,7 +4,7 @@ A live metrics dashboard with CPU, memory, and disk gauges, a network sparkline,
 
 ## Screenshot
 
-![Dashboard](../../docs/public/guides/18.png)
+![Dashboard](../../docs/images/guides/18.png)
 
 ## Run
 

--- a/examples/20-animation/README.md
+++ b/examples/20-animation/README.md
@@ -4,7 +4,7 @@ Demonstrates four terminal animation patterns: frame-cycling spinners, eased pro
 
 ## Screenshot
 
-![Animation](../../docs/public/guides/20.png)
+![Animation](../../docs/images/guides/20.png)
 
 ## Run
 

--- a/examples/21-directory-tree/README.md
+++ b/examples/21-directory-tree/README.md
@@ -2,7 +2,7 @@
 
 A foldable, keyboard-driven directory tree explorer with lazy child loading, scroll-to-cursor behavior, and ancestor path highlighting. Uses reactive state for the cursor, expanded map, and scroll position, with a watcher to keep the cursor visible as you navigate.
 
-![Directory Tree](../../docs/public/guides/21.png)
+![Directory Tree](../../docs/images/guides/21.png)
 
 See the full [Directory Tree guide](https://www.go-tui.dev/guide/directory-tree) for a walkthrough of the implementation.
 


### PR DESCRIPTION
Noticed that the image URLs in the examples were broken.