### PR TITLE
docs: add doc comments to exported constants in the root package

### DIFF
--- a/element_scroll.go
+++ b/element_scroll.go
@@ -7,7 +7,7 @@ func (e *Element) IsScrollable() bool {
 	return e.scrollMode != ScrollNone
 }
 
-// ScrollMode returns the current scroll mode.
+// ScrollModeValue returns the current scroll mode.
 func (e *Element) ScrollModeValue() ScrollMode {
 	return e.scrollMode
 }

--- a/highlight.go
+++ b/highlight.go
@@ -6,6 +6,8 @@ import "github.com/grindlemire/go-tui/internal/highlight"
 // internal lexer taxonomy.
 type TokenKind int
 
+// The token kinds produced by the built-in tokenizer. A Palette maps each
+// kind to a color.
 const (
 	TokenPlain    TokenKind = iota // uncolored
 	TokenKeyword                   // language keywords

--- a/key.go
+++ b/key.go
@@ -5,6 +5,9 @@ import "strings"
 // Key represents a keyboard key.
 type Key uint16
 
+// The keys reported in a KeyEvent. Printable characters arrive as KeyRune
+// with the character in KeyEvent.Rune; everything else maps to one of the
+// named keys below.
 const (
 	// KeyNone represents no key (zero value).
 	KeyNone Key = iota
@@ -13,6 +16,7 @@ const (
 	KeyRune
 
 	// Special keys
+
 	KeyEscape
 	KeyEnter
 	KeyTab
@@ -21,18 +25,21 @@ const (
 	KeyInsert
 
 	// Arrow keys
+
 	KeyUp
 	KeyDown
 	KeyLeft
 	KeyRight
 
 	// Navigation keys
+
 	KeyHome
 	KeyEnd
 	KeyPageUp
 	KeyPageDown
 
 	// Function keys
+
 	KeyF1
 	KeyF2
 	KeyF3

--- a/layout.go
+++ b/layout.go
@@ -7,6 +7,7 @@ import "github.com/grindlemire/go-tui/internal/layout"
 // Display specifies the layout mode for an element.
 type Display = layout.Display
 
+// Display modes.
 const (
 	DisplayBlock = layout.DisplayBlock // Block layout: column direction, fills parent width
 	DisplayFlex  = layout.DisplayFlex  // Flex layout: explicit direction control
@@ -15,6 +16,7 @@ const (
 // Direction specifies the main axis for laying out children.
 type Direction = layout.Direction
 
+// Directions.
 const (
 	Row    = layout.Row
 	Column = layout.Column
@@ -23,6 +25,7 @@ const (
 // Justify specifies how children are distributed along the main axis.
 type Justify = layout.Justify
 
+// Justify values.
 const (
 	JustifyStart        = layout.JustifyStart
 	JustifyEnd          = layout.JustifyEnd
@@ -35,6 +38,7 @@ const (
 // Align specifies how children are aligned along the cross axis.
 type Align = layout.Align
 
+// Align values.
 const (
 	AlignStart   = layout.AlignStart
 	AlignEnd     = layout.AlignEnd
@@ -45,6 +49,7 @@ const (
 // FlexWrap controls whether flex items wrap to new lines.
 type FlexWrap = layout.FlexWrap
 
+// FlexWrap values.
 const (
 	WrapNone    = layout.WrapNone    // No wrapping (default)
 	Wrap        = layout.Wrap        // Wrap to next line
@@ -54,6 +59,7 @@ const (
 // AlignContent controls how flex lines are distributed along the cross axis.
 type AlignContent = layout.AlignContent
 
+// AlignContent values.
 const (
 	ContentStart        = layout.ContentStart        // Pack lines at start
 	ContentEnd          = layout.ContentEnd          // Pack lines at end


### PR DESCRIPTION
## Summary

Clears the 12 remaining revive `exported` findings on the public API, part of the awesome-go submission prep ("All public functions and types should have a Go-style documentation header"):

- `key.go`: doc comment on the Key const block; group headers detached so they no longer read as malformed doc comments
- `layout.go`: doc comments on the six re-exported const blocks (Display, Direction, Justify, Align, FlexWrap, AlignContent)
- `highlight.go`: doc comment on the TokenKind const block
- `element_scroll.go`: the comment on `Element.ScrollModeValue` now starts with the method name

## Testing

`golangci-lint run --enable-only=revive` on the root package now reports zero `exported` findings; gofmt clean; root package tests pass.