### PR TITLE
feat: add WithBorderTitle option for rendering titles in box borders

### DIFF
--- a/border.go
+++ b/border.go
@@ -378,22 +378,53 @@ func DrawBoxWithTitle(buf *Buffer, rect Rect, border BorderStyle, title string, 
 	// First draw the box
 	DrawBox(buf, rect, border, style)
 
-	// Now add the title if there's room
-	if len(title) == 0 {
+	// Draw the title
+	drawBoxTitle(buf, rect, title, style)
+}
+
+// drawBoxTitle draws a centered title string on the top border line of the box.
+// drawBoxTitle does not draw the box itself — use DrawBoxWithTitle for that.
+func drawBoxTitle(buf *Buffer, rect Rect, title string, style Style) {
+	runes, startX, ok := prepareTitle(title, rect)
+	if !ok {
 		return
 	}
+	x := startX
+	for _, r := range runes {
+		buf.SetRune(x, rect.Y, r, style)
+		x += RuneWidth(r)
+	}
+}
 
-	// Calculate available space for title (leave at least 1 char on each side for corners)
+// drawBoxTitleClipped draws a centered title string on the top border line,
+// skipping any rune outside the given clip rectangle.
+func drawBoxTitleClipped(buf *Buffer, rect Rect, title string, style Style, clipRect Rect) {
+	// Reject if the title row is outside the clip rect's Y range.
+	if rect.Y < clipRect.Y || rect.Y >= clipRect.Y+clipRect.Height {
+		return
+	}
+	runes, startX, ok := prepareTitle(title, rect)
+	if !ok {
+		return
+	}
+	x := startX
+	for _, r := range runes {
+		if x >= clipRect.X && x+RuneWidth(r) <= clipRect.X+clipRect.Width {
+			buf.SetRune(x, rect.Y, r, style)
+		}
+		x += RuneWidth(r)
+	}
+}
+
+// prepareTitle truncates and centers a title for the given rectangle.
+func prepareTitle(title string, rect Rect) (runes []rune, startX int, ok bool) {
 	availableWidth := rect.Width - 2
 	if availableWidth <= 0 {
-		return
+		return nil, 0, false
 	}
-
-	// Truncate title if needed
 	titleRunes := []rune(title)
 	titleWidth := 0
 	truncatedRunes := make([]rune, 0, len(titleRunes))
-
 	for _, r := range titleRunes {
 		w := RuneWidth(r)
 		if titleWidth+w > availableWidth {
@@ -402,20 +433,11 @@ func DrawBoxWithTitle(buf *Buffer, rect Rect, border BorderStyle, title string, 
 		truncatedRunes = append(truncatedRunes, r)
 		titleWidth += w
 	}
-
 	if len(truncatedRunes) == 0 {
-		return
+		return nil, 0, false
 	}
-
-	// Center the title in the available space
-	startX := rect.X + 1 + (availableWidth-titleWidth)/2
-
-	// Draw the title
-	x := startX
-	for _, r := range truncatedRunes {
-		buf.SetRune(x, rect.Y, r, style)
-		x += RuneWidth(r)
-	}
+	startX = rect.X + 1 + (availableWidth-titleWidth)/2
+	return truncatedRunes, startX, true
 }
 
 // FillBox fills the interior of a box (excluding the border) with a character and style.

--- a/element.go
+++ b/element.go
@@ -60,6 +60,7 @@ type Element struct {
 	border      BorderStyle
 	borderStyle Style
 	background  *Style // nil = transparent
+	borderTitle string // title text drawn in the top border (DrawBoxWithTitle)
 
 	// Text properties
 	text         string

--- a/element_accessors.go
+++ b/element_accessors.go
@@ -37,6 +37,16 @@ func (e *Element) SetBorderStyle(style Style) {
 	e.borderStyle = style
 }
 
+// BorderTitle returns the title string drawn in the top border, or "" if none.
+func (e *Element) BorderTitle() string {
+	return e.borderTitle
+}
+
+// SetBorderTitle sets the title string drawn in the top border.
+func (e *Element) SetBorderTitle(title string) {
+	e.borderTitle = title
+}
+
 // Background returns the background style, or nil if transparent.
 func (e *Element) Background() *Style {
 	return e.background

--- a/element_integration_render_test.go
+++ b/element_integration_render_test.go
@@ -318,3 +318,151 @@ func TestIntegration_TextAlignment(t *testing.T) {
 		})
 	}
 }
+
+func TestIntegration_BorderTitle(t *testing.T) {
+	type tc struct {
+		title         string
+		borderStyle   BorderStyle
+		opts          []Option
+		width         int
+		height        int
+		wantSubstr    string
+		wantNotSubstr string
+		gradientCheck bool // check bottom-left corner retains gradient style
+	}
+
+	tests := map[string]tc{
+		"title in rounded border": {
+			title:       "Status",
+			borderStyle: BorderRounded,
+			width:       20,
+			height:      5,
+			wantSubstr:  "Status",
+		},
+		"empty title draws no title text": {
+			title:         "",
+			borderStyle:   BorderRounded,
+			width:         20,
+			height:        5,
+			wantSubstr:    "╭",     // border draws normally with rounded corner
+			wantNotSubstr: "Title", // no stray text
+		},
+		"title takes priority over gradient": {
+			title:         "MyTitle",
+			borderStyle:   BorderRounded,
+			width:         20,
+			height:        5,
+			opts:          []Option{WithBorderGradient(Gradient{Start: Red, End: Blue})},
+			wantSubstr:    "MyTitle",
+			gradientCheck: true,
+		},
+		"long title is truncated": {
+			title:       "VeryLongTitleThatExceedsBoxWidth",
+			borderStyle: BorderRounded,
+			width:       15,
+			height:      3,
+			wantSubstr:  "VeryLong",
+		},
+		"single border with title": {
+			title:       "Info",
+			borderStyle: BorderSingle,
+			width:       12,
+			height:      4,
+			wantSubstr:  "Info",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			el := New(
+				WithSize(tt.width, tt.height),
+				WithBorder(tt.borderStyle),
+				WithBorderTitle(tt.title),
+			)
+			el.Apply(tt.opts...)
+			buf := NewBuffer(tt.width, tt.height)
+			el.Render(buf, tt.width, tt.height)
+			term := NewMockTerminal(tt.width, tt.height)
+			Render(term, buf)
+			output := term.StringTrimmed()
+
+			if tt.wantSubstr != "" && !strings.Contains(output, tt.wantSubstr) {
+				t.Errorf("output should contain %q, got:\n%s", tt.wantSubstr, output)
+			}
+			if tt.wantNotSubstr != "" && strings.Contains(output, tt.wantNotSubstr) {
+				t.Errorf("output should NOT contain %q, got:\n%s", tt.wantNotSubstr, output)
+			}
+			if tt.gradientCheck {
+				cell := buf.Cell(tt.width-1, tt.height-1)
+				if cell.Style.Fg.IsDefault() {
+					t.Error("border lost its gradient when a title was set")
+				}
+			}
+		})
+	}
+}
+
+func TestIntegration_BorderTitleClipped(t *testing.T) {
+	type tc struct {
+		title         string
+		innerHeight   int
+		outerHeight   int
+		scrollY       int // vertical scroll offset (negative = scroll up)
+		wantSubstr    string
+		wantNotSubstr string
+	}
+
+	tests := map[string]tc{
+		"title visible when top border inside clip": {
+			title:       "ClippedTitle",
+			innerHeight: 8,
+			outerHeight: 5,
+			wantSubstr:  "ClippedTitle",
+		},
+		"title hidden when scrolled above viewport": {
+			title:         "HiddenTitle",
+			innerHeight:   8,
+			outerHeight:   5,
+			scrollY:       3,
+			wantSubstr:    "",
+			wantNotSubstr: "HiddenTitle",
+		},
+		"title wider than box truncated": {
+			title:       "VeryVeryLongTitleThatExceedsBoxWidth",
+			innerHeight: 8,
+			outerHeight: 5,
+			wantSubstr:  "VeryVeryLong",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			inner := New(
+				WithSize(20, tt.innerHeight),
+				WithBorder(BorderRounded),
+				WithBorderTitle(tt.title),
+			)
+			opts := []Option{WithSize(20, tt.outerHeight)}
+			if tt.scrollY != 0 {
+				opts = append(opts, WithScrollable(ScrollVertical), WithScrollOffset(0, tt.scrollY))
+			} else {
+				opts = append(opts, WithOverflow(OverflowHidden))
+			}
+			outer := New(opts...)
+			outer.AddChild(inner)
+
+			buf := NewBuffer(20, tt.outerHeight)
+			outer.Render(buf, 20, tt.outerHeight)
+			term := NewMockTerminal(20, tt.outerHeight)
+			Render(term, buf)
+			output := term.StringTrimmed()
+
+			if tt.wantSubstr != "" && !strings.Contains(output, tt.wantSubstr) {
+				t.Errorf("output should contain %q, got:\n%s", tt.wantSubstr, output)
+			}
+			if tt.wantNotSubstr != "" && strings.Contains(output, tt.wantNotSubstr) {
+				t.Errorf("output should NOT contain %q, got:\n%s", tt.wantNotSubstr, output)
+			}
+		})
+	}
+}

