### PR TITLE
feat: add hideScrollbar option for scrollable containers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,6 +449,7 @@ func helper(s string) string {
 | `scrollable` | `bool` | Enable scrolling for overflow content |
 | `scrollbarStyle` | `tui.Style` | Style for the scrollbar track |
 | `scrollbarThumbStyle` | `tui.Style` | Style for the scrollbar thumb |
+| `hideScrollbar` | `bool` | Hide the scrollbar and reclaim its gutter width |
 
 ### Modal Attributes
 
@@ -622,6 +623,7 @@ Gradient directions: `-h` (horizontal, default), `-v` (vertical), `-dd` (diagona
 | `overflow-y-scroll` | Enable vertical scrolling |
 | `overflow-x-scroll` | Enable horizontal scrolling |
 | `overflow-hidden` | Clip children without scrollbars |
+| `scrollbar-hidden` | Hide scrollbar and reclaim its gutter width |
 | `scrollbar-COLOR` | Scrollbar track color |
 | `scrollbar-thumb-COLOR` | Scrollbar thumb color |
 | `scrollbar-[#hex]` / `scrollbar-thumb-[#hex]` | Hex scrollbar colors |

--- a/docs/content/guides/10-scrolling.md
+++ b/docs/content/guides/10-scrolling.md
@@ -332,6 +332,26 @@ tui.New(
 
 The scrollbar is a single column on the right edge of the scrollable area. The track character is `│` (box drawing vertical) and the thumb is `█` (full block). Thumb size is proportional to how much of the content is visible, with a minimum of one row.
 
+### Hiding the Scrollbar
+
+To scroll without drawing a scrollbar, add the `scrollbar-hidden` class or set `hideScrollbar={true}`. The gutter column is reclaimed too, so content uses the full container width.
+
+```gsx
+<div class="overflow-y-scroll scrollbar-hidden" height={15}>
+    // scrolls, but the scrollbar column is reclaimed for content
+</div>
+```
+
+```go
+tui.New(
+    tui.WithScrollable(tui.ScrollVertical),
+    tui.WithHeight(15),
+    tui.WithScrollbarHidden(true),
+)
+```
+
+Keyboard, mouse wheel, and programmatic scroll calls still work. Use this when you render your own scroll indicator, or when the default scrollbar is visually distracting.
+
 ## Scroll Methods
 
 The `*Element` type provides these methods for programmatic scroll control:

--- a/docs/content/llm.md
+++ b/docs/content/llm.md
@@ -270,6 +270,7 @@ tui.WithPrintWidth(w int)  // Explicit width; default: auto-detect, fallback 80
 | `scrollOffset` | `int, int` | x, y scroll position |
 | `scrollbarStyle` | `tui.Style` | Track style |
 | `scrollbarThumbStyle` | `tui.Style` | Thumb style |
+| `hideScrollbar` | `bool` | Hide scrollbar and reclaim gutter width |
 
 ### Modal
 
@@ -343,7 +344,7 @@ Directions: `-h` (horizontal, default), `-v` (vertical), `-dd` (diagonal down), 
 
 ### Scroll & Overflow
 
-`overflow-scroll` `overflow-y-scroll` `overflow-x-scroll` `overflow-hidden` `scrollbar-COLOR` `scrollbar-thumb-COLOR` `scrollbar-[#hex]` `scrollbar-thumb-[#hex]`
+`overflow-scroll` `overflow-y-scroll` `overflow-x-scroll` `overflow-hidden` `scrollbar-hidden` `scrollbar-COLOR` `scrollbar-thumb-COLOR` `scrollbar-[#hex]` `scrollbar-thumb-[#hex]`
 
 ### Other
 

--- a/docs/content/reference/element.md
+++ b/docs/content/reference/element.md
@@ -209,6 +209,7 @@ tui.New(
 | `WithScrollOffset(x, y int)` | Initial scroll position. Useful for preserving scroll state across re-renders via `State[int]` |
 | `WithScrollbarStyle(style Style)` | Style for the scrollbar track |
 | `WithScrollbarThumbStyle(style Style)` | Style for the scrollbar thumb |
+| `WithScrollbarHidden(hidden bool)` | Hide the scrollbar and reclaim its gutter column. Scrolling still works via keyboard, mouse wheel, and programmatic calls |
 
 ```go
 tui.New(

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -391,6 +391,7 @@ Available on: `div`, `ul`, `li`, `table`, `span`, `p`, `button`, `input`.
 | `scrollOffset` | int, int | `tui.WithScrollOffset(x, y)` |
 | `scrollbarStyle` | `tui.Style` | `tui.WithScrollbarStyle(s)` |
 | `scrollbarThumbStyle` | `tui.Style` | `tui.WithScrollbarThumbStyle(s)` |
+| `hideScrollbar` | `bool` | `tui.WithScrollbarHidden(b)` |
 
 Available on: `div`, `ul`, `li`, `table`.
 
@@ -714,6 +715,7 @@ Examples:
 | `overflow-y-scroll` | `tui.WithScrollable(tui.ScrollVertical)` |
 | `overflow-x-scroll` | `tui.WithScrollable(tui.ScrollHorizontal)` |
 | `overflow-hidden` | `tui.WithOverflow(tui.OverflowHidden)` |
+| `scrollbar-hidden` | `tui.WithScrollbarHidden(true)` |
 
 ### Scrollbar colors
 

--- a/element.go
+++ b/element.go
@@ -98,6 +98,7 @@ type Element struct {
 	// Scrollbar styles
 	scrollbarStyle      Style
 	scrollbarThumbStyle Style
+	scrollbarHidden     bool // true = don't draw scrollbar or reserve gutter
 
 	// HR properties
 	hr bool // true if this element is a horizontal rule

--- a/element_options.go
+++ b/element_options.go
@@ -328,6 +328,16 @@ func WithScrollbarThumbStyle(style Style) Option {
 	}
 }
 
+// WithScrollbarHidden hides the scrollbar on a scrollable element.
+// When hidden, the scrollbar is neither drawn nor reserves a column of content width,
+// so the viewport uses the full available width. Scrolling still works via keyboard,
+// mouse wheel, and programmatic ScrollTo/ScrollBy.
+func WithScrollbarHidden(hidden bool) Option {
+	return func(e *Element) {
+		e.scrollbarHidden = hidden
+	}
+}
+
 // --- HR Options ---
 
 // WithHR configures an element as a horizontal rule.

--- a/element_scroll.go
+++ b/element_scroll.go
@@ -166,7 +166,7 @@ func (e *Element) layoutScrollContent() {
 	e.measureContentBounds()
 
 	// Check if scrollbars are needed
-	if e.scrollMode == ScrollVertical || e.scrollMode == ScrollBoth {
+	if !e.scrollbarHidden && (e.scrollMode == ScrollVertical || e.scrollMode == ScrollBoth) {
 		needsVScrollbar = e.contentHeight > contentRect.Height
 	}
 	// TODO: horizontal scrollbar support
@@ -239,6 +239,9 @@ func (e *Element) clampScrollOffset() {
 // needsVerticalScrollbar returns whether a vertical scrollbar should be shown.
 func (e *Element) needsVerticalScrollbar() bool {
 	if e.scrollMode != ScrollVertical && e.scrollMode != ScrollBoth {
+		return false
+	}
+	if e.scrollbarHidden {
 		return false
 	}
 	_, vh := e.ViewportSize()

--- a/element_scroll_test.go
+++ b/element_scroll_test.go
@@ -124,14 +124,15 @@ func TestElement_ScrollbarHidden(t *testing.T) {
 			t.Fatalf("expected scrollbar to be needed")
 		}
 
-		vw, _ := e.ViewportSize()
-		if vw != width {
-			t.Fatalf("viewport width = %d, want %d", vw, width)
-		}
-
-		gutter := buf.Cell(width-1, 0).Rune
-		if gutter != '█' && gutter != '│' {
-			t.Errorf("rightmost column rune = %q, want scrollbar glyph", gutter)
+		// Rightmost column should be the scrollbar, not the child's red fill.
+		for y := 0; y < height; y++ {
+			cell := buf.Cell(width-1, y)
+			if cell.Rune != '█' && cell.Rune != '│' {
+				t.Errorf("row %d rightmost column rune = %q, want scrollbar glyph", y, cell.Rune)
+			}
+			if cell.Style.Bg.Equal(Red) {
+				t.Errorf("row %d rightmost column bg = Red, expected scrollbar to cover child", y)
+			}
 		}
 	})
 
@@ -144,10 +145,12 @@ func TestElement_ScrollbarHidden(t *testing.T) {
 			t.Fatalf("expected scrollbar to be hidden")
 		}
 
+		// Rightmost column should be the child's red background, proving the
+		// scrollbar gutter was reclaimed for child layout and not left blank.
 		for y := 0; y < height; y++ {
-			r := buf.Cell(width-1, y).Rune
-			if r == '█' || r == '│' {
-				t.Errorf("row %d rightmost column = %q, expected child content (no scrollbar glyph)", y, r)
+			cell := buf.Cell(width-1, y)
+			if !cell.Style.Bg.Equal(Red) {
+				t.Errorf("row %d rightmost column bg = %v, want Red (child fills reclaimed gutter)", y, cell.Style.Bg)
 			}
 		}
 	})

--- a/element_scroll_test.go
+++ b/element_scroll_test.go
@@ -98,6 +98,61 @@ func TestElement_Scroll(t *testing.T) {
 	}
 }
 
+func TestElement_ScrollbarHidden(t *testing.T) {
+	const width, height = 20, 5
+
+	makeScrollable := func(opts ...Option) *Element {
+		opts = append([]Option{
+			WithSize(width, height),
+			WithScrollable(ScrollVertical),
+			WithDirection(Column),
+		}, opts...)
+		e := New(opts...)
+		// More rows than viewport so a scrollbar would be needed.
+		for i := 0; i < height*3; i++ {
+			e.AddChild(New(WithHeight(1), WithBackground(NewStyle().Background(Red))))
+		}
+		return e
+	}
+
+	t.Run("default shows scrollbar and reserves gutter", func(t *testing.T) {
+		e := makeScrollable()
+		buf := NewBuffer(width, height)
+		e.Render(buf, width, height)
+
+		if !e.needsVerticalScrollbar() {
+			t.Fatalf("expected scrollbar to be needed")
+		}
+
+		vw, _ := e.ViewportSize()
+		if vw != width {
+			t.Fatalf("viewport width = %d, want %d", vw, width)
+		}
+
+		gutter := buf.Cell(width-1, 0).Rune
+		if gutter != '█' && gutter != '│' {
+			t.Errorf("rightmost column rune = %q, want scrollbar glyph", gutter)
+		}
+	})
+
+	t.Run("hidden skips scrollbar and reclaims gutter", func(t *testing.T) {
+		e := makeScrollable(WithScrollbarHidden(true))
+		buf := NewBuffer(width, height)
+		e.Render(buf, width, height)
+
+		if e.needsVerticalScrollbar() {
+			t.Fatalf("expected scrollbar to be hidden")
+		}
+
+		for y := 0; y < height; y++ {
+			r := buf.Cell(width-1, y).Rune
+			if r == '█' || r == '│' {
+				t.Errorf("row %d rightmost column = %q, expected child content (no scrollbar glyph)", y, r)
+			}
+		}
+	})
+}
+
 func TestElement_ScrollToTop(t *testing.T) {
 	e := New(
 		WithSize(20, 5),

--- a/examples/10-scrolling/scrolling.gsx
+++ b/examples/10-scrolling/scrolling.gsx
@@ -6,10 +6,11 @@ import (
 )
 
 type fileList struct {
-	files    []string
-	selected *tui.State[int]
-	scrollY  *tui.State[int]
-	content  *tui.Ref
+	files         []string
+	selected      *tui.State[int]
+	scrollY       *tui.State[int]
+	hideScrollbar *tui.State[bool]
+	content       *tui.Ref
 }
 
 func FileList() *fileList {
@@ -23,10 +24,11 @@ func FileList() *fileList {
 		"state.go", "style.go", "terminal.go", "watcher.go",
 	}
 	return &fileList{
-		files:    files,
-		selected: tui.NewState(0),
-		scrollY:  tui.NewState(0),
-		content:  tui.NewRef(),
+		files:         files,
+		selected:      tui.NewState(0),
+		scrollY:       tui.NewState(0),
+		hideScrollbar: tui.NewState(false),
+		content:       tui.NewRef(),
 	}
 }
 
@@ -80,6 +82,7 @@ func (f *fileList) KeyMap() tui.KeyMap {
 		tui.On(tui.KeyPageUp, func(ke tui.KeyEvent) { f.moveTo(f.selected.Get() - 10) }),
 		tui.On(tui.KeyHome, func(ke tui.KeyEvent) { f.moveTo(0) }),
 		tui.On(tui.KeyEnd, func(ke tui.KeyEvent) { f.moveTo(len(f.files) - 1) }),
+		tui.On(tui.Rune('h'), func(ke tui.KeyEvent) { f.hideScrollbar.Set(!f.hideScrollbar.Get()) }),
 	}
 }
 
@@ -102,6 +105,7 @@ templ (f *fileList) Render() {
 			ref={f.content}
 			class="overflow-y-scroll scrollbar-cyan scrollbar-thumb-bright-cyan"
 			height={12}
+			hideScrollbar={f.hideScrollbar.Get()}
 			scrollOffset={0, f.scrollY.Get()}>
 			for i, name := range f.files {
 				if i == f.selected.Get() {
@@ -112,7 +116,7 @@ templ (f *fileList) Render() {
 			}
 		</div>
 		<div class="flex justify-between">
-			<span class="font-dim">j/k navigate | esc quit</span>
+			<span class="font-dim">j/k navigate | h toggle scrollbar | esc quit</span>
 			<span class="font-dim">{fmt.Sprintf("%d/%d", f.selected.Get()+1, len(f.files))}</span>
 		</div>
 	</div>

--- a/examples/10-scrolling/scrolling_gsx.go
+++ b/examples/10-scrolling/scrolling_gsx.go
@@ -10,10 +10,11 @@ import (
 )
 
 type fileList struct {
-	files    []string
-	selected *tui.State[int]
-	scrollY  *tui.State[int]
-	content  *tui.Ref
+	files         []string
+	selected      *tui.State[int]
+	scrollY       *tui.State[int]
+	hideScrollbar *tui.State[bool]
+	content       *tui.Ref
 }
 
 func FileList() *fileList {
@@ -27,10 +28,11 @@ func FileList() *fileList {
 		"state.go", "style.go", "terminal.go", "watcher.go",
 	}
 	return &fileList{
-		files:    files,
-		selected: tui.NewState(0),
-		scrollY:  tui.NewState(0),
-		content:  tui.NewRef(),
+		files:         files,
+		selected:      tui.NewState(0),
+		scrollY:       tui.NewState(0),
+		hideScrollbar: tui.NewState(false),
+		content:       tui.NewRef(),
 	}
 }
 
@@ -84,6 +86,7 @@ func (f *fileList) KeyMap() tui.KeyMap {
 		tui.On(tui.KeyPageUp, func(ke tui.KeyEvent) { f.moveTo(f.selected.Get() - 10) }),
 		tui.On(tui.KeyHome, func(ke tui.KeyEvent) { f.moveTo(0) }),
 		tui.On(tui.KeyEnd, func(ke tui.KeyEvent) { f.moveTo(len(f.files) - 1) }),
+		tui.On(tui.Rune('h'), func(ke tui.KeyEvent) { f.hideScrollbar.Set(!f.hideScrollbar.Get()) }),
 	}
 }
 
@@ -117,6 +120,7 @@ func (f *fileList) Render(app *tui.App) *tui.Element {
 		tui.WithScrollbarStyle(tui.NewStyle().Foreground(tui.Cyan)),
 		tui.WithScrollbarThumbStyle(tui.NewStyle().Foreground(tui.BrightCyan)),
 		tui.WithHeight(12),
+		tui.WithScrollbarHidden(f.hideScrollbar.Get()),
 		tui.WithScrollOffset(0, f.scrollY.Get()),
 	)
 	f.content.Set(__tui_2)
@@ -142,7 +146,7 @@ func (f *fileList) Render(app *tui.App) *tui.Element {
 		tui.WithJustify(tui.JustifySpaceBetween),
 	)
 	__tui_6 := tui.New(
-		tui.WithText("j/k navigate | esc quit"),
+		tui.WithText("j/k navigate | h toggle scrollbar | esc quit"),
 		tui.WithTextStyle(tui.NewStyle().Dim()),
 	)
 	__tui_5.AddChild(__tui_6)
@@ -175,6 +179,9 @@ func (f *fileList) bindAppFields(app *tui.App) {
 	}
 	if f.scrollY != nil {
 		f.scrollY.BindApp(app)
+	}
+	if f.hideScrollbar != nil {
+		f.hideScrollbar.BindApp(app)
 	}
 }
 

--- a/internal/lsp/schema/schema.go
+++ b/internal/lsp/schema/schema.go
@@ -303,6 +303,7 @@ func scrollAttrs() []AttributeDef {
 		{Name: "scrollable", Type: "bool", Description: "Enable scrolling for overflow content", Category: "scroll"},
 		{Name: "scrollbarStyle", Type: "style", Description: "Style for the scrollbar track", Category: "scroll"},
 		{Name: "scrollbarThumbStyle", Type: "style", Description: "Style for the scrollbar thumb", Category: "scroll"},
+		{Name: "hideScrollbar", Type: "bool", Description: "Hide the scrollbar and reclaim its gutter width", Category: "scroll"},
 	}
 }
 

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -158,6 +158,7 @@ var knownAttributes = map[string]bool{
 	"scrollOffset":        true,
 	"scrollbarStyle":      true,
 	"scrollbarThumbStyle": true,
+	"hideScrollbar":       true,
 
 	// Generic
 	"disabled": true,

--- a/internal/tuigen/analyzer_validation_test.go
+++ b/internal/tuigen/analyzer_validation_test.go
@@ -129,7 +129,7 @@ func TestAnalyzer_AllKnownAttributes(t *testing.T) {
 		"border", "borderStyle", "background",
 		"text", "textStyle", "textAlign",
 		"onFocus", "onBlur",
-		"scrollable", "scrollbarStyle", "scrollbarThumbStyle",
+		"scrollable", "scrollbarStyle", "scrollbarThumbStyle", "hideScrollbar",
 		"disabled", "id",
 	}
 

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -268,8 +268,9 @@ var attributeToOption = map[string]string{
 	"autoFocus": "tui.WithAutoFocus(%s)",
 
 	// Scroll
-	"scrollable":   "tui.WithScrollable(%s)",
-	"scrollOffset": "tui.WithScrollOffset(%s)",
+	"scrollable":    "tui.WithScrollable(%s)",
+	"scrollOffset":  "tui.WithScrollOffset(%s)",
+	"hideScrollbar": "tui.WithScrollbarHidden(%s)",
 }
 
 // generateAttributeOption generates an option expression from an attribute.

--- a/internal/tuigen/tailwind_autocomplete.go
+++ b/internal/tuigen/tailwind_autocomplete.go
@@ -267,6 +267,7 @@ func AllTailwindClasses() []TailwindClassInfo {
 
 	// Scrollbar styling classes
 	scrollbarClasses := []TailwindClassInfo{
+		{Name: "scrollbar-hidden", Category: "visual", Description: "Hide scrollbar and reclaim its gutter width", Example: `<div class="overflow-y-scroll scrollbar-hidden">`},
 		{Name: "scrollbar-red", Category: "visual", Description: "Set scrollbar track color to red", Example: `<div class="overflow-y-scroll scrollbar-red">`},
 		{Name: "scrollbar-thumb-cyan", Category: "visual", Description: "Set scrollbar thumb color to cyan", Example: `<div class="overflow-y-scroll scrollbar-thumb-cyan">`},
 		{Name: "scrollbar-[#ff6600]", Category: "visual", Description: "Set scrollbar track color to hex", Example: `<div class="overflow-y-scroll scrollbar-[#ff6600]">`},

--- a/internal/tuigen/tailwind_data.go
+++ b/internal/tuigen/tailwind_data.go
@@ -166,6 +166,9 @@ var tailwindClasses = map[string]TailwindMapping{
 	"nowrap": {Option: "tui.WithWrap(false)", NeedsImport: ""},
 	"wrap":   {Option: "tui.WithWrap(true)", NeedsImport: ""},
 
+	// Scrollbar visibility
+	"scrollbar-hidden": {Option: "tui.WithScrollbarHidden(true)", NeedsImport: "tui"},
+
 	// Scrollbar track colors
 	"scrollbar-red":     {Option: "tui.WithScrollbarStyle(tui.NewStyle().Foreground(tui.Red))", NeedsImport: "tui"},
 	"scrollbar-green":   {Option: "tui.WithScrollbarStyle(tui.NewStyle().Foreground(tui.Green))", NeedsImport: "tui"},


### PR DESCRIPTION
## Summary

Adds a way to have a scrollable container without a visible scrollbar. Until now, a scrollable element always drew a track on the right edge and gave up a column of content width for it. There was no built-in way to opt out.

Three equivalent knobs to hide it:

- `tui.WithScrollbarHidden(bool)` in Go
- `hideScrollbar={...}` as a gsx attribute
- `scrollbar-hidden` as a Tailwind class

When set, the scrollbar stops drawing and also stops reserving its one-column gutter, so the viewport uses the full container width. Keyboard, mouse wheel, and programmatic scrolling all keep working.

## Docs and example

- Scrolling guide gets a "Hiding the Scrollbar" subsection.
- Reference docs (element, gsx-syntax, llm.md) and CLAUDE.md list the new option and class.
- `examples/10-scrolling` now binds `h` to toggle the scrollbar, so you can watch the gutter column get reclaimed live.