### PR TITLE
fix(tuigen): access .Root when method templ root is a function-component call

### DIFF
--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -47,6 +47,7 @@ func (g *Generator) generateMethodComponent(comp *Component) {
 
 	// Track the root element variable name
 	var rootVar string
+	var rootIsComponent bool // Whether root is a function-component call (view struct, needs .Root accessor)
 
 	// Generate body nodes
 	for _, node := range comp.Body {
@@ -78,6 +79,7 @@ func (g *Generator) generateMethodComponent(comp *Component) {
 			varName := g.generateComponentCallWithRefs(n, "", false, false)
 			if rootVar == "" {
 				rootVar = varName
+				rootIsComponent = true
 			}
 		case *ComponentExpr:
 			varName := g.nextVar()
@@ -92,7 +94,11 @@ func (g *Generator) generateMethodComponent(comp *Component) {
 	// Return the root element directly
 	g.writeln("")
 	if rootVar != "" {
-		g.writef("return %s\n", rootVar)
+		if rootIsComponent {
+			g.writef("return %s.Root\n", rootVar)
+		} else {
+			g.writef("return %s\n", rootVar)
+		}
 	} else {
 		g.writeln("return nil")
 	}

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -79,7 +79,11 @@ func (g *Generator) generateMethodComponent(comp *Component) {
 			varName := g.generateComponentCallWithRefs(n, "", false, false)
 			if rootVar == "" {
 				rootVar = varName
-				rootIsComponent = true
+				// Struct mounts return *tui.Element directly; function templs
+				// return *XView and need .Root access.
+				if !g.returnsElement(n) {
+					rootIsComponent = true
+				}
 			}
 		case *ComponentExpr:
 			varName := g.nextVar()

--- a/internal/tuigen/generator_test.go
+++ b/internal/tuigen/generator_test.go
@@ -328,6 +328,22 @@ templ (e *empty) Render() {
 				"return nil",
 			},
 		},
+		"method templ with struct mount as root returns element directly": {
+			input: `package x
+
+type app struct{}
+
+templ (a *app) Render() {
+	@Sidebar()
+}`,
+			wantContains: []string{
+				"__tui_0 := app.Mount(a, 0, func() tui.Component {",
+				"return __tui_0\n",
+			},
+			wantNotContains: []string{
+				"__tui_0.Root",
+			},
+		},
 		"method templ with function-component call as root returns .Root": {
 			input: `package x
 

--- a/internal/tuigen/generator_test.go
+++ b/internal/tuigen/generator_test.go
@@ -328,6 +328,26 @@ templ (e *empty) Render() {
 				"return nil",
 			},
 		},
+		"method templ with function-component call as root returns .Root": {
+			input: `package x
+
+type app struct{}
+
+templ Dashboard() {
+	<div></div>
+}
+
+templ (a *app) Render() {
+	@Dashboard()
+}`,
+			wantContains: []string{
+				"func (a *app) Render(app *tui.App) *tui.Element {",
+				"return __tui_0.Root",
+			},
+			wantNotContains: []string{
+				"return __tui_0\n",
+			},
+		},
 		"method templ with children slot uses receiver field": {
 			input: `package x
 


### PR DESCRIPTION
## Summary

When a method templ uses a function templ call as its root, the generated code didn't compile.

For example:

```gsx
templ Dashboard() {
    <div></div>
}

templ (a *myApp) Render() {
    @Dashboard()
}
```

`@Dashboard()` returns a `*DashboardView` struct (function templs wrap their root in a view struct), but `Render()` has to return `*tui.Element`. The method-component generator was emitting `return __tui_0` directly, producing this error:

```
cannot use __tui_0 (variable of type *DashboardView) as *tui.Element value in return statement
```

The function-component path in `generateFunctionComponent` already handled this by tracking a `rootIsComponent` flag and emitting `.Root`. The method path just didn't have that branch. This copies the same logic into `generateMethodComponent` so a function-component call at the root gets unwrapped to its `Root` field.

Also added a case to `TestGenerator_MethodComponent` covering the scenario, asserting the generator emits `return __tui_0.Root` and not the bare variable.