### PR TITLE
docs: document the borderTitle attribute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,6 +469,7 @@ func helper(s string) string {
 |-----------|------|-------------|
 | `border` | `tui.BorderStyle` | Border style |
 | `borderStyle` | `string` | Border style name |
+| `borderTitle` | `string` | Title text centered in the top border |
 | `background` | `tui.Color` | Background color |
 | `text` | `string` | Text content |
 | `textStyle` | `tui.Style` | Text styling |

--- a/docs/content/guides/02-gsx-syntax.md
+++ b/docs/content/guides/02-gsx-syntax.md
@@ -277,7 +277,7 @@ Here's the full set of supported attributes, grouped by purpose:
 
 **Spacing**: `padding`, `margin`
 
-**Visual**: `border`, `borderStyle`, `background`, `text`, `textStyle`, `textAlign`
+**Visual**: `border`, `borderStyle`, `borderTitle`, `background`, `text`, `textStyle`, `textAlign`
 
 **Focus**: `focusable`, `onFocus`, `onBlur`
 

--- a/docs/content/guides/03-styling.md
+++ b/docs/content/guides/03-styling.md
@@ -151,6 +151,26 @@ Color the border with `border-{color}`:
 
 All 16 named colors and their bright variants work: `border-red`, `border-bright-green`, etc. Arbitrary hex values are supported too: `border-[#FF6B35]`.
 
+### Border Titles
+
+The `borderTitle` attribute draws a label centered in the top border line:
+
+```gsx
+<div class="border-rounded p-1" borderTitle=" Status ">
+    <span>All systems normal</span>
+</div>
+```
+
+```
+╭────── Status ──────╮
+│ All systems normal │
+╰────────────────────╯
+```
+
+The title renders with the border's style, so border color classes and the `borderStyle` attribute color both the line and the label. Titles wider than the top edge are truncated. Wrapping the text in spaces (`" Status "`) keeps a gap between the label and the line characters.
+
+Border titles also work with border gradients. The gradient draws first and the title overwrites the characters it covers.
+
 ## Gradients
 
 Gradients interpolate between two colors across text, backgrounds, or borders.

--- a/docs/content/llm.md
+++ b/docs/content/llm.md
@@ -248,6 +248,7 @@ tui.WithPrintWidth(w int)  // Explicit width; default: auto-detect, fallback 80
 | `textStyle` | `tui.Style` | Text styling |
 | `textAlign` | `string` | `"left"`, `"center"`, `"right"` |
 | `borderStyle` | `tui.Style` | Border line styling |
+| `borderTitle` | `string` | Title text centered in the top border |
 
 ### Identity & Behavior
 

--- a/docs/content/reference/element.md
+++ b/docs/content/reference/element.md
@@ -146,6 +146,7 @@ tui.New(
 |----------|-------------|
 | `WithBorder(style BorderStyle)` | Border shape: `BorderNone`, `BorderSingle`, `BorderDouble`, `BorderRounded`, `BorderThick` |
 | `WithBorderStyle(style Style)` | Color and attributes for the border lines |
+| `WithBorderTitle(title string)` | Title text centered in the top border line |
 | `WithBackground(style Style)` | Background fill style |
 | `WithText(content string)` | Text content for this element |
 | `WithTextStyle(style Style)` | Text color and attributes. Setting this prevents style inheritance from the parent |
@@ -258,9 +259,11 @@ func (e *Element) Border() BorderStyle
 func (e *Element) SetBorder(border BorderStyle)
 func (e *Element) BorderStyle() Style
 func (e *Element) SetBorderStyle(style Style)
+func (e *Element) BorderTitle() string
+func (e *Element) SetBorderTitle(title string)
 ```
 
-`Border()` returns the border shape (`BorderSingle`, `BorderRounded`, etc.). `BorderStyle()` returns the color/attribute style used to draw the border lines.
+`Border()` returns the border shape (`BorderSingle`, `BorderRounded`, etc.). `BorderStyle()` returns the color/attribute style used to draw the border lines. `BorderTitle()` returns the title text drawn in the top border, or `""` when no title is set.
 
 ### Background
 

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -353,6 +353,7 @@ Available on: `div`, `ul`, `li`, `table`, `span`, `p`, `button`.
 |-----------|------|------------------|
 | `border` | `tui.BorderStyle` | `tui.WithBorder(b)` |
 | `borderStyle` | `tui.Style` | `tui.WithBorderStyle(s)` |
+| `borderTitle` | string | `tui.WithBorderTitle(s)` |
 | `background` | `tui.Style` | `tui.WithBackground(s)` |
 
 Available on: `div`, `ul`, `li`, `table`, `span`, `p`, `button`.

--- a/docs/content/reference/styling.md
+++ b/docs/content/reference/styling.md
@@ -448,14 +448,16 @@ chars := tui.BorderRounded.Chars()
 
 ```go
 func WithBorder(style BorderStyle) Option
+func WithBorderTitle(title string) Option
 ```
 
-Sets the border style on an element:
+`WithBorder` sets the border shape. `WithBorderTitle` draws a label centered in the top border line, styled to match the border and truncated when wider than the top edge:
 
 ```go
 el := tui.New(
     tui.WithBorder(tui.BorderRounded),
     tui.WithBorderStyle(tui.NewStyle().Foreground(tui.ANSIColor(tui.Cyan))),
+    tui.WithBorderTitle(" Status "),
     tui.WithText("Bordered content"),
 )
 ```


### PR DESCRIPTION
#72 added a `borderTitle` attribute and a `WithBorderTitle` option without documentation. This PR adds the missing docs:

- a Border Titles section in the styling guide, with a `.gsx` example and a sketch of the rendered box
- attribute rows in the gsx syntax guide and reference, the element reference, `llm.md`, and CLAUDE.md
- the `WithBorderTitle` option and `BorderTitle()`/`SetBorderTitle()` accessors in the styling and element references

I ran the guide's `.gsx` example through `tui generate` to confirm it produces `tui.WithBorderTitle(" Status ")`.