### PR TITLE
fix(textarea): keep the cursor visible at display-full wrap boundaries

### DIFF
--- a/textarea.go
+++ b/textarea.go
@@ -93,17 +93,25 @@ func (t *TextArea) Clear() {
 	t.cursorPos.Set(0)
 }
 
-// Height returns the total rendered height including border.
-func (t *TextArea) Height() int {
-	lines := t.wrapText()
+// contentRows returns the number of content rows to render: the wrapped
+// lines plus the phantom cursor row, clamped to maxHeight. Note that when
+// content exceeds maxHeight the rows below the clamp (including the cursor's
+// row) are clipped; the textarea has no scroll-to-cursor.
+func (t *TextArea) contentRows(lines []string) int {
 	rows := len(lines)
 	if t.phantomCursorRow(lines) {
 		rows++
 	}
-	height := max(rows, 1)
-	if t.maxHeight > 0 && height > t.maxHeight {
-		height = t.maxHeight
+	rows = max(rows, 1)
+	if t.maxHeight > 0 && rows > t.maxHeight {
+		rows = t.maxHeight
 	}
+	return rows
+}
+
+// Height returns the total rendered height including border.
+func (t *TextArea) Height() int {
+	height := t.contentRows(t.wrapText())
 	if t.border != BorderNone {
 		height += 2
 	}
@@ -115,17 +123,10 @@ func (t *TextArea) Height() int {
 // Render returns the element tree for the text area.
 func (t *TextArea) Render(app *App) *Element {
 	lines := t.wrapText()
-	rows := len(lines)
-	if t.phantomCursorRow(lines) {
-		rows++
-	}
-	height := max(rows, 1)
-	if t.maxHeight > 0 && height > t.maxHeight {
-		height = t.maxHeight
-	}
+	rows := t.contentRows(lines)
 
 	// Account for border
-	totalHeight := height
+	totalHeight := rows
 	if t.border != BorderNone {
 		totalHeight += 2
 	}
@@ -379,6 +380,11 @@ func (t *TextArea) moveHome(ke KeyEvent) {
 func (t *TextArea) moveEnd(ke KeyEvent) {
 	lines := t.wrapText()
 	row, _ := t.cursorRowCol(lines)
+	// The cursor can sit on the phantom row one past the last line; End there
+	// resolves against the last real line.
+	if row >= len(lines) {
+		row = len(lines) - 1
+	}
 	t.cursorPos.Set(t.posFromRowCol(lines, row, utf8.RuneCountInString(lines[row])))
 	t.blink.Set(true)
 }
@@ -576,6 +582,16 @@ func (t *TextArea) lineWithCursor(lineIdx int) string {
 		}
 		runes := []rune(line)
 		if col >= len(runes) {
+			// A display-full line ended by a hard newline keeps the cursor at
+			// its end (see cursorRowCol), where an appended cursor would be
+			// clipped. Overlay the last cell instead, like a block cursor
+			// sitting on the character.
+			if w := t.wrapWidth(); w > 0 && stringWidth(line) >= w && len(runes) > 0 {
+				if !t.blink.Get() {
+					return line
+				}
+				return string(runes[:len(runes)-1]) + string(t.cursorRune)
+			}
 			return line + cursor
 		}
 		withCursor := append(runes[:col], append([]rune{t.cursorRune}, runes[col:]...)...)

--- a/textarea.go
+++ b/textarea.go
@@ -96,7 +96,11 @@ func (t *TextArea) Clear() {
 // Height returns the total rendered height including border.
 func (t *TextArea) Height() int {
 	lines := t.wrapText()
-	height := max(len(lines), 1)
+	rows := len(lines)
+	if t.phantomCursorRow(lines) {
+		rows++
+	}
+	height := max(rows, 1)
 	if t.maxHeight > 0 && height > t.maxHeight {
 		height = t.maxHeight
 	}
@@ -111,7 +115,11 @@ func (t *TextArea) Height() int {
 // Render returns the element tree for the text area.
 func (t *TextArea) Render(app *App) *Element {
 	lines := t.wrapText()
-	height := max(len(lines), 1)
+	rows := len(lines)
+	if t.phantomCursorRow(lines) {
+		rows++
+	}
+	height := max(rows, 1)
 	if t.maxHeight > 0 && height > t.maxHeight {
 		height = t.maxHeight
 	}
@@ -157,7 +165,7 @@ func (t *TextArea) Render(app *App) *Element {
 	if t.text.Get() == "" && t.placeholder != "" && !t.focused.Get() {
 		root.AddChild(New(WithText(t.placeholder), WithTextStyle(t.placeholderStyle)))
 	} else {
-		for i := range lines {
+		for i := range rows {
 			root.AddChild(New(WithText(t.lineWithCursor(i)), WithTextStyle(t.textStyle), WithWrap(false)))
 		}
 	}
@@ -440,6 +448,13 @@ func (t *TextArea) wrapText() []string {
 }
 
 // cursorRowCol returns the row and column of the cursor.
+//
+// A cursor at the end of a display-full line has no column left to render in,
+// so it moves to the start of the next visual line (downstream affinity). This
+// applies at soft wrap boundaries and at end of text, where the reported row
+// is one past the last wrapped line (a phantom row that Render and Height
+// account for). A full line ended by a hard newline keeps the cursor at its
+// end, since the next row starts a different paragraph.
 func (t *TextArea) cursorRowCol(lines []string) (row, col int) {
 	text := t.text.Get()
 	pos := t.clampCursorPos()
@@ -448,7 +463,8 @@ func (t *TextArea) cursorRowCol(lines []string) (row, col int) {
 	currentRow := 0
 	currentCol := 0
 	lineIdx := 0
-	wrapping := t.wrapWidth() > 0
+	width := t.wrapWidth()
+	wrapping := width > 0
 
 	for i := 0; i < len(textRunes) && i < pos; i++ {
 		if textRunes[i] == '\n' {
@@ -463,6 +479,13 @@ func (t *TextArea) cursorRowCol(lines []string) (row, col int) {
 				lineIdx++
 			}
 		}
+	}
+
+	if wrapping && lineIdx < len(lines) && currentCol > 0 &&
+		currentCol == utf8.RuneCountInString(lines[lineIdx]) &&
+		stringWidth(lines[lineIdx]) >= width &&
+		(pos == len(textRunes) || textRunes[pos] != '\n') {
+		return currentRow + 1, 0
 	}
 
 	return currentRow, currentCol
@@ -499,6 +522,13 @@ func (t *TextArea) posFromRowCol(lines []string, targetRow, targetCol int) int {
 				currentRow++
 				currentCol = 1
 				lineIdx++
+				// The position before rune i is the start of the new line, so
+				// (row, 0) targets on soft-wrapped lines resolve here. Without
+				// this, column-0 targets after a soft wrap fall through the
+				// loop and land at the end of the text.
+				if currentRow == targetRow && targetCol == 0 {
+					return i
+				}
 			}
 		}
 	}
@@ -506,14 +536,30 @@ func (t *TextArea) posFromRowCol(lines []string, targetRow, targetCol int) int {
 	return len(textRunes)
 }
 
+// phantomCursorRow reports whether the cursor sits one row past the last
+// wrapped line (end of text on a display-full line), which needs an extra
+// rendered row to host the cursor.
+func (t *TextArea) phantomCursorRow(lines []string) bool {
+	if !t.focused.Get() || t.hideVirtualCursor {
+		return false
+	}
+	row, _ := t.cursorRowCol(lines)
+	return row >= len(lines)
+}
+
 // lineWithCursor returns a line with the cursor character inserted.
 func (t *TextArea) lineWithCursor(lineIdx int) string {
 	lines := t.wrapText()
+	row, col := t.cursorRowCol(lines)
+
 	if lineIdx >= len(lines) {
+		// Phantom row hosting the cursor past a display-full last line.
+		if lineIdx == row && t.focused.Get() && !t.hideVirtualCursor && t.blink.Get() {
+			return string(t.cursorRune)
+		}
 		return " "
 	}
 
-	row, col := t.cursorRowCol(lines)
 	line := lines[lineIdx]
 
 	if lineIdx == row && t.focused.Get() {

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -141,12 +141,15 @@ func TestTextArea_CursorRowCol_WideChars(t *testing.T) {
 		wantCol int
 	}
 
-	// width 10, "一二三四五六七八九十" wraps to ["一二三四五", "六七八九十"]
+	// width 10, "一二三四五六七八九十" wraps to ["一二三四五", "六七八九十"].
+	// Both wrapped lines are display-full, so boundary positions move to the
+	// next visual line (downstream affinity); end of text lands on a phantom
+	// row past the last line.
 	tests := map[string]tc{
 		"start of text":              {pos: 0, wantRow: 0, wantCol: 0},
-		"end of first wrapped line":  {pos: 5, wantRow: 0, wantCol: 5},
+		"soft wrap boundary":         {pos: 5, wantRow: 1, wantCol: 0},
 		"after first rune of second": {pos: 6, wantRow: 1, wantCol: 1},
-		"end of text":                {pos: 10, wantRow: 1, wantCol: 5},
+		"end of text":                {pos: 10, wantRow: 2, wantCol: 0},
 	}
 
 	for name, tt := range tests {
@@ -221,6 +224,131 @@ func TestTextArea_Render_NoClippedContent(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestTextArea_CursorRowCol_WrapBoundaryAffinity(t *testing.T) {
+	type tc struct {
+		text    string
+		width   int
+		pos     int
+		wantRow int
+		wantCol int
+	}
+
+	tests := map[string]tc{
+		"soft boundary on full line moves to next line start": {
+			text: "abcdefgh", width: 4, pos: 4, wantRow: 1, wantCol: 0,
+		},
+		"soft boundary on non-full line stays at line end": {
+			// "ab界" is 4 columns in width 5, so the cursor still fits there
+			text: "ab界界", width: 5, pos: 3, wantRow: 0, wantCol: 3,
+		},
+		"hard newline after full line stays at line end": {
+			text: "abcd\nef", width: 4, pos: 4, wantRow: 0, wantCol: 4,
+		},
+		"end of text on full last line moves to phantom row": {
+			text: "abcd", width: 4, pos: 4, wantRow: 1, wantCol: 0,
+		},
+		"end of text on full cjk line moves to phantom row": {
+			text: "一二", width: 4, pos: 2, wantRow: 1, wantCol: 0,
+		},
+		"end of text on non-full line stays at line end": {
+			text: "abc", width: 4, pos: 3, wantRow: 0, wantCol: 3,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ta := NewTextArea(WithTextAreaWidth(tt.width))
+			ta.BindApp(testApp)
+			ta.SetText(tt.text)
+			ta.cursorPos.Set(tt.pos)
+
+			row, col := ta.cursorRowCol(ta.wrapText())
+			if row != tt.wantRow || col != tt.wantCol {
+				t.Fatalf("cursorRowCol() = (%d, %d), want (%d, %d)", row, col, tt.wantRow, tt.wantCol)
+			}
+		})
+	}
+}
+
+func TestTextArea_MoveDown_SoftWrapColZero(t *testing.T) {
+	// posFromRowCol could not resolve (row, 0) targets on soft-wrapped lines,
+	// so moving down from column 0 jumped past the target line entirely.
+	ta := NewTextArea(WithTextAreaWidth(4))
+	ta.BindApp(testApp)
+	ta.SetText("abcdef")
+	ta.cursorPos.Set(0)
+
+	ta.moveDown(KeyEvent{Key: KeyDown})
+	if got := ta.cursorPos.Get(); got != 4 {
+		t.Fatalf("cursorPos after moveDown = %d, want 4", got)
+	}
+}
+
+func TestTextArea_MoveUp_FromWrapBoundary(t *testing.T) {
+	// The cursor at a full-line soft boundary displays on the next line, so
+	// moving up from there should land on the line above it.
+	ta := NewTextArea(WithTextAreaWidth(4))
+	ta.BindApp(testApp)
+	ta.SetText("abcdef")
+	ta.cursorPos.Set(4)
+
+	ta.moveUp(KeyEvent{Key: KeyUp})
+	if got := ta.cursorPos.Get(); got != 0 {
+		t.Fatalf("cursorPos after moveUp = %d, want 0", got)
+	}
+}
+
+func TestTextArea_CursorVisibleAtWrapBoundary(t *testing.T) {
+	type tc struct {
+		text       string
+		width      int
+		pos        int
+		wantHeight int
+	}
+
+	tests := map[string]tc{
+		"soft boundary on full line":      {text: "abcdefgh", width: 4, pos: 4, wantHeight: 2},
+		"end of text on full last line":   {text: "abcd", width: 4, pos: 4, wantHeight: 2},
+		"end of text on full cjk line":    {text: "一二三四五", width: 10, pos: 5, wantHeight: 2},
+		"end of text on non-full line":    {text: "abc", width: 4, pos: 3, wantHeight: 1},
+		"end of text after hard newline":  {text: "abcd\n", width: 4, pos: 5, wantHeight: 2},
+		"mid-line cursor away from edges": {text: "abcdef", width: 4, pos: 2, wantHeight: 2},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ta := NewTextArea(WithTextAreaWidth(tt.width))
+			ta.BindApp(testApp)
+			ta.SetText(tt.text)
+			ta.Focus()
+			ta.cursorPos.Set(tt.pos)
+			ta.blink.Set(true)
+
+			rows := renderedRows(t, ta, tt.width)
+			if len(rows) != tt.wantHeight {
+				t.Fatalf("rendered height = %d, want %d\n%s", len(rows), tt.wantHeight, strings.Join(rows, "\n"))
+			}
+			if !strings.ContainsRune(strings.Join(rows, "\n"), ta.cursorRune) {
+				t.Fatalf("cursor not visible in rendered output:\n%s", strings.Join(rows, "\n"))
+			}
+		})
+	}
+}
+
+func TestTextArea_Height_PhantomCursorRow(t *testing.T) {
+	ta := NewTextArea(WithTextAreaWidth(4))
+	ta.BindApp(testApp)
+	ta.SetText("abcd")
+
+	if got := ta.Height(); got != 1 {
+		t.Fatalf("unfocused Height() = %d, want 1", got)
+	}
+	ta.Focus()
+	if got := ta.Height(); got != 2 {
+		t.Fatalf("focused Height() = %d, want 2", got)
 	}
 }
 

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -273,31 +273,56 @@ func TestTextArea_CursorRowCol_WrapBoundaryAffinity(t *testing.T) {
 	}
 }
 
-func TestTextArea_MoveDown_SoftWrapColZero(t *testing.T) {
-	// posFromRowCol could not resolve (row, 0) targets on soft-wrapped lines,
-	// so moving down from column 0 jumped past the target line entirely.
-	ta := NewTextArea(WithTextAreaWidth(4))
-	ta.BindApp(testApp)
-	ta.SetText("abcdef")
-	ta.cursorPos.Set(0)
-
-	ta.moveDown(KeyEvent{Key: KeyDown})
-	if got := ta.cursorPos.Get(); got != 4 {
-		t.Fatalf("cursorPos after moveDown = %d, want 4", got)
+func TestTextArea_Move_WrapBoundary(t *testing.T) {
+	type tc struct {
+		text    string
+		width   int
+		pos     int
+		move    func(*TextArea)
+		wantPos int
 	}
-}
 
-func TestTextArea_MoveUp_FromWrapBoundary(t *testing.T) {
-	// The cursor at a full-line soft boundary displays on the next line, so
-	// moving up from there should land on the line above it.
-	ta := NewTextArea(WithTextAreaWidth(4))
-	ta.BindApp(testApp)
-	ta.SetText("abcdef")
-	ta.cursorPos.Set(4)
+	tests := map[string]tc{
+		// posFromRowCol could not resolve (row, 0) targets on soft-wrapped
+		// lines, so moving down from column 0 jumped past the target line.
+		"down from column zero crosses soft wrap": {
+			text: "abcdef", width: 4, pos: 0,
+			move:    func(ta *TextArea) { ta.moveDown(KeyEvent{Key: KeyDown}) },
+			wantPos: 4,
+		},
+		// The cursor at a full-line soft boundary displays on the next line,
+		// so moving up from there lands on the line above it.
+		"up from wrap boundary lands on previous line": {
+			text: "abcdef", width: 4, pos: 4,
+			move:    func(ta *TextArea) { ta.moveUp(KeyEvent{Key: KeyUp}) },
+			wantPos: 0,
+		},
+		// End with the cursor on the phantom row resolves against the last
+		// real line instead of indexing past the lines slice.
+		"end on phantom row stays at end of text": {
+			text: "abcd", width: 4, pos: 4,
+			move:    func(ta *TextArea) { ta.moveEnd(KeyEvent{Key: KeyEnd}) },
+			wantPos: 4,
+		},
+		"home on phantom row stays at boundary": {
+			text: "abcd", width: 4, pos: 4,
+			move:    func(ta *TextArea) { ta.moveHome(KeyEvent{Key: KeyHome}) },
+			wantPos: 4,
+		},
+	}
 
-	ta.moveUp(KeyEvent{Key: KeyUp})
-	if got := ta.cursorPos.Get(); got != 0 {
-		t.Fatalf("cursorPos after moveUp = %d, want 0", got)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ta := NewTextArea(WithTextAreaWidth(tt.width))
+			ta.BindApp(testApp)
+			ta.SetText(tt.text)
+			ta.cursorPos.Set(tt.pos)
+
+			tt.move(ta)
+			if got := ta.cursorPos.Get(); got != tt.wantPos {
+				t.Fatalf("cursorPos after move = %d, want %d", got, tt.wantPos)
+			}
+		})
 	}
 }
 
@@ -316,6 +341,9 @@ func TestTextArea_CursorVisibleAtWrapBoundary(t *testing.T) {
 		"end of text on non-full line":    {text: "abc", width: 4, pos: 3, wantHeight: 1},
 		"end of text after hard newline":  {text: "abcd\n", width: 4, pos: 5, wantHeight: 2},
 		"mid-line cursor away from edges": {text: "abcdef", width: 4, pos: 2, wantHeight: 2},
+		// The cursor overlays the last cell when a display-full line ends in
+		// a hard newline, since there is no continuation line to move it to.
+		"full line before hard newline": {text: "abcd\nef", width: 4, pos: 4, wantHeight: 2},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
## Summary

Follow-up to #82. The textarea renders its cursor by splicing the cursor rune into the line text, so a cursor at the end of a display-full wrapped line produced a line one column wider than the wrap width and the cursor was clipped invisible. You hit it by pressing End on a wrapped line, arrowing onto a wrap boundary, or calling SetText with content that exactly fills the width, since the cursor lands at the end of the text which is the boundary.

The fix gives the cursor downstream affinity, matching what browsers and editors do: at a soft wrap boundary on a full line, `cursorRowCol` now reports the start of the next visual line instead of one column past the end of the full one. At the end of the text there is no next line, so the cursor gets a phantom row one past the last wrapped line, and `Render` and `Height` grow by that row while focused. Your next keystroke was about to create that row anyway, so the height change just happens one keystroke early. Navigation reads the same row/col mapping, which keeps End, Home, and the arrow keys consistent with what you see.

A display-full line ended by a hard newline is the one case that keeps the cursor at the line's end. Shifting it would put it on the next paragraph's row and make End jump to the wrong line. Instead the cursor overlays the line's last cell there, like a block cursor sitting on the character.

Fixing the inverse mapping turned up a navigation bug that predates all of this: `posFromRowCol` could not resolve column-0 targets on soft-wrapped lines, so pressing Down from column 0 across a soft wrap jumped the cursor to the end of the text. `TestTextArea_Move_WrapBoundary` pins the fix.

The review pass caught a panic in my first cut: End with the cursor on the phantom row indexed one past the lines slice. That is guarded now and pinned by a regression test. Two expectations in the #82 cursor tests changed on purpose, since boundary positions on full lines now report the next line's start and end of text on a full last line reports the phantom row.

One known limitation is unchanged: when content exceeds maxHeight there is no scroll-to-cursor, so the cursor's row can sit below the clamp. That predates this change and is noted in the code.
