### PR TITLE
feat: add PostRenderHook and allow invisible virtual cursor

### DIFF
--- a/app.go
+++ b/app.go
@@ -79,6 +79,7 @@ type App struct {
 	mounts        *mountState
 	dispatchTable *dispatchTable // Key broadcast dispatch table, rebuilt on dirty frames
 	rootComponent Component      // Root struct component (set via SetRoot with Component)
+	postRenderHook func()
 	rootUnbinder  AppUnbinder    // Tracks the current root's AppUnbinder for swap-time teardown. Covers SetRootView where rootComponent is nil.
 
 	// Component watchers (from WatcherProvider components)

--- a/app_options.go
+++ b/app_options.go
@@ -122,6 +122,14 @@ func WithMouse() AppOption {
 	}
 }
 
+// WithPostRenderHook sets a callback that runs after every render cycle.
+func WithPostRenderHook(fn func()) AppOption {
+	return func(a *App) error {
+		a.postRenderHook = fn
+		return nil
+	}
+}
+
 // WithoutMouse explicitly disables mouse event reporting.
 // Use this to disable mouse in full screen mode (where it's enabled by default).
 func WithoutMouse() AppOption {

--- a/app_render.go
+++ b/app_render.go
@@ -94,6 +94,9 @@ func (a *App) renderFrame() {
 	} else {
 		Render(a.terminal, a.buffer)
 	}
+	if a.postRenderHook != nil {
+		a.postRenderHook()
+	}
 }
 
 // renderInline handles rendering for inline mode by offsetting Y coordinates.
@@ -160,6 +163,9 @@ func (a *App) RenderFull() {
 	RenderFull(a.terminal, a.buffer)
 
 	a.rebuildDispatchTable()
+	if a.postRenderHook != nil {
+		a.postRenderHook()
+	}
 }
 
 // rerenderComponent re-renders the root component to produce a fresh element tree.

--- a/app_render_test.go
+++ b/app_render_test.go
@@ -2,50 +2,316 @@ package tui
 
 import (
 	"testing"
+	"time"
 )
 
