### PR TITLE
Refactor generator to support import aliases for state and events

### DIFF
--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -150,8 +150,8 @@ var knownAttributes = map[string]bool{
 	// Focus
 	"onFocus":   true,
 	"onBlur":    true,
-	"focusable":  true,
-	"autoFocus":  true,
+	"focusable": true,
+	"autoFocus": true,
 
 	// Scroll
 	"scrollable":          true,
@@ -195,17 +195,17 @@ var knownAttributes = map[string]bool{
 	"submitKey":        true,
 	"onSubmit":         true,
 	"value":            true,
-	"onChange":          true,
+	"onChange":         true,
 }
 
 // stateNewStateRegex matches tui.NewState(...) declarations.
 // It captures the variable name and the initializer expression.
-var stateNewStateRegex = regexp.MustCompile(`(\w+)\s*:=\s*tui\.NewState\((.+)\)`)
+var stateNewStateRegex = regexp.MustCompile(`(\w+)\s*:=\s*[a-zA-Z0-9_]*\.?NewState\((.+)\)`)
 
 // eventsNewEventsRegex matches tui.NewEvents("topic") and
 // tui.NewEvents[T]("topic") declarations.
 // It captures the variable name.
-var eventsNewEventsRegex = regexp.MustCompile(`(\w+)\s*:=\s*tui\.NewEvents(?:\[.+\])?\([^)]*\)`)
+var eventsNewEventsRegex = regexp.MustCompile(`(\w+)\s*:=\s*[a-zA-Z0-9_]*\.?NewEvents(?:\[.+\])?\([^)]*\)`)
 
 // stateGetRegex matches state.Get() calls to detect state usage in expressions.
 // This pattern handles:
@@ -216,22 +216,22 @@ var stateGetRegex = regexp.MustCompile(`(?:\(\*(\w+)\)|(\w+))\.Get\(\)`)
 // stateParamRegex matches *tui.State[T] parameter types.
 // Uses greedy .+ but anchored to end of string with $, which works because
 // parameter type strings don't have trailing content after the closing bracket.
-var stateParamRegex = regexp.MustCompile(`\*tui\.State\[(.+)\]$`)
+var stateParamRegex = regexp.MustCompile(`\*?[a-zA-Z0-9_]*\.?State\[(.+)\]$`)
 
 // attributeSimilar maps common typos to correct attribute names.
 var attributeSimilar = map[string]string{
-	"colour":      "color",
-	"color":       "background",
-	"onfocus":     "onFocus",
-	"onblur":      "onBlur",
-	"flexgrow":    "flexGrow",
-	"flexshrink":  "flexShrink",
-	"textstyle":   "textStyle",
-	"textalign":   "textAlign",
-	"alignself":     "alignSelf",
-	"flexwrap":      "flexWrap",
-	"aligncontent":  "alignContent",
-	"borderstyle":   "borderStyle",
+	"colour":       "color",
+	"color":        "background",
+	"onfocus":      "onFocus",
+	"onblur":       "onBlur",
+	"flexgrow":     "flexGrow",
+	"flexshrink":   "flexShrink",
+	"textstyle":    "textStyle",
+	"textalign":    "textAlign",
+	"alignself":    "alignSelf",
+	"flexwrap":     "flexWrap",
+	"aligncontent": "alignContent",
+	"borderstyle":  "borderStyle",
 }
 
 // Analyze performs semantic analysis on a parsed file.

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -200,12 +200,12 @@ var knownAttributes = map[string]bool{
 
 // stateNewStateRegex matches tui.NewState(...) declarations.
 // It captures the variable name and the initializer expression.
-var stateNewStateRegex = regexp.MustCompile(`(\w+)\s*:=\s*[a-zA-Z0-9_]*\.?NewState\((.+)\)`)
+var stateNewStateRegex = regexp.MustCompile(`(\w+)\s*:=\s*tui\.NewState\((.+)\)`)
 
 // eventsNewEventsRegex matches tui.NewEvents("topic") and
 // tui.NewEvents[T]("topic") declarations.
 // It captures the variable name.
-var eventsNewEventsRegex = regexp.MustCompile(`(\w+)\s*:=\s*[a-zA-Z0-9_]*\.?NewEvents(?:\[.+\])?\([^)]*\)`)
+var eventsNewEventsRegex = regexp.MustCompile(`(\w+)\s*:=\s*tui\.NewEvents(?:\[.+\])?\([^)]*\)`)
 
 // stateGetRegex matches state.Get() calls to detect state usage in expressions.
 // This pattern handles:
@@ -216,7 +216,7 @@ var stateGetRegex = regexp.MustCompile(`(?:\(\*(\w+)\)|(\w+))\.Get\(\)`)
 // stateParamRegex matches *tui.State[T] parameter types.
 // Uses greedy .+ but anchored to end of string with $, which works because
 // parameter type strings don't have trailing content after the closing bracket.
-var stateParamRegex = regexp.MustCompile(`\*?[a-zA-Z0-9_]*\.?State\[(.+)\]$`)
+var stateParamRegex = regexp.MustCompile(`\*tui\.State\[(.+)\]$`)
 
 // attributeSimilar maps common typos to correct attribute names.
 var attributeSimilar = map[string]string{
@@ -567,6 +567,22 @@ func (a *Analyzer) addMissingImports() {
 			Path:  "github.com/grindlemire/go-tui",
 		})
 	}
+}
+
+// getTUIAlias returns the import alias for github.com/grindlemire/go-tui in the current file.
+func (a *Analyzer) getTUIAlias() string {
+	if a.file == nil {
+		return "tui"
+	}
+	for _, imp := range a.file.Imports {
+		if imp.Path == "github.com/grindlemire/go-tui" {
+			if imp.Alias != "" {
+				return imp.Alias
+			}
+			return "tui"
+		}
+	}
+	return "tui"
 }
 
 // validateChildrenField checks that a method templ using {children...} has a

