### PR TITLE
fix(tuigen): avoid receiver shadowing in generated UpdateProps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,22 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests with coverage
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="https://github.com/grindlemire/go-tui/actions/workflows/ci.yml"><img src="https://github.com/grindlemire/go-tui/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/grindlemire/go-tui/blob/main/LICENSE"><img src="https://img.shields.io/github/license/grindlemire/go-tui" alt="License"></a>
   <a href="https://goreportcard.com/report/github.com/grindlemire/go-tui"><img src="https://goreportcard.com/badge/github.com/grindlemire/go-tui" alt="Go Report Card"></a>
+  <a href="https://codecov.io/gh/grindlemire/go-tui"><img src="https://codecov.io/gh/grindlemire/go-tui/branch/main/graph/badge.svg" alt="Coverage"></a>
 </p>
 
 <p align="center">

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    # Informational while coverage is being raised toward the 80% target;
+    # flip to blocking thresholds once the library packages are there.
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+ignore:
+  - "examples"
+  - "dist"
+  - "editor"
+  - "docs"
+  - "scripts"
+  - "cmd/tui/testdata"

--- a/examples/10-scrolling/scrolling_gsx.go
+++ b/examples/10-scrolling/scrolling_gsx.go
@@ -161,11 +161,11 @@ func (f *fileList) Render(app *tui.App) *tui.Element {
 }
 
 func (f *fileList) UpdateProps(fresh tui.Component) {
-	f, ok := fresh.(*fileList)
+	ff, ok := fresh.(*fileList)
 	if !ok {
 		return
 	}
-	f.files = f.files
+	f.files = ff.files
 }
 
 var _ tui.PropsUpdater = (*fileList)(nil)

--- a/examples/22-event-loop/feed_gsx.go
+++ b/examples/22-event-loop/feed_gsx.go
@@ -250,11 +250,11 @@ func (f *feedApp) Render(app *tui.App) *tui.Element {
 }
 
 func (f *feedApp) UpdateProps(fresh tui.Component) {
-	f, ok := fresh.(*feedApp)
+	ff, ok := fresh.(*feedApp)
 	if !ok {
 		return
 	}
-	f.mode = f.mode
+	f.mode = ff.mode
 }
 
 var _ tui.PropsUpdater = (*feedApp)(nil)

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -562,10 +562,18 @@ func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 	// Get the receiver type name without pointer
 	typeName := strings.TrimPrefix(comp.ReceiverType, "*")
 
+	// Pick a local name for the type-asserted fresh component that does not
+	// shadow the receiver; shadowing would turn every prop copy below into a
+	// self-assignment.
+	freshName := "f"
+	for freshName == comp.ReceiverName {
+		freshName += "f"
+	}
+
 	// Generate UpdateProps method
 	g.writef("func (%s) UpdateProps(fresh tui.Component) {\n", comp.Receiver)
 	g.indent++
-	g.writef("f, ok := fresh.(%s)\n", comp.ReceiverType)
+	g.writef("%s, ok := fresh.(%s)\n", freshName, comp.ReceiverType)
 	g.writeln("if !ok {")
 	g.indent++
 	g.writeln("return")
@@ -574,7 +582,7 @@ func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 
 	// Copy each prop field
 	for _, f := range propFields {
-		g.writef("%s.%s = f.%s\n", comp.ReceiverName, f.Name, f.Name)
+		g.writef("%s.%s = %s.%s\n", comp.ReceiverName, f.Name, freshName, f.Name)
 	}
 
 	g.indent--

--- a/internal/tuigen/generator_test.go
+++ b/internal/tuigen/generator_test.go
@@ -1402,3 +1402,73 @@ templ (c *myRoot) Render() {
 		}
 	}
 }
+
+// TestGenerator_UpdatePropsReceiverShadowing verifies that the generated
+// UpdateProps does not shadow the method receiver with the type-asserted
+// local. When a component's receiver was named "f" (the hardcoded local
+// name), the assertion shadowed the receiver and every prop copy became a
+// self-assignment, silently dropping prop updates on cached components.
+func TestGenerator_UpdatePropsReceiverShadowing(t *testing.T) {
+	type tc struct {
+		input           string
+		wantContains    []string
+		wantNotContains []string
+	}
+
+	tests := map[string]tc{
+		"receiver named f does not shadow the fresh local": {
+			input: `package x
+
+type fileList struct {
+	files []string
+}
+
+templ (f *fileList) Render() {
+	<div></div>
+}`,
+			wantContains: []string{
+				"func (f *fileList) UpdateProps(fresh tui.Component) {",
+				"f.files = ff.files",
+			},
+			wantNotContains: []string{
+				"f.files = f.files",
+			},
+		},
+		"non-colliding receiver keeps the f local": {
+			input: `package x
+
+type fileList struct {
+	files []string
+}
+
+templ (l *fileList) Render() {
+	<div></div>
+}`,
+			wantContains: []string{
+				"f, ok := fresh.(*fileList)",
+				"l.files = f.files",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			output, err := parseAndGenerateSkipImports("test.gsx", tt.input)
+			if err != nil {
+				t.Fatalf("generation failed: %v", err)
+			}
+
+			code := string(output)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(code, want) {
+					t.Errorf("output missing expected string: %q\nGot:\n%s", want, code)
+				}
+			}
+			for _, notWant := range tt.wantNotContains {
+				if strings.Contains(code, notWant) {
+					t.Errorf("output contains unexpected string: %q\nGot:\n%s", notWant, code)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Prep work for the awesome-go submission:

- **fix(tuigen)**: the generated `UpdateProps` hardcoded `f` as the local for the type-asserted fresh component. When a component's receiver was also named `f`, the local shadowed the receiver and every prop copy became a self-assignment, silently dropping prop updates on cached components (and tripping `go vet` in two examples, which would hurt the Go Report Card grade). The generator now picks a non-colliding local name; affected examples regenerated.
- **ci**: new `coverage` job uploads a coverage profile to Codecov, plus a `codecov.yml` (examples/tooling dirs ignored, status checks informational for now) and a coverage badge in the README.
