### PR TITLE
fix(textarea): wrap wide characters at the display-width boundary

### DIFF
--- a/textarea.go
+++ b/textarea.go
@@ -384,7 +384,22 @@ func (t *TextArea) submit(ke KeyEvent) {
 
 // --- Text Wrapping and Cursor Position ---
 
-// wrapText wraps the text to fit within width, respecting embedded newlines.
+// wrapWidth returns the display columns available for text content. Borders
+// are drawn inside the element width, so they reduce the wrap width by one
+// column on each side.
+func (t *TextArea) wrapWidth() int {
+	w := t.width
+	if t.border != BorderNone {
+		w -= 2
+	}
+	return w
+}
+
+// wrapText wraps the text to fit within the content width, respecting
+// embedded newlines. Lines break at display-column boundaries (CJK and emoji
+// runes occupy two columns), never mid-rune: a wide rune that does not fit
+// moves to the next line. Cursor math stays in rune indices, which remain
+// consistent because wrapping only changes where lines split, not their runes.
 func (t *TextArea) wrapText() []string {
 	text := t.text.Get()
 	if text == "" {
@@ -392,6 +407,7 @@ func (t *TextArea) wrapText() []string {
 	}
 
 	var lines []string
+	width := t.wrapWidth()
 
 	// Split on embedded newlines first
 	paragraphs := strings.SplitSeq(text, "\n")
@@ -404,12 +420,18 @@ func (t *TextArea) wrapText() []string {
 
 		// Wrap this paragraph to width
 		currentLine := make([]rune, 0)
+		currentWidth := 0
 		for _, r := range para {
-			if t.width > 0 && len(currentLine) >= t.width {
+			rw := RuneWidth(r)
+			// The len guard keeps a rune wider than the wrap width on a line
+			// of its own instead of emitting empty lines before it.
+			if width > 0 && len(currentLine) > 0 && currentWidth+rw > width {
 				lines = append(lines, string(currentLine))
 				currentLine = currentLine[:0]
+				currentWidth = 0
 			}
 			currentLine = append(currentLine, r)
+			currentWidth += rw
 		}
 		lines = append(lines, string(currentLine))
 	}

--- a/textarea.go
+++ b/textarea.go
@@ -448,6 +448,7 @@ func (t *TextArea) cursorRowCol(lines []string) (row, col int) {
 	currentRow := 0
 	currentCol := 0
 	lineIdx := 0
+	wrapping := t.wrapWidth() > 0
 
 	for i := 0; i < len(textRunes) && i < pos; i++ {
 		if textRunes[i] == '\n' {
@@ -456,7 +457,7 @@ func (t *TextArea) cursorRowCol(lines []string) (row, col int) {
 			lineIdx++
 		} else {
 			currentCol++
-			if t.width > 0 && lineIdx < len(lines) && currentCol > utf8.RuneCountInString(lines[lineIdx]) {
+			if wrapping && lineIdx < len(lines) && currentCol > utf8.RuneCountInString(lines[lineIdx]) {
 				currentRow++
 				currentCol = 1
 				lineIdx++
@@ -475,6 +476,7 @@ func (t *TextArea) posFromRowCol(lines []string, targetRow, targetCol int) int {
 	currentRow := 0
 	currentCol := 0
 	lineIdx := 0
+	wrapping := t.wrapWidth() > 0
 
 	for i := range textRunes {
 		if currentRow == targetRow && currentCol == targetCol {
@@ -490,7 +492,7 @@ func (t *TextArea) posFromRowCol(lines []string, targetRow, targetCol int) int {
 			lineIdx++
 		} else {
 			currentCol++
-			if t.width > 0 && lineIdx < len(lines) && currentCol > utf8.RuneCountInString(lines[lineIdx]) {
+			if wrapping && lineIdx < len(lines) && currentCol > utf8.RuneCountInString(lines[lineIdx]) {
 				if currentRow == targetRow {
 					return i
 				}

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 	"unicode/utf8"
 )
@@ -49,6 +50,161 @@ func TestTextArea_MoveRight_UsesRuneLength(t *testing.T) {
 
 	if got := ta.cursorPos.Get(); got != 2 {
 		t.Fatalf("cursorPos = %d, want 2", got)
+	}
+}
+
+func TestTextArea_WrapText_DisplayWidth(t *testing.T) {
+	type tc struct {
+		width  int
+		border BorderStyle
+		text   string
+		want   []string
+	}
+
+	tests := map[string]tc{
+		"ascii wraps at width": {
+			width: 10,
+			text:  "abcdefghijklmnop",
+			want:  []string{"abcdefghij", "klmnop"},
+		},
+		"cjk wraps at display columns not rune count": {
+			width: 10,
+			text:  "一二三四五六七八九十",
+			want:  []string{"一二三四五", "六七八九十"},
+		},
+		"mixed ascii and cjk": {
+			width: 10,
+			text:  "ab界cd界ef界",
+			want:  []string{"ab界cd界ef", "界"},
+		},
+		"wide char that does not fit moves to next line": {
+			width: 5,
+			text:  "ab界界",
+			want:  []string{"ab界", "界"},
+		},
+		"border reduces wrap width by two": {
+			width:  10,
+			border: BorderSingle,
+			text:   "abcdefghijklmnop",
+			want:   []string{"abcdefgh", "ijklmnop"},
+		},
+		"embedded newlines preserved": {
+			width: 10,
+			text:  "一二三\n\nab",
+			want:  []string{"一二三", "", "ab"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := []TextAreaOption{WithTextAreaWidth(tt.width)}
+			if tt.border != BorderNone {
+				opts = append(opts, WithTextAreaBorder(tt.border))
+			}
+			ta := NewTextArea(opts...)
+			ta.BindApp(testApp)
+			ta.SetText(tt.text)
+
+			lines := ta.wrapText()
+			if len(lines) != len(tt.want) {
+				t.Fatalf("wrapText() = %q, want %q", lines, tt.want)
+			}
+			for i := range lines {
+				if lines[i] != tt.want[i] {
+					t.Fatalf("wrapText()[%d] = %q, want %q", i, lines[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestTextArea_CursorRowCol_WideChars(t *testing.T) {
+	type tc struct {
+		pos     int
+		wantRow int
+		wantCol int
+	}
+
+	// width 10, "一二三四五六七八九十" wraps to ["一二三四五", "六七八九十"]
+	tests := map[string]tc{
+		"start of text":              {pos: 0, wantRow: 0, wantCol: 0},
+		"end of first wrapped line":  {pos: 5, wantRow: 0, wantCol: 5},
+		"after first rune of second": {pos: 6, wantRow: 1, wantCol: 1},
+		"end of text":                {pos: 10, wantRow: 1, wantCol: 5},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ta := NewTextArea(WithTextAreaWidth(10))
+			ta.BindApp(testApp)
+			ta.SetText("一二三四五六七八九十")
+			ta.cursorPos.Set(tt.pos)
+
+			row, col := ta.cursorRowCol(ta.wrapText())
+			if row != tt.wantRow || col != tt.wantCol {
+				t.Fatalf("cursorRowCol() = (%d, %d), want (%d, %d)", row, col, tt.wantRow, tt.wantCol)
+			}
+		})
+	}
+}
+
+// renderedRows renders a component into a standalone buffer and returns each
+// row as a plain string (continuation cells skipped, empty cells as spaces).
+func renderedRows(t *testing.T, c Component, width int) []string {
+	t.Helper()
+	buf, height := renderElementToBuffer(c.Render(testApp), width, Capabilities{})
+	if buf == nil {
+		t.Fatal("renderElementToBuffer returned nil buffer")
+	}
+	rows := make([]string, 0, height)
+	for y := range height {
+		var sb strings.Builder
+		for x := range width {
+			cell := buf.Cell(x, y)
+			if cell.IsContinuation() {
+				continue
+			}
+			if cell.Rune == 0 {
+				sb.WriteRune(' ')
+			} else {
+				sb.WriteRune(cell.Rune)
+			}
+		}
+		rows = append(rows, sb.String())
+	}
+	return rows
+}
+
+func TestTextArea_Render_NoClippedContent(t *testing.T) {
+	type tc struct {
+		width  int
+		border BorderStyle
+		text   string
+	}
+
+	tests := map[string]tc{
+		"cjk without border": {width: 10, text: "一二三四五六七八九十"},
+		"cjk with border":    {width: 10, border: BorderSingle, text: "一二三四五六七八"},
+		"ascii with border":  {width: 10, border: BorderSingle, text: "abcdefghijklmnop"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := []TextAreaOption{WithTextAreaWidth(tt.width)}
+			if tt.border != BorderNone {
+				opts = append(opts, WithTextAreaBorder(tt.border))
+			}
+			ta := NewTextArea(opts...)
+			ta.BindApp(testApp)
+			ta.SetText(tt.text)
+
+			rendered := strings.Join(renderedRows(t, ta, tt.width), "\n")
+			for _, r := range tt.text {
+				if !strings.ContainsRune(rendered, r) {
+					t.Errorf("rune %q clipped out of rendered output:\n%s", r, rendered)
+				}
+			}
+		})
 	}
 }
 

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -93,6 +93,22 @@ func TestTextArea_WrapText_DisplayWidth(t *testing.T) {
 			text:  "一二三\n\nab",
 			want:  []string{"一二三", "", "ab"},
 		},
+		"emoji wraps at display columns": {
+			width: 5,
+			text:  "🎉🎉🎉",
+			want:  []string{"🎉🎉", "🎉"},
+		},
+		"rune wider than wrap width gets its own line": {
+			width:  3,
+			border: BorderSingle,
+			text:   "界界",
+			want:   []string{"界", "界"},
+		},
+		"zero width disables wrapping": {
+			width: 0,
+			text:  "abcdef\ngh",
+			want:  []string{"abcdef", "gh"},
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
## Summary

Typing CJK text into a textarea drops half of it from view. `wrapText()` breaks lines at `t.width` runes, but CJK and emoji runes are two terminal columns wide, so a width-10 textarea packs 10 CJK runes (20 columns) onto one line and the renderer clips everything past column 10. The cursor sits at the end of what you typed, so it disappears too.

```
width 10, text "一二三四五六七八九十"

before:  ["一二三四五六七八九十"]    20 columns, renders as "一二三四五"
after:   ["一二三四五", "六七八九十"]
```

The fix accumulates display columns via `RuneWidth` instead of counting runes, and a wide rune that doesn't fit moves to the next line. The cursor functions (`cursorRowCol`, `posFromRowCol`, the movement handlers) need no changes since they work on rune indices and read per-line lengths from the wrapped lines themselves. The cursor renders in-band by splicing into the line text, so its visual position follows automatically.

While verifying this I found the wrap width was also wrong for bordered textareas, even with plain ASCII. Borders draw inside the element width, so the content box is `t.width - 2`, but wrapping happened at `t.width` and the last two columns of every full line got clipped. `Input.visibleWidth()` already subtracts the border for the same reason, so the new `wrapWidth()` helper does the same here.

One thing worth noting: the package-level `wrapText` in text_wrap.go can't be reused for this. It wraps at word boundaries and collapses whitespace through `strings.Fields`, which would break the rune-index invariant the cursor math depends on. The textarea needs character wrapping that preserves the source runes exactly.

The new tests pin the wrap boundaries (CJK, emoji, mixed text, borders, the degenerate one-column case) and render real buffers to assert no rune gets clipped from view. All three render cases fail without the fix.

`<input>` has a sibling bug I'm leaving for a separate issue: `displayText()` computes its scroll window in columns but slices by rune count, so a focused width-10 input returns 19 columns of CJK text. That one needs its own scroll-math fix.

Fixes #81
