### PR TITLE
fix(tuigen): prevent loop mount keys from colliding with other mount call sites

### DIFF
--- a/internal/tuigen/generator.go
+++ b/internal/tuigen/generator.go
@@ -356,10 +356,13 @@ func (g *Generator) loopIndexExpr(baseIndex int) string {
 	if len(g.loopIndexStack) == 0 {
 		return ""
 	}
-	// For a single loop level: baseIndex*1000000 + loopIdx
+	// For a single loop level: (baseIndex+1)*1000000 + loopIdx
 	// For nested loops: combine all indices with large multipliers
-	// This ensures unique keys for each (component call site, loop iteration) combination
-	expr := fmt.Sprintf("%d", baseIndex)
+	// This ensures unique keys for each (component call site, loop iteration) combination.
+	// The +1 keeps the multiplier from cancelling when baseIndex is 0; otherwise the
+	// loop's keys collapse to the bare loop index (0, 1, 2, ...) and collide with the
+	// small sequential keys of components mounted outside the loop (issue #88).
+	expr := fmt.Sprintf("%d", baseIndex+1)
 	multiplier := 1000000
 	for _, idxVar := range g.loopIndexStack {
 		expr = fmt.Sprintf("%s*%d+%s", expr, multiplier, idxVar)

--- a/internal/tuigen/generator.go
+++ b/internal/tuigen/generator.go
@@ -357,15 +357,19 @@ func (g *Generator) loopIndexExpr(baseIndex int) string {
 		return ""
 	}
 	// For a single loop level: (baseIndex+1)*1000000 + loopIdx
-	// For nested loops: combine all indices with large multipliers
-	// This ensures unique keys for each (component call site, loop iteration) combination.
-	// The +1 keeps the multiplier from cancelling when baseIndex is 0; otherwise the
-	// loop's keys collapse to the bare loop index (0, 1, 2, ...) and collide with the
-	// small sequential keys of components mounted outside the loop (issue #88).
+	// For nested loops, each level re-multiplies the accumulated expression, e.g.
+	// ((baseIndex+1)*1000000 + i)*1000000 + j, so every (call site, iteration
+	// combination) gets a unique key as long as loops stay under 1000000
+	// iterations. The +1 keeps the multiplier from cancelling when baseIndex is 0;
+	// otherwise the loop's keys collapse to the bare loop index (0, 1, 2, ...) and
+	// collide with the small sequential keys of components mounted outside the
+	// loop (issue #88). The parentheses make the multipliers compound; without
+	// them Go precedence flattens the expression and nested-loop keys collide
+	// with sibling loops' keys.
 	expr := fmt.Sprintf("%d", baseIndex+1)
 	multiplier := 1000000
 	for _, idxVar := range g.loopIndexStack {
-		expr = fmt.Sprintf("%s*%d+%s", expr, multiplier, idxVar)
+		expr = fmt.Sprintf("(%s)*%d+%s", expr, multiplier, idxVar)
 	}
 	return expr
 }

--- a/internal/tuigen/generator_children_coverage_test.go
+++ b/internal/tuigen/generator_children_coverage_test.go
@@ -377,7 +377,7 @@ templ (c *shell) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.Mount(c, 0*1000000+i, func() tui.Component {",
+				"app.Mount(c, 1*1000000+i, func() tui.Component {",
 				"return Sidebar(item)",
 			},
 		},

--- a/internal/tuigen/generator_children_coverage_test.go
+++ b/internal/tuigen/generator_children_coverage_test.go
@@ -377,7 +377,7 @@ templ (c *shell) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.Mount(c, 1*1000000+i, func() tui.Component {",
+				"app.Mount(c, (1)*1000000+i, func() tui.Component {",
 				"return Sidebar(item)",
 			},
 		},

--- a/internal/tuigen/generator_element_coverage_test.go
+++ b/internal/tuigen/generator_element_coverage_test.go
@@ -348,7 +348,7 @@ templ (c *form) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, 0*1000000+i, func() tui.Component {",
+				"app.MountPersistent(c, 1*1000000+i, func() tui.Component {",
 				"c.areas.Append(__tui_",
 				"tui.WithTextAreaPlaceholder(f)",
 			},

--- a/internal/tuigen/generator_element_coverage_test.go
+++ b/internal/tuigen/generator_element_coverage_test.go
@@ -348,7 +348,7 @@ templ (c *form) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, 1*1000000+i, func() tui.Component {",
+				"app.MountPersistent(c, (1)*1000000+i, func() tui.Component {",
 				"c.areas.Append(__tui_",
 				"tui.WithTextAreaPlaceholder(f)",
 			},

--- a/internal/tuigen/generator_mountkey_test.go
+++ b/internal/tuigen/generator_mountkey_test.go
@@ -1,0 +1,195 @@
+package tuigen
+
+import (
+	"fmt"
+	"go/constant"
+	"go/token"
+	"go/types"
+	"regexp"
+	"testing"
+)
+
+// mountIndexRe extracts the index expression from generated app.Mount /
+// app.MountPersistent calls.
+var mountIndexRe = regexp.MustCompile(`app\.Mount(?:Persistent)?\(c, (.+), func\(\) tui\.Component \{`)
+
+// evalMountKey evaluates a generated mount index expression after substituting
+// concrete iteration values for loop index variables.
+func evalMountKey(t *testing.T, expr string, vars map[string]int) int64 {
+	t.Helper()
+	for name, val := range vars {
+		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
+		expr = re.ReplaceAllString(expr, fmt.Sprintf("%d", val))
+	}
+	tv, err := types.Eval(token.NewFileSet(), nil, token.NoPos, expr)
+	if err != nil {
+		t.Fatalf("evaluating mount key %q: %v", expr, err)
+	}
+	v, ok := constant.Int64Val(tv.Value)
+	if !ok {
+		t.Fatalf("mount key %q did not evaluate to an integer constant", expr)
+	}
+	return v
+}
+
+// TestGenerator_MountKeysDoNotCollide reproduces issue #88: a component
+// mounted inside a for loop must never share a runtime mount key with a
+// component mounted at a different call site. With the colliding keys, the
+// mount cache returns the wrong component type at runtime (e.g. a Markdown
+// where a TextArea was requested).
+func TestGenerator_MountKeysDoNotCollide(t *testing.T) {
+	type tc struct {
+		input    string
+		loopVars []string // loop index variables expected in generated keys
+		iters    int      // iterations to simulate per loop variable
+		wantKeys int      // expected number of mount call sites
+	}
+
+	tests := map[string]tc{
+		"loop component followed by standalone component": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for i, item := range c.items {
+			<markdown source={item} />
+		}
+		<textarea onSubmit={c.submit} />
+	</div>
+}`,
+			loopVars: []string{"i"},
+			iters:    3,
+			wantKeys: 2,
+		},
+		"loop with discarded index uses synthetic variable": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for _, item := range c.items {
+			<markdown source={item} />
+		}
+		<textarea onSubmit={c.submit} />
+	</div>
+}`,
+			loopVars: []string{"__idx_0"},
+			iters:    3,
+			wantKeys: 2,
+		},
+		"loop struct component call followed by standalone component": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for i, item := range c.items {
+			@Widget(item)
+		}
+		<textarea onSubmit={c.submit} />
+	</div>
+}`,
+			loopVars: []string{"i"},
+			iters:    3,
+			wantKeys: 2,
+		},
+		"nested loop component followed by standalone component": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for i, row := range c.rows {
+			for j, item := range row {
+				<markdown source={item} />
+			}
+		}
+		<textarea onSubmit={c.submit} />
+	</div>
+}`,
+			loopVars: []string{"i", "j"},
+			iters:    3,
+			wantKeys: 2,
+		},
+		"two sibling loops with components": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for i, item := range c.items {
+			<markdown source={item} />
+		}
+		for j, other := range c.others {
+			<markdown source={other} />
+		}
+	</div>
+}`,
+			loopVars: []string{"i", "j"},
+			iters:    3,
+			wantKeys: 2,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			output, err := parseAndGenerateSkipImports("test.gsx", tt.input)
+			if err != nil {
+				t.Fatalf("generation failed: %v", err)
+			}
+			code := string(output)
+
+			matches := mountIndexRe.FindAllStringSubmatch(code, -1)
+			if len(matches) != tt.wantKeys {
+				t.Fatalf("expected %d mount calls, found %d\nGot:\n%s", tt.wantKeys, len(matches), code)
+			}
+
+			// For each call site, expand the key expression over simulated
+			// loop iterations and record every runtime key it can produce.
+			seen := map[int64]int{} // runtime key -> call site index
+			for site, m := range matches {
+				expr := m[1]
+
+				// Find which loop variables this expression references.
+				var refs []string
+				for _, v := range tt.loopVars {
+					if regexp.MustCompile(`\b` + regexp.QuoteMeta(v) + `\b`).MatchString(expr) {
+						refs = append(refs, v)
+					}
+				}
+
+				// Enumerate all combinations of iteration values for the
+				// referenced loop variables.
+				combos := [][]int{{}}
+				for range refs {
+					var next [][]int
+					for _, c := range combos {
+						for it := 0; it < tt.iters; it++ {
+							next = append(next, append(append([]int{}, c...), it))
+						}
+					}
+					combos = next
+				}
+
+				for _, combo := range combos {
+					vars := map[string]int{}
+					for vi, v := range refs {
+						vars[v] = combo[vi]
+					}
+					key := evalMountKey(t, expr, vars)
+					if prev, ok := seen[key]; ok && prev != site {
+						t.Errorf("mount key collision: call site %d expr %q produces key %d already produced by call site %d (vars %v)",
+							site, expr, key, prev, vars)
+					}
+					seen[key] = site
+				}
+			}
+		})
+	}
+}

--- a/internal/tuigen/generator_mountkey_test.go
+++ b/internal/tuigen/generator_mountkey_test.go
@@ -11,10 +11,12 @@ import (
 
 // mountIndexRe extracts the index expression from generated app.Mount /
 // app.MountPersistent calls.
-var mountIndexRe = regexp.MustCompile(`app\.Mount(?:Persistent)?\(c, (.+), func\(\) tui\.Component \{`)
+var mountIndexRe = regexp.MustCompile(`app\.Mount(?:Persistent)?\(\w+, (.+), func\(\) tui\.Component \{`)
 
 // evalMountKey evaluates a generated mount index expression after substituting
-// concrete iteration values for loop index variables.
+// concrete iteration values for loop index variables. Keys must fit in int64,
+// which mirrors the generated code's int arithmetic and caps practical loop
+// nesting at three levels (a fourth level's keys reach ~1e24 and overflow).
 func evalMountKey(t *testing.T, expr string, vars map[string]int) int64 {
 	t.Helper()
 	for name, val := range vars {
@@ -27,7 +29,7 @@ func evalMountKey(t *testing.T, expr string, vars map[string]int) int64 {
 	}
 	v, ok := constant.Int64Val(tv.Value)
 	if !ok {
-		t.Fatalf("mount key %q did not evaluate to an integer constant", expr)
+		t.Fatalf("mount key %q did not evaluate to an int64 (likely overflow from too-deep loop nesting)", expr)
 	}
 	return v
 }

--- a/internal/tuigen/generator_mountkey_test.go
+++ b/internal/tuigen/generator_mountkey_test.go
@@ -116,6 +116,48 @@ templ (c *app) Render() {
 			iters:    3,
 			wantKeys: 2,
 		},
+		"nested loop followed by sibling loop": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for i, row := range c.rows {
+			for j, item := range row {
+				<markdown source={item} />
+			}
+		}
+		for k, other := range c.others {
+			<markdown source={other} />
+		}
+	</div>
+}`,
+			loopVars: []string{"i", "j", "k"},
+			iters:    3,
+			wantKeys: 2,
+		},
+		"three-level nested loop followed by standalone component": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for i, plane := range c.planes {
+			for j, row := range plane {
+				for k, item := range row {
+					<markdown source={item} />
+				}
+			}
+		}
+		<textarea onSubmit={c.submit} />
+	</div>
+}`,
+			loopVars: []string{"i", "j", "k"},
+			iters:    3,
+			wantKeys: 2,
+		},
 		"two sibling loops with components": {
 			input: `package x
 
@@ -152,7 +194,9 @@ templ (c *app) Render() {
 
 			// For each call site, expand the key expression over simulated
 			// loop iterations and record every runtime key it can produce.
-			seen := map[int64]int{} // runtime key -> call site index
+			// Any two distinct (call site, iteration combo) pairs sharing a
+			// key is a collision, including two iterations of the same site.
+			seen := map[int64]string{} // runtime key -> "site/combo" identity
 			for site, m := range matches {
 				expr := m[1]
 
@@ -170,7 +214,7 @@ templ (c *app) Render() {
 				for range refs {
 					var next [][]int
 					for _, c := range combos {
-						for it := 0; it < tt.iters; it++ {
+						for it := range tt.iters {
 							next = append(next, append(append([]int{}, c...), it))
 						}
 					}
@@ -182,12 +226,13 @@ templ (c *app) Render() {
 					for vi, v := range refs {
 						vars[v] = combo[vi]
 					}
+					id := fmt.Sprintf("call site %d (vars %v)", site, vars)
 					key := evalMountKey(t, expr, vars)
-					if prev, ok := seen[key]; ok && prev != site {
-						t.Errorf("mount key collision: call site %d expr %q produces key %d already produced by call site %d (vars %v)",
-							site, expr, key, prev, vars)
+					if prev, ok := seen[key]; ok {
+						t.Errorf("mount key collision: %s expr %q produces key %d already produced by %s",
+							id, expr, key, prev)
 					}
-					seen[key] = site
+					seen[key] = id
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

Components mounted inside `for` loops could share a mount cache key with other call sites and silently render as the wrong component type. Reported by @chuanyi in #88 with the exact root cause: `loopIndexExpr` builds keys as `baseIndex*1000000 + loopIndex`, and when the loop holds the first component in a templ, `baseIndex` is 0, the multiplier cancels, and the loop's runtime keys become 0, 1, 2, and so on. The same `mountIndex` counter hands those small keys to components declared after the loop, and since the mount cache is keyed only by `(parent, index)`, the later mount gets a cache hit on the loop's component. A textarea after the loop renders as the second iteration's markdown block, losing its cursor, focus, and key handling, with nothing logging an error.

The fix is the one suggested in the issue: `(baseIndex+1)*1000000 + loopIndex`, so loop keys are always at least 1,000,000 and can never reach the small sequential keys of standalone mounts.

Review turned up a second instance of the same bug class. The accumulated expression was never parenthesized, so a two-level nested loop generated `1*1000000+i*1000000+j`, which Go precedence flattens to `(1+i)*1000000+j` instead of compounding the multipliers. A nested loop followed by a sibling loop collided at small indices, and three-level nesting collided with itself. Wrapping the accumulated expression in parentheses fixes both.

The new `generator_mountkey_test.go` generates code from .gsx sources, extracts the emitted mount key expressions, evaluates them over simulated loop iterations with `go/types.Eval`, and asserts that no two distinct (call site, iteration) pairs produce the same runtime key. Cases cover single loops, synthetic indices (`for _, item`), struct component calls, nested loops, sibling loops, and nested-then-sibling. All failed before the fix except the flat sibling-loops case, which pins behavior that already worked.

Known limits left in place: loops over maps with non-int keys still generate non-compiling key arithmetic (pre-existing, separate issue), and the scheme assumes loops stay under a million iterations. A runtime type check in the mount cache, which would turn any future key collision into a loud error instead of a silent component swap, is also follow-up material.

Fixes #88