-func TestPostRenderHook_FiresInRenderFrame(t *testing.T) {
-	called := 0
-	a := &App{
-		terminal:   NewMockTerminal(80, 24),
-		focus:      newFocusManager(),
-		buffer:     NewBuffer(80, 24),
-		merged:     make(chan Event, 256),
+func TestApp_QueueUpdate_EnqueuesSafely(t *testing.T) {
+	app := &App{
+		focus:        newFocusManager(),
+		buffer:       NewBuffer(80, 24),
+		updates:      make(chan Event, 256),
+		merged:       make(chan Event, 256),
 		watcherQueue: make(chan func(), 256),
-		stopCh:     make(chan struct{}),
-		mounts:     newMountState(),
-		batch:      newBatchContext(),
-		postRenderHook: func() {
-			called++
-		},
+		stopCh:       make(chan struct{}),
+		stopped:      false,
 	}
 
-	a.renderFrame()
+	var executed bool
+	app.QueueUpdate(func() {
+		executed = true
+	})
 
-	if called != 1 {
-		t.Fatalf("postRenderHook called %d times, want 1", called)
+	// QueueUpdate sends to updates channel; read directly (no fan-in in test)
+	select {
+	case ev := <-app.updates:
+		app.Dispatch(ev)
+		if !executed {
+			t.Error("Queued function was not executed correctly")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("QueueUpdate did not enqueue function")
 	}
 }
 
-func TestPostRenderHook_FiresInRenderFull(t *testing.T) {
-	called := 0
-	a := &App{
-		terminal:   NewMockTerminal(80, 24),
-		focus:      newFocusManager(),
-		buffer:     NewBuffer(80, 24),
-		merged:     make(chan Event, 256),
+func TestApp_QueueUpdate_FromGoroutine(t *testing.T) {
+	app := &App{
+		focus:        newFocusManager(),
+		buffer:       NewBuffer(80, 24),
+		updates:      make(chan Event, 256),
+		merged:       make(chan Event, 256),
 		watcherQueue: make(chan func(), 256),
-		stopCh:     make(chan struct{}),
-		mounts:     newMountState(),
-		batch:      newBatchContext(),
-		postRenderHook: func() {
-			called++
+		stopCh:       make(chan struct{}),
+		stopped:      false,
+	}
+
+	var executed int
+	done := make(chan struct{})
+
+	// Queue from multiple goroutines
+	for i := 0; i < 10; i++ {
+		go func() {
+			app.QueueUpdate(func() {
+				executed++
+			})
+		}()
+	}
+
+	// Read all queued functions from updates channel
+	go func() {
+		for i := 0; i < 10; i++ {
+			select {
+			case ev := <-app.updates:
+				app.Dispatch(ev)
+			case <-time.After(100 * time.Millisecond):
+				return
+			}
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if executed != 10 {
+			t.Errorf("Expected 10 executions, got %d", executed)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Timed out waiting for goroutines to complete")
+	}
+}
+
+func TestApp_QueueUpdate_DropsWhenFull(t *testing.T) {
+	app := &App{
+		focus:        newFocusManager(),
+		buffer:       NewBuffer(80, 24),
+		updates:      make(chan Event, 1),
+		merged:       make(chan Event, 1),
+		watcherQueue: make(chan func(), 1),
+		stopCh:       make(chan struct{}),
+	}
+
+	seen := make([]int, 0, 2)
+	app.QueueUpdate(func() { seen = append(seen, 1) }) // fits in buffer
+	app.QueueUpdate(func() { seen = append(seen, 2) }) // channel full, dropped
+
+	// Drain: only the first update should be present
+	select {
+	case ev := <-app.updates:
+		app.Dispatch(ev)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected queued update")
+	}
+
+	// Channel should be empty now
+	select {
+	case <-app.updates:
+		t.Fatal("expected channel to be empty after draining one event")
+	default:
+	}
+
+	if len(seen) != 1 || seen[0] != 1 {
+		t.Fatalf("expected only first update to run, got %v", seen)
+	}
+}
+
+func TestApp_SetGlobalKeyHandler(t *testing.T) {
+	app := &App{
+		focus:        newFocusManager(),
+		buffer:       NewBuffer(80, 24),
+		merged:       make(chan Event, 256),
+		watcherQueue: make(chan func(), 256),
+		stopCh:       make(chan struct{}),
+		stopped:      false,
+	}
+
+	var handlerCalled bool
+	app.SetGlobalKeyHandler(func(e KeyEvent) bool {
+		handlerCalled = true
+		return true
+	})
+
+	if app.globalKeyHandler == nil {
+		t.Fatal("SetGlobalKeyHandler should set the handler")
+	}
+
+	// Call it
+	result := app.globalKeyHandler(KeyEvent{Key: KeyRune, Rune: 'q'})
+
+	if !handlerCalled {
+		t.Error("Global key handler was not called")
+	}
+	if !result {
+		t.Error("Global key handler should return true")
+	}
+}
+
+func TestApp_GlobalKeyHandler_ConsumesEvent(t *testing.T) {
+	mockReader := NewMockEventReader(KeyEvent{Key: KeyRune, Rune: 'q'})
+
+	focusable := newMockFocusable("elem", true)
+	focusable.handled = false
+
+	app := &App{
+		focus:        newFocusManager(),
+		buffer:       NewBuffer(80, 24),
+		reader:       mockReader,
+		merged:       make(chan Event, 256),
+		watcherQueue: make(chan func(), 256),
+		stopCh:       make(chan struct{}),
+		stopped:      false,
+	}
+	app.focus.Register(focusable)
+	app.focus.SetFocus(focusable)
+
+	var globalHandlerCalled bool
+	app.SetGlobalKeyHandler(func(e KeyEvent) bool {
+		globalHandlerCalled = true
+		if e.Rune == 'q' {
+			return true // Consume event
+		}
+		return false
+	})
+
+	// Dispatch goes through Dispatch() which handles globalKeyHandler in legacy path
+	event := KeyEvent{Key: KeyRune, Rune: 'q'}
+	app.Dispatch(event)
+
+	if !globalHandlerCalled {
+		t.Error("Global handler was not called")
+	}
+
+	if focusable.lastEvent != nil {
+		t.Error("Event should have been consumed by global handler")
+	}
+}
+
+func TestApp_GlobalKeyHandler_PassesEvent(t *testing.T) {
+	focusable := newMockFocusable("elem", true)
+	focusable.handled = true
+
+	app := &App{
+		focus:        newFocusManager(),
+		buffer:       NewBuffer(80, 24),
+		merged:       make(chan Event, 256),
+		watcherQueue: make(chan func(), 256),
+		stopCh:       make(chan struct{}),
+		stopped:      false,
+	}
+	app.focus.Register(focusable)
+	app.focus.SetFocus(focusable)
+
+	var globalHandlerCalled bool
+	app.SetGlobalKeyHandler(func(e KeyEvent) bool {
+		globalHandlerCalled = true
+		// Don't consume - let it pass through
+		return false
+	})
+
+	// Dispatch goes through Dispatch() which handles globalKeyHandler in legacy path
+	event := KeyEvent{Key: KeyRune, Rune: 'j'}
+	app.Dispatch(event)
+
+	if !globalHandlerCalled {
+		t.Error("Global handler was not called")
+	}
+
+	if focusable.lastEvent == nil {
+		t.Error("Event should have been passed to focused element")
+	}
+}
+
+func TestApp_EventBatching(t *testing.T) {
+	// Reset dirty flag for clean test
+	testApp.resetDirty()
+
+	mockReader := NewMockEventReader()
+
+	app := &App{
+		focus:        newFocusManager(),
+		buffer:       NewBuffer(80, 24),
+		reader:       mockReader,
+		root:         New(),
+		merged:       make(chan Event, 256),
+		watcherQueue: make(chan func(), 256),
+		stopCh:       make(chan struct{}),
+		stopped:      false,
+	}
+
+	// Queue multiple events directly to merged (simulating fan-in output)
+	for i := 0; i < 5; i++ {
+		app.merged <- UpdateEvent{fn: func() {
+			testApp.MarkDirty()
+		}}
+	}
+
+	// Process one batch manually (simulating the Run() loop logic)
+	// Block until at least one event arrives
+	select {
+	case ev := <-app.merged:
+		app.Dispatch(ev)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Expected event in queue")
+	}
+
+	// Drain additional queued events
+drain:
+	for {
+		select {
+		case ev := <-app.merged:
+			app.Dispatch(ev)
+		default:
+			break drain
+		}
+	}
+
+	// Only check dirty once, clear it
+	var renderCount int
+	if testApp.checkAndClearDirty() {
+		// Would call Render() here in the real loop
+		renderCount++
+	}
+
+	// Should only have rendered once despite multiple events
+	if renderCount != 1 {
+		t.Errorf("Expected 1 render after batched events, got %d", renderCount)
+	}
+}
+
+func TestPostRenderHook(t *testing.T) {
+	type tc struct {
+		name   string
+		setup  func(a *App)
+		render func(a *App)
+	}
+
+	tests := []tc{
+		{
+			name: "fires after renderFrame (covers all 3 paths)",
+			render: func(a *App) { a.renderFrame() },
+		},
+		{
+			name: "fires after RenderFull",
+			render: func(a *App) { a.RenderFull() },
 		},
 	}
 
-	a.RenderFull()
-
-	if called != 1 {
-		t.Fatalf("postRenderHook called %d times, want 1", called)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := 0
+			a := &App{
+				terminal:   NewMockTerminal(80, 24),
+				focus:      newFocusManager(),
+				buffer:     NewBuffer(80, 24),
+				merged:     make(chan Event, 256),
+				watcherQueue: make(chan func(), 256),
+				stopCh:     make(chan struct{}),
+				mounts:     newMountState(),
+				batch:      newBatchContext(),
+				postRenderHook: func() { called++ },
+			}
+			tt.render(a)
+			if called != 1 {
+				t.Fatalf("postRenderHook called %d times, want 1", called)
+			}
+		})
 	}
 }

--- a/app_render_test.go
+++ b/app_render_test.go
@@ -278,24 +278,16 @@ drain:
 
 func TestPostRenderHook(t *testing.T) {
 	type tc struct {
-		name   string
-		setup  func(a *App)
 		render func(a *App)
 	}
 
-	tests := []tc{
-		{
-			name: "fires after renderFrame (covers all 3 paths)",
-			render: func(a *App) { a.renderFrame() },
-		},
-		{
-			name: "fires after RenderFull",
-			render: func(a *App) { a.RenderFull() },
-		},
+	tests := map[string]tc{
+		"fires after renderFrame": {render: func(a *App) { a.renderFrame() }},
+		"fires after RenderFull":  {render: func(a *App) { a.RenderFull() }},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
 			called := 0
 			a := &App{
 				terminal:   NewMockTerminal(80, 24),

--- a/app_render_test.go
+++ b/app_render_test.go
@@ -7,43 +7,45 @@ import (
 func TestPostRenderHook_FiresInRenderFrame(t *testing.T) {
 	called := 0
 	a := &App{
-		stopCh:       make(chan struct{}),
-		merged:       make(chan Event, 1),
-		watcherQueue: make(chan func(), 1),
-		focus:        newFocusManager(),
-		mounts:       newMountState(),
-		batch:        newBatchContext(),
-		PostRenderHook: func() {
+		terminal:   NewMockTerminal(80, 24),
+		focus:      newFocusManager(),
+		buffer:     NewBuffer(80, 24),
+		merged:     make(chan Event, 256),
+		watcherQueue: make(chan func(), 256),
+		stopCh:     make(chan struct{}),
+		mounts:     newMountState(),
+		batch:      newBatchContext(),
+		postRenderHook: func() {
 			called++
 		},
 	}
-	a.buffer = NewBuffer(80, 24)
 
 	a.renderFrame()
 
 	if called != 1 {
-		t.Fatalf("PostRenderHook called %d times, want 1", called)
+		t.Fatalf("postRenderHook called %d times, want 1", called)
 	}
 }
 
 func TestPostRenderHook_FiresInRenderFull(t *testing.T) {
 	called := 0
 	a := &App{
-		stopCh:       make(chan struct{}),
-		merged:       make(chan Event, 1),
-		watcherQueue: make(chan func(), 1),
-		focus:        newFocusManager(),
-		mounts:       newMountState(),
-		batch:        newBatchContext(),
-		PostRenderHook: func() {
+		terminal:   NewMockTerminal(80, 24),
+		focus:      newFocusManager(),
+		buffer:     NewBuffer(80, 24),
+		merged:     make(chan Event, 256),
+		watcherQueue: make(chan func(), 256),
+		stopCh:     make(chan struct{}),
+		mounts:     newMountState(),
+		batch:      newBatchContext(),
+		postRenderHook: func() {
 			called++
 		},
 	}
-	a.buffer = NewBuffer(80, 24)
 
 	a.RenderFull()
 
 	if called != 1 {
-		t.Fatalf("PostRenderHook called %d times, want 1", called)
+		t.Fatalf("postRenderHook called %d times, want 1", called)
 	}
 }

--- a/app_render_test.go
+++ b/app_render_test.go
@@ -2,276 +2,48 @@ package tui
 
 import (
 	"testing"
-	"time"
 )
 
-func TestApp_QueueUpdate_EnqueuesSafely(t *testing.T) {
-	app := &App{
-		focus:        newFocusManager(),
-		buffer:       NewBuffer(80, 24),
-		updates:      make(chan Event, 256),
-		merged:       make(chan Event, 256),
-		watcherQueue: make(chan func(), 256),
+func TestPostRenderHook_FiresInRenderFrame(t *testing.T) {
+	called := 0
+	a := &App{
 		stopCh:       make(chan struct{}),
-		stopped:      false,
-	}
-
-	var executed bool
-	app.QueueUpdate(func() {
-		executed = true
-	})
-
-	// QueueUpdate sends to updates channel; read directly (no fan-in in test)
-	select {
-	case ev := <-app.updates:
-		app.Dispatch(ev)
-		if !executed {
-			t.Error("Queued function was not executed correctly")
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("QueueUpdate did not enqueue function")
-	}
-}
-
-func TestApp_QueueUpdate_FromGoroutine(t *testing.T) {
-	app := &App{
-		focus:        newFocusManager(),
-		buffer:       NewBuffer(80, 24),
-		updates:      make(chan Event, 256),
-		merged:       make(chan Event, 256),
-		watcherQueue: make(chan func(), 256),
-		stopCh:       make(chan struct{}),
-		stopped:      false,
-	}
-
-	var executed int
-	done := make(chan struct{})
-
-	// Queue from multiple goroutines
-	for i := 0; i < 10; i++ {
-		go func() {
-			app.QueueUpdate(func() {
-				executed++
-			})
-		}()
-	}
-
-	// Read all queued functions from updates channel
-	go func() {
-		for i := 0; i < 10; i++ {
-			select {
-			case ev := <-app.updates:
-				app.Dispatch(ev)
-			case <-time.After(100 * time.Millisecond):
-				return
-			}
-		}
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		if executed != 10 {
-			t.Errorf("Expected 10 executions, got %d", executed)
-		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("Timed out waiting for goroutines to complete")
-	}
-}
-
-func TestApp_QueueUpdate_DropsWhenFull(t *testing.T) {
-	app := &App{
-		focus:        newFocusManager(),
-		buffer:       NewBuffer(80, 24),
-		updates:      make(chan Event, 1),
 		merged:       make(chan Event, 1),
 		watcherQueue: make(chan func(), 1),
-		stopCh:       make(chan struct{}),
+		focus:        newFocusManager(),
+		mounts:       newMountState(),
+		batch:        newBatchContext(),
+		PostRenderHook: func() {
+			called++
+		},
 	}
+	a.buffer = NewBuffer(80, 24)
 
-	seen := make([]int, 0, 2)
-	app.QueueUpdate(func() { seen = append(seen, 1) }) // fits in buffer
-	app.QueueUpdate(func() { seen = append(seen, 2) }) // channel full, dropped
+	a.renderFrame()
 
-	// Drain: only the first update should be present
-	select {
-	case ev := <-app.updates:
-		app.Dispatch(ev)
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("expected queued update")
-	}
-
-	// Channel should be empty now
-	select {
-	case <-app.updates:
-		t.Fatal("expected channel to be empty after draining one event")
-	default:
-	}
-
-	if len(seen) != 1 || seen[0] != 1 {
-		t.Fatalf("expected only first update to run, got %v", seen)
+	if called != 1 {
+		t.Fatalf("PostRenderHook called %d times, want 1", called)
 	}
 }
 
-func TestApp_SetGlobalKeyHandler(t *testing.T) {
-	app := &App{
-		focus:        newFocusManager(),
-		buffer:       NewBuffer(80, 24),
-		merged:       make(chan Event, 256),
-		watcherQueue: make(chan func(), 256),
+func TestPostRenderHook_FiresInRenderFull(t *testing.T) {
+	called := 0
+	a := &App{
 		stopCh:       make(chan struct{}),
-		stopped:      false,
-	}
-
-	var handlerCalled bool
-	app.SetGlobalKeyHandler(func(e KeyEvent) bool {
-		handlerCalled = true
-		return true
-	})
-
-	if app.globalKeyHandler == nil {
-		t.Fatal("SetGlobalKeyHandler should set the handler")
-	}
-
-	// Call it
-	result := app.globalKeyHandler(KeyEvent{Key: KeyRune, Rune: 'q'})
-
-	if !handlerCalled {
-		t.Error("Global key handler was not called")
-	}
-	if !result {
-		t.Error("Global key handler should return true")
-	}
-}
-
-func TestApp_GlobalKeyHandler_ConsumesEvent(t *testing.T) {
-	mockReader := NewMockEventReader(KeyEvent{Key: KeyRune, Rune: 'q'})
-
-	focusable := newMockFocusable("elem", true)
-	focusable.handled = false
-
-	app := &App{
+		merged:       make(chan Event, 1),
+		watcherQueue: make(chan func(), 1),
 		focus:        newFocusManager(),
-		buffer:       NewBuffer(80, 24),
-		reader:       mockReader,
-		merged:       make(chan Event, 256),
-		watcherQueue: make(chan func(), 256),
-		stopCh:       make(chan struct{}),
-		stopped:      false,
+		mounts:       newMountState(),
+		batch:        newBatchContext(),
+		PostRenderHook: func() {
+			called++
+		},
 	}
-	app.focus.Register(focusable)
-	app.focus.SetFocus(focusable)
+	a.buffer = NewBuffer(80, 24)
 
-	var globalHandlerCalled bool
-	app.SetGlobalKeyHandler(func(e KeyEvent) bool {
-		globalHandlerCalled = true
-		if e.Rune == 'q' {
-			return true // Consume event
-		}
-		return false
-	})
+	a.RenderFull()
 
-	// Dispatch goes through Dispatch() which handles globalKeyHandler in legacy path
-	event := KeyEvent{Key: KeyRune, Rune: 'q'}
-	app.Dispatch(event)
-
-	if !globalHandlerCalled {
-		t.Error("Global handler was not called")
-	}
-
-	if focusable.lastEvent != nil {
-		t.Error("Event should have been consumed by global handler")
-	}
-}
-
-func TestApp_GlobalKeyHandler_PassesEvent(t *testing.T) {
-	focusable := newMockFocusable("elem", true)
-	focusable.handled = true
-
-	app := &App{
-		focus:        newFocusManager(),
-		buffer:       NewBuffer(80, 24),
-		merged:       make(chan Event, 256),
-		watcherQueue: make(chan func(), 256),
-		stopCh:       make(chan struct{}),
-		stopped:      false,
-	}
-	app.focus.Register(focusable)
-	app.focus.SetFocus(focusable)
-
-	var globalHandlerCalled bool
-	app.SetGlobalKeyHandler(func(e KeyEvent) bool {
-		globalHandlerCalled = true
-		// Don't consume - let it pass through
-		return false
-	})
-
-	// Dispatch goes through Dispatch() which handles globalKeyHandler in legacy path
-	event := KeyEvent{Key: KeyRune, Rune: 'j'}
-	app.Dispatch(event)
-
-	if !globalHandlerCalled {
-		t.Error("Global handler was not called")
-	}
-
-	if focusable.lastEvent == nil {
-		t.Error("Event should have been passed to focused element")
-	}
-}
-
-func TestApp_EventBatching(t *testing.T) {
-	// Reset dirty flag for clean test
-	testApp.resetDirty()
-
-	mockReader := NewMockEventReader()
-
-	app := &App{
-		focus:        newFocusManager(),
-		buffer:       NewBuffer(80, 24),
-		reader:       mockReader,
-		root:         New(),
-		merged:       make(chan Event, 256),
-		watcherQueue: make(chan func(), 256),
-		stopCh:       make(chan struct{}),
-		stopped:      false,
-	}
-
-	// Queue multiple events directly to merged (simulating fan-in output)
-	for i := 0; i < 5; i++ {
-		app.merged <- UpdateEvent{fn: func() {
-			testApp.MarkDirty()
-		}}
-	}
-
-	// Process one batch manually (simulating the Run() loop logic)
-	// Block until at least one event arrives
-	select {
-	case ev := <-app.merged:
-		app.Dispatch(ev)
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("Expected event in queue")
-	}
-
-	// Drain additional queued events
-drain:
-	for {
-		select {
-		case ev := <-app.merged:
-			app.Dispatch(ev)
-		default:
-			break drain
-		}
-	}
-
-	// Only check dirty once, clear it
-	var renderCount int
-	if testApp.checkAndClearDirty() {
-		// Would call Render() here in the real loop
-		renderCount++
-	}
-
-	// Should only have rendered once despite multiple events
-	if renderCount != 1 {
-		t.Errorf("Expected 1 render after batched events, got %d", renderCount)
+	if called != 1 {
+		t.Fatalf("PostRenderHook called %d times, want 1", called)
 	}
 }

--- a/text_wrap.go
+++ b/text_wrap.go
@@ -26,7 +26,8 @@ func wrapParagraph(text string, maxWidth int) []string {
 		return []string{""}
 	}
 
-	words := strings.Fields(text)
+	// Use strings.Split instead of strings.Fields to preserve consecutive spaces.
+	words := strings.Split(text, " ")
 	if len(words) == 0 {
 		return []string{""}
 	}

--- a/text_wrap.go
+++ b/text_wrap.go
@@ -26,8 +26,7 @@ func wrapParagraph(text string, maxWidth int) []string {
 		return []string{""}
 	}
 
-	// Use strings.Split instead of strings.Fields to preserve consecutive spaces.
-	words := strings.Split(text, " ")
+	words := strings.Fields(text)
 	if len(words) == 0 {
 		return []string{""}
 	}

--- a/textarea.go
+++ b/textarea.go
@@ -503,7 +503,7 @@ func (t *TextArea) lineWithCursor(lineIdx int) string {
 	line := lines[lineIdx]
 
 	if lineIdx == row && t.focused.Get() {
-		// Skip virtual cursor when using hardware cursor (cursorRune == ' ')
+		// Skip virtual cursor when hardware cursor mode is enabled
 		if t.hideVirtualCursor {
 			if line == "" {
 				return " "

--- a/textarea.go
+++ b/textarea.go
@@ -164,11 +164,7 @@ func (t *TextArea) Render(app *App) *Element {
 		root.AddChild(New(WithText(t.placeholder), WithTextStyle(t.placeholderStyle)))
 	} else {
 		for i := range lines {
-			if t.hideVirtualCursor {
-				root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
-			} else {
-				root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle)))
-			}
+			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
 		}
 	}
 

--- a/textarea.go
+++ b/textarea.go
@@ -164,7 +164,13 @@ func (t *TextArea) Render(app *App) *Element {
 		root.AddChild(New(WithText(t.placeholder), WithTextStyle(t.placeholderStyle)))
 	} else {
 		for i := range lines {
-			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
+			// When hideVirtualCursor is set and wrapWidth is configured, disable
+// element-level re-wrapping since wrapText() already handles it.
+if t.hideVirtualCursor {
+		root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
+		} else {
+		root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle)))
+		}
 		}
 	}
 

--- a/textarea.go
+++ b/textarea.go
@@ -163,7 +163,7 @@ func (t *TextArea) Render(app *App) *Element {
 		root.AddChild(New(WithText(t.placeholder), WithTextStyle(t.placeholderStyle)))
 	} else {
 		for i := range lines {
-			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
+			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle)))
 		}
 	}
 
@@ -501,8 +501,6 @@ func (t *TextArea) lineWithCursor(lineIdx int) string {
 		// Skip virtual cursor when using hardware cursor (cursorRune == ' ')
 		if t.cursorRune == ' ' {
 			if line == "" {
-				// Return a space so the cursor cell is occupied, matching
-				// the behavior of all other code paths (line + cursor).
 				return " "
 			}
 			return line

--- a/textarea.go
+++ b/textarea.go
@@ -500,7 +500,7 @@ func (t *TextArea) lineWithCursor(lineIdx int) string {
 
 	if lineIdx == row && t.focused.Get() {
 		// Skip virtual cursor when using hardware cursor (cursorRune == ' ')
-		if t.cursorRune == ' ' {
+		if t.hideVirtualCursor {
 			if line == "" {
 				return " "
 			}

--- a/textarea.go
+++ b/textarea.go
@@ -164,13 +164,7 @@ func (t *TextArea) Render(app *App) *Element {
 		root.AddChild(New(WithText(t.placeholder), WithTextStyle(t.placeholderStyle)))
 	} else {
 		for i := range lines {
-			// When hideVirtualCursor is set and wrapWidth is configured, disable
-// element-level re-wrapping since wrapText() already handles it.
-if t.hideVirtualCursor {
-		root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
-		} else {
-		root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle)))
-		}
+			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
 		}
 	}
 

--- a/textarea.go
+++ b/textarea.go
@@ -164,7 +164,11 @@ func (t *TextArea) Render(app *App) *Element {
 		root.AddChild(New(WithText(t.placeholder), WithTextStyle(t.placeholderStyle)))
 	} else {
 		for i := range lines {
-			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
+			if t.hideVirtualCursor {
+				root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
+			} else {
+				root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle)))
+			}
 		}
 	}
 

--- a/textarea.go
+++ b/textarea.go
@@ -498,6 +498,13 @@ func (t *TextArea) lineWithCursor(lineIdx int) string {
 	line := lines[lineIdx]
 
 	if lineIdx == row && t.focused.Get() {
+		// Skip virtual cursor when using hardware cursor (cursorRune == ' ')
+		if t.cursorRune == ' ' {
+			if line == "" {
+				return " "
+			}
+			return line
+		}
 		cursor := string(t.cursorRune)
 		if !t.blink.Get() {
 			cursor = " "

--- a/textarea.go
+++ b/textarea.go
@@ -17,6 +17,7 @@ type TextArea struct {
 	placeholder      string
 	placeholderStyle Style
 	cursorRune       rune
+	hideVirtualCursor bool
 	focusColor       *Color
 	borderGradient   *Gradient
 	focusGradient    *Gradient
@@ -163,7 +164,7 @@ func (t *TextArea) Render(app *App) *Element {
 		root.AddChild(New(WithText(t.placeholder), WithTextStyle(t.placeholderStyle)))
 	} else {
 		for i := range lines {
-			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle)))
+			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
 		}
 	}
 

--- a/textarea.go
+++ b/textarea.go
@@ -163,7 +163,7 @@ func (t *TextArea) Render(app *App) *Element {
 		root.AddChild(New(WithText(t.placeholder), WithTextStyle(t.placeholderStyle)))
 	} else {
 		for i := range lines {
-			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle)))
+			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
 		}
 	}
 
@@ -501,6 +501,8 @@ func (t *TextArea) lineWithCursor(lineIdx int) string {
 		// Skip virtual cursor when using hardware cursor (cursorRune == ' ')
 		if t.cursorRune == ' ' {
 			if line == "" {
+				// Return a space so the cursor cell is occupied, matching
+				// the behavior of all other code paths (line + cursor).
 				return " "
 			}
 			return line

--- a/textarea_options.go
+++ b/textarea_options.go
@@ -56,6 +56,15 @@ func WithTextAreaCursor(r rune) TextAreaOption {
 	}
 }
 
+// WithTextAreaVirtualCursor controls whether the virtual cursor character
+// is drawn in the text. When false, lineWithCursor returns the line unchanged
+// and applications can position the terminal's hardware cursor instead.
+func WithTextAreaVirtualCursor(visible bool) TextAreaOption {
+	return func(t *TextArea) {
+		t.hideVirtualCursor = !visible
+	}
+}
+
 // WithTextAreaFocusColor sets the border color when focused.
 func WithTextAreaFocusColor(c Color) TextAreaOption {
 	return func(t *TextArea) {

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -50,19 +50,20 @@ func TestTextArea_MoveRight_UsesRuneLength(t *testing.T) {
 }
 
 func TestTextArea_HideVirtualCursor(t *testing.T) {
-	tests := []struct {
-		name    string
+	type tc struct {
 		text    string
 		cursor  int
-		wantLen int // expected line length (0 = same as text)
-	}{
-		{name: "returns line unchanged", text: "hello", cursor: 3, wantLen: 5},
-		{name: "returns space on empty line", text: "", cursor: 0, wantLen: 1},
-		{name: "line width matches wrapped text", text: "hello world", cursor: 5, wantLen: 11},
+		wantLen int
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	tests := map[string]tc{
+		"returns line unchanged":            {text: "hello", cursor: 3, wantLen: 5},
+		"returns space on empty line":       {text: "", cursor: 0, wantLen: 1},
+		"line width matches wrapped text":   {text: "hello world", cursor: 5, wantLen: 11},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
 			ta := NewTextArea(
 				WithTextAreaVirtualCursor(false),
 			)

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -1,6 +1,9 @@
 package tui
 
-import "testing"
+import (
+	"testing"
+	"unicode/utf8"
+)
 
 func TestTextArea_SetText_UsesRuneCursorPosition(t *testing.T) {
 	ta := NewTextArea()
@@ -75,8 +78,8 @@ func TestTextArea_HideVirtualCursor(t *testing.T) {
 			lines := ta.wrapText()
 			for i := range lines {
 				rendered := ta.lineWithCursor(i)
-				if len(rendered) != tt.wantLen {
-					t.Fatalf("lineWithCursor(%d) = %q (len=%d), want len=%d", i, rendered, len(rendered), tt.wantLen)
+				if utf8.RuneCountInString(rendered) != tt.wantLen {
+					t.Fatalf("lineWithCursor(%d) = %q (len=%d), want len=%d", i, rendered, utf8.RuneCountInString(rendered), tt.wantLen)
 				}
 			}
 		})

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -49,52 +49,35 @@ func TestTextArea_MoveRight_UsesRuneLength(t *testing.T) {
 	}
 }
 
-func TestTextArea_HideVirtualCursor_ReturnsLineUnchanged(t *testing.T) {
-	ta := NewTextArea(
-		WithTextAreaVirtualCursor(false),
-	)
-	ta.BindApp(testApp)
-	ta.SetText("hello")
-	ta.Focus()
-	ta.cursorPos.Set(3)
-
-	line := ta.lineWithCursor(0)
-	want := "hello"
-	if line != want {
-		t.Fatalf("lineWithCursor(0) = %q, want %q (unchanged)", line, want)
+func TestTextArea_HideVirtualCursor(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		cursor  int
+		wantLen int // expected line length (0 = same as text)
+	}{
+		{name: "returns line unchanged", text: "hello", cursor: 3, wantLen: 5},
+		{name: "returns space on empty line", text: "", cursor: 0, wantLen: 1},
+		{name: "line width matches wrapped text", text: "hello world", cursor: 5, wantLen: 11},
 	}
-}
 
-func TestTextArea_HideVirtualCursor_ReturnsSpaceOnEmptyLine(t *testing.T) {
-	ta := NewTextArea(
-		WithTextAreaVirtualCursor(false),
-	)
-	ta.BindApp(testApp)
-	ta.SetText("")
-	ta.Focus()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ta := NewTextArea(
+				WithTextAreaVirtualCursor(false),
+			)
+			ta.BindApp(testApp)
+			ta.SetText(tt.text)
+			ta.Focus()
+			ta.cursorPos.Set(tt.cursor)
 
-	line := ta.lineWithCursor(0)
-	want := " "
-	if line != want {
-		t.Fatalf("lineWithCursor(0) on empty = %q, want %q", line, want)
-	}
-}
-
-func TestTextArea_HideVirtualCursor_LineWidthUnchanged(t *testing.T) {
-	ta := NewTextArea(
-		WithTextAreaVirtualCursor(false),
-	)
-	ta.BindApp(testApp)
-	ta.SetText("hello world")
-	ta.Focus()
-
-	// With virtual cursor on, line would gain an extra character.
-	// With it off, line width should match the wrapped line width.
-	lines := ta.wrapText()
-	for i, line := range lines {
-		rendered := ta.lineWithCursor(i)
-		if rendered != line && rendered != " " {
-			t.Fatalf("lineWithCursor(%d) = %q, want %q (or space for empty)", i, rendered, line)
-		}
+			lines := ta.wrapText()
+			for i := range lines {
+				rendered := ta.lineWithCursor(i)
+				if len(rendered) != tt.wantLen && rendered != " " {
+					t.Fatalf("lineWithCursor(%d) = %q (len=%d), want len=%d", i, rendered, len(rendered), tt.wantLen)
+				}
+			}
+		})
 	}
 }

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -75,7 +75,7 @@ func TestTextArea_HideVirtualCursor(t *testing.T) {
 			lines := ta.wrapText()
 			for i := range lines {
 				rendered := ta.lineWithCursor(i)
-				if len(rendered) != tt.wantLen && rendered != " " {
+				if len(rendered) != tt.wantLen {
 					t.Fatalf("lineWithCursor(%d) = %q (len=%d), want len=%d", i, rendered, len(rendered), tt.wantLen)
 				}
 			}

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -48,3 +48,53 @@ func TestTextArea_MoveRight_UsesRuneLength(t *testing.T) {
 		t.Fatalf("cursorPos = %d, want 2", got)
 	}
 }
+
+func TestTextArea_HideVirtualCursor_ReturnsLineUnchanged(t *testing.T) {
+	ta := NewTextArea(
+		WithTextAreaVirtualCursor(false),
+	)
+	ta.BindApp(testApp)
+	ta.SetText("hello")
+	ta.Focus()
+	ta.cursorPos.Set(3)
+
+	line := ta.lineWithCursor(0)
+	want := "hello"
+	if line != want {
+		t.Fatalf("lineWithCursor(0) = %q, want %q (unchanged)", line, want)
+	}
+}
+
+func TestTextArea_HideVirtualCursor_ReturnsSpaceOnEmptyLine(t *testing.T) {
+	ta := NewTextArea(
+		WithTextAreaVirtualCursor(false),
+	)
+	ta.BindApp(testApp)
+	ta.SetText("")
+	ta.Focus()
+
+	line := ta.lineWithCursor(0)
+	want := " "
+	if line != want {
+		t.Fatalf("lineWithCursor(0) on empty = %q, want %q", line, want)
+	}
+}
+
+func TestTextArea_HideVirtualCursor_LineWidthUnchanged(t *testing.T) {
+	ta := NewTextArea(
+		WithTextAreaVirtualCursor(false),
+	)
+	ta.BindApp(testApp)
+	ta.SetText("hello world")
+	ta.Focus()
+
+	// With virtual cursor on, line would gain an extra character.
+	// With it off, line width should match the wrapped line width.
+	lines := ta.wrapText()
+	for i, line := range lines {
+		rendered := ta.lineWithCursor(i)
+		if rendered != line && rendered != " " {
+			t.Fatalf("lineWithCursor(%d) = %q, want %q (or space for empty)", i, rendered, line)
+		}
+	}
+}


### PR DESCRIPTION
Two small changes that enable applications to use the terminal's native hardware cursor instead of go-tui's virtual cursor character.

**1. PostRenderHook on App** (`app.go` + `app_render.go`)

A callback that fires after each render, immediately after `buffer.Swap()`. Currently there's no way to run code after a render completes, so any attempt to position the terminal cursor (e.g. `Terminal().SetCursor()`) races with `Flush`, which moves the cursor to the last painted cell.

This hook gives external code a deterministic window — on the main goroutine, after all cell data has been flushed — to send cursor-positioning escape sequences safely.

**2. Skip virtual cursor when cursorRune is `' '`** (`textarea.go`)

When `cursorRune` is set to a space, `lineWithCursor` currently inserts a space character into the displayed text, creating a visible gap. With this check, `cursorRune == ' '` means "no virtual cursor" — the line is returned as-is.

**Usage example:**

```go
ta := tui.NewTextArea(
    tui.WithTextAreaCursor(' '), // invisible virtual cursor
)

// In component setup:
app.PostRenderHook = func() {
    // Position hardware cursor at textarea cursor position
    // ...
    app.Terminal().ShowCursor()
    app.Terminal().SetCursor(ax+col, ay+row)
}
```

The result is a native blinking block cursor with proper reverse video — matching how every terminal renders its cursor.