--- a/element_options.go
+++ b/element_options.go
@@ -185,6 +185,15 @@ func WithBorder(style BorderStyle) Option {
 	}
 }
 
+// WithBorderTitle sets a title string drawn in the top border of the box.
+// When WithBorderGradient is also set, the gradient is drawn first and the title
+// overwrites the gradient characters on the top border line.
+func WithBorderTitle(title string) Option {
+	return func(e *Element) {
+		e.borderTitle = title
+	}
+}
+
 // WithBorderStyle sets the color/attributes for the border.
 func WithBorderStyle(style Style) Option {
 	return func(e *Element) {

--- a/element_render.go
+++ b/element_render.go
@@ -124,12 +124,14 @@ func renderElement(buf *Buffer, e *Element, inherited inheritedStyle) {
 		}
 	}
 
-	// 2. Draw border (border style does NOT inherit)
 	if e.border != BorderNone {
 		if e.borderGradient != nil {
 			DrawBoxGradient(buf, rect, e.border, *e.borderGradient, e.borderStyle)
 		} else {
 			DrawBox(buf, rect, e.border, e.borderStyle)
+		}
+		if e.borderTitle != "" {
+			drawBoxTitle(buf, rect, e.borderTitle, e.borderStyle)
 		}
 	}
 
@@ -239,6 +241,9 @@ func renderClippedElement(buf *Buffer, e *Element, clipRect Rect, scrollX, scrol
 			DrawBoxGradientClipped(buf, screenRect, e.border, *e.borderGradient, e.borderStyle, clipRect)
 		} else {
 			DrawBoxClipped(buf, screenRect, e.border, e.borderStyle, clipRect)
+		}
+		if e.borderTitle != "" {
+			drawBoxTitleClipped(buf, screenRect, e.borderTitle, e.borderStyle, clipRect)
 		}
 	}
 