--- a/internal/tuigen/analyzer_state.go
+++ b/internal/tuigen/analyzer_state.go
@@ -9,6 +9,14 @@ import (
 // DetectEventsVars scans a component for tui.NewEvents declarations.
 // It returns a list of all detected events variables.
 func (a *Analyzer) DetectEventsVars(comp *Component) []EventsVar {
+	alias := a.getTUIAlias()
+	var eventsNewEventsRegex *regexp.Regexp
+	if alias == "." {
+		eventsNewEventsRegex = regexp.MustCompile(`(\w+)\s*:=\s*NewEvents(?:\[.+\])?\([^)]*\)`)
+	} else {
+		eventsNewEventsRegex = regexp.MustCompile(`(\w+)\s*:=\s*` + regexp.QuoteMeta(alias) + `\.NewEvents(?:\[.+\])?\([^)]*\)`)
+	}
+
 	var eventsVars []EventsVar
 	for _, node := range comp.Body {
 		if goCode, ok := node.(*GoCode); ok {
@@ -29,6 +37,14 @@ func (a *Analyzer) DetectEventsVars(comp *Component) []EventsVar {
 // DetectStateVars scans a component for tui.NewState declarations and state parameters.
 // It returns a list of all detected state variables.
 func (a *Analyzer) DetectStateVars(comp *Component) []StateVar {
+	alias := a.getTUIAlias()
+	var stateParamRegex *regexp.Regexp
+	if alias == "." {
+		stateParamRegex = regexp.MustCompile(`\*?State\[(.+)\]$`)
+	} else {
+		stateParamRegex = regexp.MustCompile(`\*?` + regexp.QuoteMeta(alias) + `\.State\[(.+)\]$`)
+	}
+
 	var stateVars []StateVar
 
 	// First, detect state parameters in component signature
@@ -57,6 +73,14 @@ func (a *Analyzer) DetectStateVars(comp *Component) []StateVar {
 
 // parseStateDeclarations extracts tui.NewState declarations from Go code.
 func (a *Analyzer) parseStateDeclarations(code *GoCode) []StateVar {
+	alias := a.getTUIAlias()
+	var stateNewStateRegex *regexp.Regexp
+	if alias == "." {
+		stateNewStateRegex = regexp.MustCompile(`(\w+)\s*:=\s*NewState\((.+)\)`)
+	} else {
+		stateNewStateRegex = regexp.MustCompile(`(\w+)\s*:=\s*` + regexp.QuoteMeta(alias) + `\.NewState\((.+)\)`)
+	}
+
 	var stateVars []StateVar
 
 	// Find all matches in the code

--- a/internal/tuigen/generator.go
+++ b/internal/tuigen/generator.go
@@ -72,6 +72,9 @@ type Generator struct {
 	// Used to avoid mounting function templs via app.Mount() from method templs —
 	// they should be called directly since they're stateless view functions.
 	functionTempls map[string]bool
+
+	tuiAlias     string
+	isTuiPackage bool
 }
 
 // componentVarEntry tracks a function component call variable for watcher/bind aggregation.
@@ -106,6 +109,18 @@ func (g *Generator) Generate(file *File, sourceFile string) ([]byte, error) {
 	g.sourceFile = sourceFile
 	g.sourceMap = NewSourceMap(sourceFile)
 	g.currentLine = 0
+
+	// Detect go-tui package alias and package name
+	g.tuiAlias = "tui"
+	for _, imp := range file.Imports {
+		if imp.Path == "github.com/grindlemire/go-tui" {
+			if imp.Alias != "" {
+				g.tuiAlias = imp.Alias
+			}
+			break
+		}
+	}
+	g.isTuiPackage = (file.Package == "tui")
 
 	// Generate header
 	g.generateHeader()

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -433,25 +433,27 @@ func parseStructFields(structCode string) []StructField {
 	return fields
 }
 
+func getCoreType(fieldType string) string {
+	t := strings.TrimPrefix(fieldType, "*")
+	if idx := strings.Index(t, "."); idx != -1 {
+		prefix := t[:idx]
+		if !strings.ContainsAny(prefix, "[]{}()*") {
+			t = t[idx+1:]
+		}
+	}
+	if idx := strings.Index(t, "["); idx != -1 {
+		t = t[:idx]
+	}
+	return t
+}
+
 // isInternalStateType returns true if the type is an internal state type
 // that should NOT be updated via UpdateProps.
 func isInternalStateType(fieldType string) bool {
-	// These types are internal state that should be preserved across re-renders
-	internalTypes := []string{
-		"*tui.Ref",
-		"*tui.RefList",
-		"*tui.RefMap",
-		"*tui.State",
-		"tui.Ref",
-		"tui.RefList",
-		"tui.RefMap",
-		"tui.State",
-	}
-
-	for _, t := range internalTypes {
-		if strings.HasPrefix(fieldType, t) {
-			return true
-		}
+	core := getCoreType(fieldType)
+	switch core {
+	case "Ref", "RefList", "RefMap", "State":
+		return true
 	}
 
 	// Channels and functions are runtime state, not props.
@@ -572,15 +574,10 @@ func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 // isAppBindableType returns true if the field type has a BindApp method
 // (i.e., *tui.State[...] or *tui.Events[...]).
 func isAppBindableType(fieldType string) bool {
-	bindableTypes := []string{
-		"*tui.State[",
-		"*tui.Events[",
-		"*tui.TextArea",
-	}
-	for _, t := range bindableTypes {
-		if strings.HasPrefix(fieldType, t) {
-			return true
-		}
+	core := getCoreType(fieldType)
+	switch core {
+	case "State", "Events", "TextArea":
+		return true
 	}
 	return false
 }
@@ -725,7 +722,7 @@ func (g *Generator) generateUnbindApp(comp *Component, decls []*GoDecl) {
 
 	var unbindFields []StructField
 	for _, f := range fields {
-		if strings.HasPrefix(f.Type, "*tui.Events[") {
+		if getCoreType(f.Type) == "Events" {
 			unbindFields = append(unbindFields, f)
 		}
 	}

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -433,26 +433,46 @@ func parseStructFields(structCode string) []StructField {
 	return fields
 }
 
-func getCoreType(fieldType string) string {
+func (g *Generator) isTUIType(fieldType string, baseNames ...string) bool {
 	t := strings.TrimPrefix(fieldType, "*")
-	if idx := strings.Index(t, "."); idx != -1 {
-		prefix := t[:idx]
-		if !strings.ContainsAny(prefix, "[]{}()*") {
-			t = t[idx+1:]
-		}
-	}
 	if idx := strings.Index(t, "["); idx != -1 {
 		t = t[:idx]
 	}
-	return t
+	idx := strings.Index(t, ".")
+	if idx == -1 {
+		if g.tuiAlias == "." {
+			for _, name := range baseNames {
+				if t == name {
+					return true
+				}
+			}
+		}
+		if g.isTuiPackage {
+			for _, name := range baseNames {
+				if t == name {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	prefix := t[:idx]
+	typeName := t[idx+1:]
+	if prefix != g.tuiAlias {
+		return false
+	}
+	for _, name := range baseNames {
+		if typeName == name {
+			return true
+		}
+	}
+	return false
 }
 
 // isInternalStateType returns true if the type is an internal state type
 // that should NOT be updated via UpdateProps.
-func isInternalStateType(fieldType string) bool {
-	core := getCoreType(fieldType)
-	switch core {
-	case "Ref", "RefList", "RefMap", "State":
+func (g *Generator) isInternalStateType(fieldType string) bool {
+	if g.isTUIType(fieldType, "Ref", "RefList", "RefMap", "State") {
 		return true
 	}
 
@@ -535,7 +555,7 @@ func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 	// Find prop fields (non-internal-state types)
 	var propFields []StructField
 	for _, f := range fields {
-		if !isInternalStateType(f.Type) {
+		if !g.isInternalStateType(f.Type) {
 			propFields = append(propFields, f)
 		}
 	}
@@ -573,13 +593,8 @@ func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 
 // isAppBindableType returns true if the field type has a BindApp method
 // (i.e., *tui.State[...] or *tui.Events[...]).
-func isAppBindableType(fieldType string) bool {
-	core := getCoreType(fieldType)
-	switch core {
-	case "State", "Events", "TextArea":
-		return true
-	}
-	return false
+func (g *Generator) isAppBindableType(fieldType string) bool {
+	return g.isTUIType(fieldType, "State", "Events", "TextArea")
 }
 
 // generateBindApp generates a BindApp method for a method component.
@@ -614,7 +629,7 @@ func (g *Generator) generateBindApp(comp *Component, decls []*GoDecl) {
 	// Find fields that need BindApp (known types like State, Events, TextArea)
 	var bindableFields []StructField
 	for _, f := range fields {
-		if isAppBindableType(f.Type) {
+		if g.isAppBindableType(f.Type) {
 			bindableFields = append(bindableFields, f)
 		}
 	}
@@ -722,7 +737,7 @@ func (g *Generator) generateUnbindApp(comp *Component, decls []*GoDecl) {
 
 	var unbindFields []StructField
 	for _, f := range fields {
-		if getCoreType(f.Type) == "Events" {
+		if g.isTUIType(f.Type, "Events") {
 			unbindFields = append(unbindFields, f)
 		}
 	}


### PR DESCRIPTION
### Summary
When using custom package aliases for imports (for example, `import gt "github.com/grindlemire/go-tui"`), the code generator failed to recognize `State` and `Events` declarations. Because the analyzer and generator relied on hardcoded `tui.` package prefixes, types like `*gt.State[T]` were skipped. This caused the generated Go code to omit automatic binding/unbinding registrations, preventing components from registering state changes and rendering them inert.

This PR adds support for arbitrary import aliases by reading the imports block of each file dynamically, extracting the alias in use, and strictly verifying that package prefixes match the detected alias. This prevents false-positives from types in other packages (e.g., `foo.State`) while supporting custom aliases.

### Key Changes
- **Analyzer**: Dynamically inspects the AST's import block to extract the alias used for `go-tui`.
- **Dynamic Regexes**: Compiles state/event declaration regexes on-the-fly using the resolved package alias to avoid false-positive matches on other packages.
- **Generator**: Added a strict `isTUIType` helper on the `Generator` struct that compares type prefixes with the file's import alias, ensuring code generation only triggers for genuine `go-tui` types.