### PR TITLE
docs: soften import alias guidance in gsx-syntax guide

### DIFF
--- a/docs/content/guides/02-gsx-syntax.md
+++ b/docs/content/guides/02-gsx-syntax.md
@@ -19,7 +19,7 @@ import (
 )
 ```
 
-The examples in this guide alias the import as `tui`. This is optional. The root package is already named `tui`, so `import "github.com/grindlemire/go-tui"` works on its own. We add the alias because the import path ends in `go-tui` while the package is `tui`, and writing it out keeps it clear which name option calls like `tui.NewState` and `tui.KeyEscape` use. Use whichever form you prefer.
+The examples alias the import as `tui`, but this is optional since the root package is already named `tui`. The alias just makes it explicit that option calls like `tui.NewState` use the `tui` name, even though the path ends in `go-tui`. Use whichever form you prefer.
 
 Everything else in the file (type declarations, constants, variables, helper functions) follows normal Go syntax.
 

--- a/docs/content/guides/02-gsx-syntax.md
+++ b/docs/content/guides/02-gsx-syntax.md
@@ -19,7 +19,7 @@ import (
 )
 ```
 
-The convention is to alias the import as `tui`. This keeps element option calls readable (`tui.NewState`, `tui.KeyEscape`, etc.) and is the style used throughout the framework's own examples.
+The examples in this guide alias the import as `tui`. This is optional. The root package is already named `tui`, so `import "github.com/grindlemire/go-tui"` works on its own. We add the alias because the import path ends in `go-tui` while the package is `tui`, and writing it out keeps it clear which name option calls like `tui.NewState` and `tui.KeyEscape` use. Use whichever form you prefer.
 
 Everything else in the file (type declarations, constants, variables, helper functions) follows normal Go syntax.
 


### PR DESCRIPTION
Addresses #67.

The guide called aliasing the import as `tui` "the convention," which read as a requirement. Since the root package is already named `tui`, the alias is optional. This reframes it as a readability preference and tells readers they can use the unaliased form if they prefer.

The alias itself stays in the examples for consistency; only the surrounding language changes.