--- a/internal/lsp/schema/schema.go
+++ b/internal/lsp/schema/schema.go
@@ -283,6 +283,7 @@ func visualAttrs() []AttributeDef {
 		{Name: "border", Type: "border", Description: "Border style (none, single, double, rounded, thick)", Category: "visual"},
 		{Name: "borderStyle", Type: "string", Description: "Border style name", Category: "visual"},
 		{Name: "background", Type: "color", Description: "Background color", Category: "visual"},
+		{Name: "borderTitle", Type: "string", Description: "Title text drawn in the top border", Category: "visual"},
 	}
 }
 

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -141,6 +141,7 @@ var knownAttributes = map[string]bool{
 	// Visual
 	"border":             true,
 	"borderStyle":        true,
+	"borderTitle":        true,
 	"background":         true,
 	"backgroundGradient": true,
 

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -255,6 +255,7 @@ var attributeToOption = map[string]string{
 	// Visual
 	"border":             "tui.WithBorder(%s)",
 	"borderStyle":        "tui.WithBorderStyle(%s)",
+	"borderTitle":        "tui.WithBorderTitle(%s)",
 	"background":         "tui.WithBackground(%s)",
 	"backgroundGradient": "tui.WithBackgroundGradient(%s)",
 


### PR DESCRIPTION
Adds a `borderTitle` field to Element and a `WithBorderTitle(title string)` option that renders a title centered in the top border line using the existing `DrawBoxWithTitle` function.

```go
frame := tui.New(
    tui.WithBorder(tui.BorderRounded),
    tui.WithBorderTitle(" Status: connected "),
)
```

The title replaces the horizontal line of the top border:

```
┌─── Status: connected ────┐
│ content                  │
└──────────────────────────┘
```

`DrawBoxWithTitle` already existed in `border.go` — this PR just integrates it into the Element system.