### PR TITLE
fix(buffer): keep wide-char continuation cells out of Diff tail erase

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -490,6 +490,12 @@ func (b *Buffer) Diff() []CellChange {
 			c := b.back[y*b.width+x]
 			if !c.IsEmpty() && !c.IsContinuation() {
 				lastContent = x
+				// A wide character also occupies the next column via its
+				// continuation cell. Keep that column inside the content region
+				// so the trailing erase can never clip the glyph's second half.
+				if c.Width == 2 && x+1 < b.width {
+					lastContent = x + 1
+				}
 				break
 			}
 		}

--- a/buffer_diff_test.go
+++ b/buffer_diff_test.go
@@ -92,6 +92,77 @@ func TestBuffer_Diff_RowMajorOrder(t *testing.T) {
 	}
 }
 
+func TestBuffer_Diff_TrailingWideChar(t *testing.T) {
+	type tc struct {
+		width      int
+		prevRow    string
+		newRow     string
+		wantEraseX int // expected X of the EraseToEOL change; -1 means no erase expected
+	}
+
+	tests := map[string]tc{
+		"erase starts after continuation cell when row shrinks to trailing wide char": {
+			width:      12,
+			prevRow:    "ABCDEFGHIJ",
+			newRow:     "测试题", // cols 0-5; continuation cell of '题' at col 5
+			wantEraseX: 6,
+		},
+		"erase skips unchanged trailing wide char when tail content is removed": {
+			width:      8,
+			prevRow:    "题  X",
+			newRow:     "题",
+			wantEraseX: 2,
+		},
+		"narrow trailing content erases immediately after it": {
+			width:      8,
+			prevRow:    "ABCDE",
+			newRow:     "ABC",
+			wantEraseX: 3,
+		},
+		"no erase when tail past trailing wide char is unchanged": {
+			width:      8,
+			prevRow:    "",
+			newRow:     "测试题",
+			wantEraseX: -1,
+		},
+		"continuation cell at last column leaves no tail to erase": {
+			width:      3,
+			prevRow:    "ABC",
+			newRow:     "A题", // continuation cell of '题' sits at col 2, the last column
+			wantEraseX: -1,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := NewBuffer(tt.width, 1)
+
+			// Previous frame: write and "flush" so it becomes the front buffer.
+			b.SetString(0, 0, tt.prevRow, NewStyle())
+			b.Swap()
+
+			// New frame.
+			b.ClearRect(b.Rect())
+			b.SetString(0, 0, tt.newRow, NewStyle())
+
+			gotEraseX := -1
+			for _, ch := range b.Diff() {
+				if !ch.EraseToEOL {
+					continue
+				}
+				if gotEraseX != -1 {
+					t.Fatalf("Diff() emitted more than one EraseToEOL change for a single row")
+				}
+				gotEraseX = ch.X
+			}
+
+			if gotEraseX != tt.wantEraseX {
+				t.Errorf("EraseToEOL X = %d, want %d", gotEraseX, tt.wantEraseX)
+			}
+		})
+	}
+}
+
 func TestBuffer_Swap(t *testing.T) {
 	b := NewBuffer(5, 3)
 	style := NewStyle()


### PR DESCRIPTION
## Summary

When a row ends in a wide (CJK/emoji) character, every differential update destroys that character on screen. Scrolling the markdown example with Chinese text drops the last character of each heading and paragraph, and it stays missing until something forces a full redraw. Initial render and resize are unaffected since they go through the full-redraw paths.

`Diff()` scans each row right to left for the rightmost content cell, skipping continuation cells. A trailing wide char stops the scan at its primary cell, which leaves the continuation column in the tail region, and the tail's single `EraseToEOL` starts on the glyph's second half:

```
row:  [测][ ][试][ ][标][ ][题][ ]
       0   1   2   3   4   5   6   7

lastContent = 6, tailStart = 7  =>  ESC[K at column 7
```

Terminals blank a multi-column glyph when any of its columns is erased, so the flush writes `题` and then immediately clips it. Worse, after `Swap()` the front buffer thinks the continuation cell is fine, so no later diff repaints the glyph. It stays broken until a full redraw.

The fix is when the rightmost primary has `Width == 2`, extend `lastContent` past the continuation cell so the tail erase starts after the glyph. The continuation cell can now be emitted as a regular `CellChange` when it changed, which is already a handled case. `ANSITerminal.Flush` skips continuation cells and receives them today for interior wide chars.

`TestBuffer_Diff_TrailingWideChar` covers the scroll case from the issue plus a few neighbors found while poking at this: a tail that clears while the wide char itself is unchanged (the erase used to wipe a glyph that never got rewritten), a freshly written trailing wide char (the back continuation never matches the front space, so a bogus erase went out on the first incremental paint of the row), a continuation cell sitting on the last buffer column, and an ASCII control case. All five fail without the fix, at the positions the trace predicts.

I also checked the two sibling scans that use the same idiom, `RenderFull` and `bufferRowToANSI`. Both only trim trailing output, and writing the primary rune covers both columns, so neither needs the extension.

Fixes #79
