### PR TITLE
feat: identity-based mount keys with React-like key attribute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,7 @@ func helper(s string) string {
 | `class` | `string` | Tailwind-style classes |
 | `disabled` | `bool` | Disable interaction |
 | `ref` | expression | Bind element to a `tui.Ref`/`RefList`/`RefMap` variable |
+| `key` | expression | Stable identity within a loop: mount cache key for component elements, RefMap key with `ref` |
 | `deps` | expression | Explicit state dependencies for reactive bindings |
 
 ### Layout Attributes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,7 +439,7 @@ func helper(s string) string {
 | `class` | `string` | Tailwind-style classes |
 | `disabled` | `bool` | Disable interaction |
 | `ref` | expression | Bind element to a `tui.Ref`/`RefList`/`RefMap` variable |
-| `key` | expression | Stable identity within a loop: mount cache key for component elements, RefMap key with `ref` |
+| `key` | expression | Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): mount cache key for component elements, RefMap key with `ref` |
 | `deps` | expression | Explicit state dependencies for reactive bindings |
 
 ### Layout Attributes

--- a/docs/content/guides/07-components.md
+++ b/docs/content/guides/07-components.md
@@ -467,7 +467,7 @@ app.Mount(a, 0, func() tui.Component {
 })
 ```
 
-The mount system caches the `sidebar` instance by its parent and position index. On the first render, it creates the sidebar, binds its state to the app, and calls `Init()` if implemented. On subsequent renders, it reuses the cached instance and calls `UpdateProps` if the child implements it.
+The mount system caches the `sidebar` instance by its parent and a cache key (its position in the file, combined with the loop's index or map key when mounted inside a loop). On the first render, it creates the sidebar, binds its state to the app, and calls `Init()` if implemented. On subsequent renders, it reuses the cached instance and calls `UpdateProps` if the child implements it.
 
 The sidebar's `selected` state persists even when the parent re-renders, because the framework reuses the cached instance instead of creating a new one.
 

--- a/docs/content/guides/14-multi-component.md
+++ b/docs/content/guides/14-multi-component.md
@@ -288,7 +288,16 @@ app.Mount(a, 0, func() tui.Component {
 })
 ```
 
-`Mount` takes the parent component, a position index, and a factory function. It uses the `(parent, index)` pair as a cache key:
+`Mount` takes the parent component, a cache key, and a factory function. It uses the `(parent, key)` pair to identify the instance. For a component declared once the key is just its position in the file; inside a `for` loop the generated code builds a composite key with `tui.MountKey` from the loop's index or map key, so each item gets its own instance:
+
+```go
+// Generated from: for i, item := range a.items { @Row(item) }
+app.Mount(a, tui.MountKey(0, i), func() tui.Component {
+    return Row(item)
+})
+```
+
+Either way, the cache behaves the same:
 
 - **First render**: The factory runs, creating a new component instance. The framework calls `BindApp()` to wire up state fields, then calls `Init()` if the component implements `Initializer`. The instance is cached.
 - **Subsequent renders**: The cached instance is reused. If the component implements `PropsUpdater`, a fresh instance is created from the factory and passed to `UpdateProps()` so the cached instance can pick up changed props without losing its internal state.

--- a/docs/content/reference/app.md
+++ b/docs/content/reference/app.md
@@ -755,7 +755,7 @@ Stale cache entries are swept after each render pass. When a component disappear
 func (a *App) MountPersistent(parent Component, key any, factory func() Component) *Element
 ```
 
-Like `Mount`, but the instance survives the sweep even when it is not rendered. Generated code uses this for component elements (`<textarea>`, `<input>`, `<modal>`, `<markdown>`) declared outside loops, so a textarea hidden by an `if` keeps its draft text when it reappears. Component elements inside loops use plain `Mount` instead: loop keys come from data, and persisting every key ever seen would leak instances as the data changes.
+Like `Mount`, but the instance survives the sweep even when it is not rendered. Generated code uses this for component elements (`<textarea>`, `<input>`, `<modal>`, `<markdown>`) declared outside loops without a `key` attribute, so a textarea hidden by an `if` keeps its draft text when it reappears. Component elements inside loops, or with a `key={...}` attribute, use plain `Mount` instead: their identity comes from data, and persisting every key ever seen would leak instances as the data changes.
 
 ### MountKey
 

--- a/docs/content/reference/app.md
+++ b/docs/content/reference/app.md
@@ -736,14 +736,34 @@ app.Batch(func() {
 ### Mount
 
 ```go
-func (a *App) Mount(parent Component, index int, factory func() Component) *Element
+func (a *App) Mount(parent Component, key any, factory func() Component) *Element
 ```
 
 Creates or retrieves a cached component instance and returns its rendered element tree. Generated code calls this; you typically don't call it directly.
 
-On first call for a given `(parent, index)` pair: executes `factory`, caches the instance, calls `BindApp` and `Init()` (if implemented). On subsequent calls: returns the cached instance's `Render()` result. If the instance implements `PropsUpdater`, `UpdateProps` is called with a fresh instance so the cached component can pick up new props.
+On first call for a given `(parent, key)` pair: executes `factory`, caches the instance, calls `BindApp` and `Init()` (if implemented). On subsequent calls: returns the cached instance's `Render()` result. If the instance implements `PropsUpdater`, `UpdateProps` is called with a fresh instance so the cached component can pick up new props.
+
+The key must be a comparable value. Generated code passes a plain int for a component declared once, and a `MountKey` composite for components inside loops, so each loop item gets its own cached instance.
+
+If a cached instance's concrete type differs from what the factory produces (a key collision between two call sites), the stale instance is evicted, its cleanup runs, and the fresh component mounts in its place. The collision is logged through the debug log rather than rendering the wrong component silently.
 
 Stale cache entries are swept after each render pass. When a component disappears from the tree, its cleanup function runs.
+
+### MountPersistent
+
+```go
+func (a *App) MountPersistent(parent Component, key any, factory func() Component) *Element
+```
+
+Like `Mount`, but the instance survives the sweep even when it is not rendered. Generated code uses this for component elements (`<textarea>`, `<input>`, `<modal>`, `<markdown>`) declared outside loops, so a textarea hidden by an `if` keeps its draft text when it reappears. Component elements inside loops use plain `Mount` instead: loop keys come from data, and persisting every key ever seen would leak instances as the data changes.
+
+### MountKey
+
+```go
+func MountKey(site int, parts ...any) any
+```
+
+Builds the comparable cache key generated code passes to `Mount` for loop call sites. The first argument identifies the call site within the component; each part is one enclosing loop's key value (a slice index, a map key, or the expression from a `key={...}` attribute). Every part must itself be comparable; a non-comparable value panics when the key enters the cache. Keys built from different call sites or different loop values never compare equal, so distinct items cannot collide.
 
 ## Other
 

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -288,13 +288,23 @@ See the [Refs Reference](refs.md) for `Ref`, `RefList`, and `RefMap` details.
 
 ### Key attributes
 
-Inside `for` loops, the `key` attribute tells the framework how to identify elements for `RefMap`:
+Inside `for` loops, the `key` attribute gives an element a stable identity among its siblings, like keys in React. It does two things. With a `ref` bound to a `RefMap`, it provides the map key:
 
 ```gsx
 for _, name := range items {
     <div ref={s.itemRefs} key={name}>{name}</div>
 }
 ```
+
+On component elements (`<textarea>`, `<input>`, `<modal>`, `<markdown>`), it also identifies the cached component instance, so a component's internal state follows its item when the list reorders or items are inserted:
+
+```gsx
+for _, msg := range s.messages {
+    <textarea key={msg.ID} placeholder={msg.Author} />
+}
+```
+
+Without `key`, components in a loop are identified by the loop's index or map key, which is fine for stable lists but ties state to position when a slice reorders. The key must be unique among siblings of the innermost loop; in nested loops, outer loops contribute their own identity automatically. The value must be a Go expression: `key="literal"` is a compile error.
 
 ## Attribute reference
 
@@ -307,7 +317,7 @@ for _, name := range items {
 | `disabled` | bool | -- | Disables the element |
 | `ref` | expression | `ref.Set(el)` | Binds element to a ref |
 | `deps` | expression | -- | Explicit state dependencies |
-| `key` | expression | -- | Key for RefMap in loops |
+| `key` | expression | -- | Loop item identity: component cache key, RefMap key with `ref` |
 
 ### Layout attributes
 

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -306,6 +306,8 @@ for _, msg := range s.messages {
 
 Without `key`, components in a loop are identified by the loop's index or map key, which is fine for stable lists but ties state to position when a slice reorders. The key must be unique among siblings of the innermost loop; in nested loops, outer loops contribute their own identity automatically. The value must be a Go expression: `key="literal"` is a compile error.
 
+A `key` on a component element outside any loop changes identity per value: when the expression changes, the old instance is swept and a fresh one mounts. Use this to reset a component's internal state when the thing it represents changes, such as `<textarea key={c.activeDraftID} />` clearing between drafts.
+
 ## Attribute reference
 
 ### Generic attributes (all elements)

--- a/docs/content/reference/refs.md
+++ b/docs/content/reference/refs.md
@@ -256,6 +256,8 @@ templ (s *tabApp) Render() {
 
 The generated code calls `s.tabRefs.Put(name, el)` each iteration. Without `key`, the same loop would generate `Append` calls and treat the ref as a `RefList` instead.
 
+On component elements (`<textarea>`, `<input>`, `<modal>`, `<markdown>`), the same `key` also identifies the cached component instance, so the component's state follows its item across reorders. See the [GSX Syntax Reference](gsx-syntax.md) for details.
+
 You can then look up specific elements in handlers:
 
 ```go

--- a/events_test.go
+++ b/events_test.go
@@ -239,7 +239,7 @@ func TestResetRootSession_CallsUnbindOnCachedMounts(t *testing.T) {
 
 	unbound := 0
 	tracker := &componentTracker{onUnbind: func() { unbound++ }}
-	key := mountKey{parent: nil, index: 0}
+	key := mountKey{parent: nil, key: 0}
 	app.mounts.cache[key] = tracker
 
 	app.resetRootSession()

--- a/focus_integration_test.go
+++ b/focus_integration_test.go
@@ -83,7 +83,7 @@ func (c *testAppComponent) KeyMap() KeyMap {
 
 // getInputFromApp extracts the cached testInputComponent from the mount cache.
 func getInputFromApp(app *App, parent Component) *testInputComponent {
-	key := mountKey{parent: parent, index: 0}
+	key := mountKey{parent: parent, key: 0}
 	if comp, ok := app.mounts.cache[key]; ok {
 		return comp.(*testInputComponent)
 	}

--- a/internal/lsp/schema/schema.go
+++ b/internal/lsp/schema/schema.go
@@ -242,6 +242,7 @@ func genericAttrs() []AttributeDef {
 		{Name: "disabled", Type: "bool", Description: "Whether the element is disabled", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable (tui.NewRef/NewRefList/NewRefMap)", Category: "ref"},
+		{Name: "key", Type: "expression", Description: "Stable identity for this element within a loop: used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
 	}
 }
 
@@ -383,6 +384,7 @@ func inputAttrs() []AttributeDef {
 		{Name: "onChange", Type: "func", Description: "Callback when text changes: func(string)", Category: "event"},
 		{Name: "autoFocus", Type: "bool", Description: "Automatically focus this input on startup", Category: "event"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
+		{Name: "key", Type: "expression", Description: "Stable identity for this element within a loop: used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }
@@ -407,6 +409,7 @@ func textareaAttrs() []AttributeDef {
 		{Name: "onSubmit", Type: "func", Description: "Callback when submit key is pressed: func(string)", Category: "event"},
 		{Name: "autoFocus", Type: "bool", Description: "Automatically focus this text area on startup", Category: "event"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
+		{Name: "key", Type: "expression", Description: "Stable identity for this element within a loop: used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }
@@ -423,6 +426,7 @@ func modalAttrs() []AttributeDef {
 		{Name: "trapFocus", Type: "bool", Description: "Tab/Shift+Tab restricted to modal children; when true, also blocks unhandled keys from reaching parent components (default true)", Category: "event"},
 		{Name: "keyMap", Type: "expression", Description: "Custom KeyMap bindings for the modal; fire before the catch-all when trapFocus is true", Category: "event"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
+		{Name: "key", Type: "expression", Description: "Stable identity for this element within a loop: used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }
@@ -437,6 +441,7 @@ func markdownAttrs() []AttributeDef {
 		{Name: "width", Type: "int", Description: "Fixed render width in characters (0 = fill available width)", Category: "layout"},
 		{Name: "theme", Type: "expression", Description: "tui.MarkdownTheme overriding the default styling", Category: "visual"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
+		{Name: "key", Type: "expression", Description: "Stable identity for this element within a loop: used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }

--- a/internal/lsp/schema/schema.go
+++ b/internal/lsp/schema/schema.go
@@ -242,7 +242,7 @@ func genericAttrs() []AttributeDef {
 		{Name: "disabled", Type: "bool", Description: "Whether the element is disabled", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable (tui.NewRef/NewRefList/NewRefMap)", Category: "ref"},
-		{Name: "key", Type: "expression", Description: "Stable identity for this element within a loop: used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
+		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
 	}
 }
 
@@ -384,7 +384,7 @@ func inputAttrs() []AttributeDef {
 		{Name: "onChange", Type: "func", Description: "Callback when text changes: func(string)", Category: "event"},
 		{Name: "autoFocus", Type: "bool", Description: "Automatically focus this input on startup", Category: "event"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
-		{Name: "key", Type: "expression", Description: "Stable identity for this element within a loop: used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
+		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }
@@ -409,7 +409,7 @@ func textareaAttrs() []AttributeDef {
 		{Name: "onSubmit", Type: "func", Description: "Callback when submit key is pressed: func(string)", Category: "event"},
 		{Name: "autoFocus", Type: "bool", Description: "Automatically focus this text area on startup", Category: "event"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
-		{Name: "key", Type: "expression", Description: "Stable identity for this element within a loop: used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
+		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }
@@ -426,7 +426,7 @@ func modalAttrs() []AttributeDef {
 		{Name: "trapFocus", Type: "bool", Description: "Tab/Shift+Tab restricted to modal children; when true, also blocks unhandled keys from reaching parent components (default true)", Category: "event"},
 		{Name: "keyMap", Type: "expression", Description: "Custom KeyMap bindings for the modal; fire before the catch-all when trapFocus is true", Category: "event"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
-		{Name: "key", Type: "expression", Description: "Stable identity for this element within a loop: used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
+		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }
@@ -441,7 +441,7 @@ func markdownAttrs() []AttributeDef {
 		{Name: "width", Type: "int", Description: "Fixed render width in characters (0 = fill available width)", Category: "layout"},
 		{Name: "theme", Type: "expression", Description: "tui.MarkdownTheme overriding the default styling", Category: "visual"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
-		{Name: "key", Type: "expression", Description: "Stable identity for this element within a loop: used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
+		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -175,7 +175,7 @@ var knownAttributes = map[string]bool{
 
 	// Element refs
 	"ref": true, // ref={varName} for element references
-	"key": true, // key={expr} for map-based refs in loops
+	"key": true, // key={expr}: loop item identity (mount cache key; RefMap key with ref)
 
 	// Modal
 	"open":                 true,
@@ -384,6 +384,17 @@ func (a *Analyzer) analyzeAttribute(attr *Attribute, tagName string) {
 			err.Hint = "did you mean " + similar + "?"
 		}
 
+		a.errors.Add(err)
+		return
+	}
+
+	// key and ref take Go expressions. The parser lifts expression-valued
+	// key/ref into RefKey/RefExpr and removes them from Attributes, so any
+	// that survive to this point hold a literal and would be silently
+	// ignored by the generator.
+	if attr.Name == "key" || attr.Name == "ref" {
+		err := NewError(attr.Position, attr.Name+" must be an expression")
+		err.Hint = "use " + attr.Name + "={...} with a Go expression, not a literal"
 		a.errors.Add(err)
 		return
 	}

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -388,10 +388,8 @@ func (a *Analyzer) analyzeAttribute(attr *Attribute, tagName string) {
 		return
 	}
 
-	// key and ref take Go expressions. The parser lifts expression-valued
-	// key/ref into RefKey/RefExpr and removes them from Attributes, so any
-	// that survive to this point hold a literal and would be silently
-	// ignored by the generator.
+	// The parser lifts expression-valued key/ref out of Attributes, so any
+	// surviving here hold a literal the generator would silently ignore.
 	if attr.Name == "key" || attr.Name == "ref" {
 		err := NewError(attr.Position, attr.Name+" must be an expression")
 		err.Hint = "use " + attr.Name + "={...} with a Go expression, not a literal"

--- a/internal/tuigen/analyzer_test.go
+++ b/internal/tuigen/analyzer_test.go
@@ -416,3 +416,61 @@ templ (p *panel) Render() {
 		})
 	}
 }
+
+func TestAnalyzer_KeyAndRefRequireExpressions(t *testing.T) {
+	type tc struct {
+		input         string
+		wantError     bool
+		errorContains string
+	}
+
+	tests := map[string]tc{
+		"key expression is valid": {
+			input: `package x
+templ Test() {
+	<div>
+		for _, item := range items {
+			<markdown key={item.ID} source={item.Text} />
+		}
+	</div>
+}`,
+			wantError: false,
+		},
+		"key string literal is rejected": {
+			input: `package x
+templ Test() {
+	<markdown key="myid" source={src} />
+}`,
+			wantError:     true,
+			errorContains: "key must be an expression",
+		},
+		"ref string literal is rejected": {
+			input: `package x
+templ Test() {
+	<textarea ref="myref" />
+}`,
+			wantError:     true,
+			errorContains: "ref must be an expression",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := AnalyzeFile("test.gsx", tt.input)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error, got nil")
+					return
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errorContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/tuigen/generator.go
+++ b/internal/tuigen/generator.go
@@ -350,13 +350,10 @@ func (g *Generator) popLoopIndex() {
 	}
 }
 
-// mountKeyExpr returns the Go expression for a component's mount cache key.
-// Standalone call sites use the static site index. Call sites inside loops
-// combine the site with each enclosing loop's key value via tui.MountKey,
-// so every iteration (slice index, map key, ...) gets its own cache slot.
-// A userKey expression (from a key={...} attribute) replaces the innermost
-// loop's value only: like React keys, it identifies the item among its
-// siblings, while outer loops keep contributing their own key values.
+// mountKeyExpr returns the Go expression for a component's mount cache key:
+// the static site index alone, or tui.MountKey(site, loopVars...) inside
+// loops. A userKey (from key={...}) replaces the innermost loop's value,
+// matching React's sibling-scoped key semantics.
 func (g *Generator) mountKeyExpr(baseIndex int, userKey string) string {
 	parts := slices.Clone(g.loopIndexStack)
 	if userKey != "" {

--- a/internal/tuigen/generator.go
+++ b/internal/tuigen/generator.go
@@ -349,29 +349,20 @@ func (g *Generator) popLoopIndex() {
 	}
 }
 
-// loopIndexExpr returns a Go expression for computing a unique mount index
-// based on the current loop context. Returns empty string if not in a loop.
-// The expression combines a static base index with runtime loop indices.
-func (g *Generator) loopIndexExpr(baseIndex int) string {
+// mountKeyExpr returns the Go expression for a component's mount cache key.
+// Standalone call sites use the static site index. Call sites inside loops
+// combine the site with each enclosing loop's key value via tui.MountKey,
+// so every iteration (slice index, map key, ...) gets its own cache slot.
+// A userKey expression (from a key={...} attribute) replaces the loop
+// values: the user asserts the item's identity directly.
+func (g *Generator) mountKeyExpr(baseIndex int, userKey string) string {
+	if userKey != "" {
+		return fmt.Sprintf("tui.MountKey(%d, %s)", baseIndex, userKey)
+	}
 	if len(g.loopIndexStack) == 0 {
-		return ""
+		return fmt.Sprintf("%d", baseIndex)
 	}
-	// For a single loop level: (baseIndex+1)*1000000 + loopIdx
-	// For nested loops, each level re-multiplies the accumulated expression, e.g.
-	// ((baseIndex+1)*1000000 + i)*1000000 + j, so every (call site, iteration
-	// combination) gets a unique key as long as loops stay under 1000000
-	// iterations. The +1 keeps the multiplier from cancelling when baseIndex is 0;
-	// otherwise the loop's keys collapse to the bare loop index (0, 1, 2, ...) and
-	// collide with the small sequential keys of components mounted outside the
-	// loop (issue #88). The parentheses make the multipliers compound; without
-	// them Go precedence flattens the expression and nested-loop keys collide
-	// with sibling loops' keys.
-	expr := fmt.Sprintf("%d", baseIndex+1)
-	multiplier := 1000000
-	for _, idxVar := range g.loopIndexStack {
-		expr = fmt.Sprintf("(%s)*%d+%s", expr, multiplier, idxVar)
-	}
-	return expr
+	return fmt.Sprintf("tui.MountKey(%d, %s)", baseIndex, strings.Join(g.loopIndexStack, ", "))
 }
 
 // stateNameSet returns a set of state variable names for quick lookup.

--- a/internal/tuigen/generator.go
+++ b/internal/tuigen/generator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
+	"slices"
 	"strings"
 
 	"golang.org/x/tools/imports"
@@ -353,16 +354,22 @@ func (g *Generator) popLoopIndex() {
 // Standalone call sites use the static site index. Call sites inside loops
 // combine the site with each enclosing loop's key value via tui.MountKey,
 // so every iteration (slice index, map key, ...) gets its own cache slot.
-// A userKey expression (from a key={...} attribute) replaces the loop
-// values: the user asserts the item's identity directly.
+// A userKey expression (from a key={...} attribute) replaces the innermost
+// loop's value only: like React keys, it identifies the item among its
+// siblings, while outer loops keep contributing their own key values.
 func (g *Generator) mountKeyExpr(baseIndex int, userKey string) string {
+	parts := slices.Clone(g.loopIndexStack)
 	if userKey != "" {
-		return fmt.Sprintf("tui.MountKey(%d, %s)", baseIndex, userKey)
+		if len(parts) == 0 {
+			parts = []string{userKey}
+		} else {
+			parts[len(parts)-1] = userKey
+		}
 	}
-	if len(g.loopIndexStack) == 0 {
+	if len(parts) == 0 {
 		return fmt.Sprintf("%d", baseIndex)
 	}
-	return fmt.Sprintf("tui.MountKey(%d, %s)", baseIndex, strings.Join(g.loopIndexStack, ", "))
+	return fmt.Sprintf("tui.MountKey(%d, %s)", baseIndex, strings.Join(parts, ", "))
 }
 
 // stateNameSet returns a set of state variable names for quick lookup.

--- a/internal/tuigen/generator_children.go
+++ b/internal/tuigen/generator_children.go
@@ -187,14 +187,9 @@ func (g *Generator) generateStructMount(call *ComponentCall, parentVar string) s
 	baseIndex := g.mountIndex
 	g.mountIndex++
 
-	// Determine the mount index expression.
-	// If we're inside a loop, combine the static base index with runtime loop indices
-	// to ensure each iteration gets a unique mount key.
-	indexExpr := g.loopIndexExpr(baseIndex)
-	if indexExpr == "" {
-		// Not in a loop - use static index
-		indexExpr = fmt.Sprintf("%d", baseIndex)
-	}
+	// Component calls have no key attribute; identity comes from the call
+	// site plus the enclosing loops' key values.
+	indexExpr := g.mountKeyExpr(baseIndex, "")
 
 	// Build children slice if the component call has children
 	childrenVar := ""

--- a/internal/tuigen/generator_children.go
+++ b/internal/tuigen/generator_children.go
@@ -187,8 +187,7 @@ func (g *Generator) generateStructMount(call *ComponentCall, parentVar string) s
 	baseIndex := g.mountIndex
 	g.mountIndex++
 
-	// Component calls have no key attribute; identity comes from the call
-	// site plus the enclosing loops' key values.
+	// Component calls have no key attribute.
 	indexExpr := g.mountKeyExpr(baseIndex, "")
 
 	// Build children slice if the component call has children

--- a/internal/tuigen/generator_children_coverage_test.go
+++ b/internal/tuigen/generator_children_coverage_test.go
@@ -377,7 +377,7 @@ templ (c *shell) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.Mount(c, (1)*1000000+i, func() tui.Component {",
+				"app.Mount(c, tui.MountKey(0, i), func() tui.Component {",
 				"return Sidebar(item)",
 			},
 		},

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -433,10 +433,11 @@ func (g *Generator) generateComponentElementWithRefs(elem *Element, parentVar st
 	baseIndex := g.mountIndex
 	g.mountIndex++
 
-	indexExpr := g.loopIndexExpr(baseIndex)
-	if indexExpr == "" {
-		indexExpr = fmt.Sprintf("%d", baseIndex)
+	userKey := ""
+	if elem.RefKey != nil {
+		userKey = elem.RefKey.Code
 	}
+	indexExpr := g.mountKeyExpr(baseIndex, userKey)
 
 	// Build component-specific options from attributes
 	elemOpts := g.buildComponentElementOptions(elem)

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -451,7 +451,16 @@ func (g *Generator) generateComponentElementWithRefs(elem *Element, parentVar st
 		}
 	}
 
-	g.writef("%s := app.MountPersistent(%s, %s, func() tui.Component {\n", varName, g.currentReceiver, indexExpr)
+	// Loop call sites use Mount (mark-and-sweep) so components for keys that
+	// disappear from the data are cleaned up; with map keys and key={...}
+	// the key domain is unbounded, and persisting every key ever seen would
+	// leak. MountPersistent remains for standalone sites so a component
+	// hidden by a conditional keeps its state (e.g. a textarea's draft).
+	mountFunc := "app.MountPersistent"
+	if len(g.loopIndexStack) > 0 {
+		mountFunc = "app.Mount"
+	}
+	g.writef("%s := %s(%s, %s, func() tui.Component {\n", varName, mountFunc, g.currentReceiver, indexExpr)
 	g.indent++
 
 	constructor := componentConstructor(elem.Tag)

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -451,12 +451,10 @@ func (g *Generator) generateComponentElementWithRefs(elem *Element, parentVar st
 		}
 	}
 
-	// Keyed and loop call sites use Mount (mark-and-sweep): their identity
-	// comes from data, the key domain is unbounded, and persisting every key
-	// ever seen would leak. Sweeping also gives a standalone key={...} the
-	// React remount-on-key-change semantics. MountPersistent remains for
-	// plain positional standalone sites so a component hidden by a
-	// conditional keeps its state (e.g. a textarea's draft).
+	// Data-derived identities (loops, key={...}) use sweepable Mount since
+	// persisting an unbounded key domain would leak. MountPersistent stays
+	// for positional standalone sites so conditionally hidden components
+	// keep state (e.g. a textarea's draft).
 	mountFunc := "app.MountPersistent"
 	if len(g.loopIndexStack) > 0 || userKey != "" {
 		mountFunc = "app.Mount"

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -451,13 +451,14 @@ func (g *Generator) generateComponentElementWithRefs(elem *Element, parentVar st
 		}
 	}
 
-	// Loop call sites use Mount (mark-and-sweep) so components for keys that
-	// disappear from the data are cleaned up; with map keys and key={...}
-	// the key domain is unbounded, and persisting every key ever seen would
-	// leak. MountPersistent remains for standalone sites so a component
-	// hidden by a conditional keeps its state (e.g. a textarea's draft).
+	// Keyed and loop call sites use Mount (mark-and-sweep): their identity
+	// comes from data, the key domain is unbounded, and persisting every key
+	// ever seen would leak. Sweeping also gives a standalone key={...} the
+	// React remount-on-key-change semantics. MountPersistent remains for
+	// plain positional standalone sites so a component hidden by a
+	// conditional keeps its state (e.g. a textarea's draft).
 	mountFunc := "app.MountPersistent"
-	if len(g.loopIndexStack) > 0 {
+	if len(g.loopIndexStack) > 0 || userKey != "" {
 		mountFunc = "app.Mount"
 	}
 	g.writef("%s := %s(%s, %s, func() tui.Component {\n", varName, mountFunc, g.currentReceiver, indexExpr)

--- a/internal/tuigen/generator_element_coverage_test.go
+++ b/internal/tuigen/generator_element_coverage_test.go
@@ -348,7 +348,7 @@ templ (c *form) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, (1)*1000000+i, func() tui.Component {",
+				"app.MountPersistent(c, tui.MountKey(0, i), func() tui.Component {",
 				"c.areas.Append(__tui_",
 				"tui.WithTextAreaPlaceholder(f)",
 			},

--- a/internal/tuigen/generator_element_coverage_test.go
+++ b/internal/tuigen/generator_element_coverage_test.go
@@ -348,7 +348,7 @@ templ (c *form) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, tui.MountKey(0, i), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(0, i), func() tui.Component {",
 				"c.areas.Append(__tui_",
 				"tui.WithTextAreaPlaceholder(f)",
 			},

--- a/internal/tuigen/generator_mountkey_test.go
+++ b/internal/tuigen/generator_mountkey_test.go
@@ -152,6 +152,20 @@ templ (c *app) Render() {
 				"c.areas.Put(item.ID, __tui_",
 			},
 		},
+		"standalone component with key uses sweepable Mount": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		<markdown key={c.selectedDoc} source={c.body} />
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, c.selectedDoc), func() tui.Component {",
+			},
+		},
 		"struct component call in loop": {
 			input: `package x
 

--- a/internal/tuigen/generator_mountkey_test.go
+++ b/internal/tuigen/generator_mountkey_test.go
@@ -30,7 +30,7 @@ templ (c *app) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, tui.MountKey(0, i), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(0, i), func() tui.Component {",
 			},
 		},
 		"slice loop with discarded index uses synthetic variable": {
@@ -46,7 +46,7 @@ templ (c *app) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, tui.MountKey(0, __idx_0), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(0, __idx_0), func() tui.Component {",
 			},
 		},
 		"map loop keys by the map key (issue 92)": {
@@ -62,7 +62,7 @@ templ (c *app) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, tui.MountKey(0, name), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(0, name), func() tui.Component {",
 			},
 		},
 		"nested loops pass both loop keys": {
@@ -80,7 +80,7 @@ templ (c *app) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, tui.MountKey(0, i, j), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(0, i, j), func() tui.Component {",
 			},
 		},
 		"standalone component after loop keeps plain site index": {
@@ -97,11 +97,11 @@ templ (c *app) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, tui.MountKey(0, i), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(0, i), func() tui.Component {",
 				"app.MountPersistent(c, 1, func() tui.Component {",
 			},
 		},
-		"key attribute replaces loop keys with user identity": {
+		"key attribute replaces the innermost loop key with user identity": {
 			input: `package x
 
 type app struct{}
@@ -114,7 +114,25 @@ templ (c *app) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, tui.MountKey(0, item.ID), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(0, item.ID), func() tui.Component {",
+			},
+		},
+		"key attribute in nested loop is scoped to the innermost loop": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for i, group := range c.groups {
+			for _, item := range group {
+				<markdown key={item.ID} source={item.Text} />
+			}
+		}
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, i, item.ID), func() tui.Component {",
 			},
 		},
 		"key attribute still drives RefMap.Put alongside mount identity": {
@@ -130,7 +148,7 @@ templ (c *app) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.MountPersistent(c, tui.MountKey(0, item.ID), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(0, item.ID), func() tui.Component {",
 				"c.areas.Put(item.ID, __tui_",
 			},
 		},

--- a/internal/tuigen/generator_mountkey_test.go
+++ b/internal/tuigen/generator_mountkey_test.go
@@ -1,54 +1,23 @@
 package tuigen
 
 import (
-	"fmt"
-	"go/constant"
-	"go/token"
-	"go/types"
-	"regexp"
+	"strings"
 	"testing"
 )
 
-// mountIndexRe extracts the index expression from generated app.Mount /
-// app.MountPersistent calls.
-var mountIndexRe = regexp.MustCompile(`app\.Mount(?:Persistent)?\(\w+, (.+), func\(\) tui\.Component \{`)
-
-// evalMountKey evaluates a generated mount index expression after substituting
-// concrete iteration values for loop index variables. Keys must fit in int64,
-// which mirrors the generated code's int arithmetic and caps practical loop
-// nesting at three levels (a fourth level's keys reach ~1e24 and overflow).
-func evalMountKey(t *testing.T, expr string, vars map[string]int) int64 {
-	t.Helper()
-	for name, val := range vars {
-		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
-		expr = re.ReplaceAllString(expr, fmt.Sprintf("%d", val))
-	}
-	tv, err := types.Eval(token.NewFileSet(), nil, token.NoPos, expr)
-	if err != nil {
-		t.Fatalf("evaluating mount key %q: %v", expr, err)
-	}
-	v, ok := constant.Int64Val(tv.Value)
-	if !ok {
-		t.Fatalf("mount key %q did not evaluate to an int64 (likely overflow from too-deep loop nesting)", expr)
-	}
-	return v
-}
-
-// TestGenerator_MountKeysDoNotCollide reproduces issue #88: a component
-// mounted inside a for loop must never share a runtime mount key with a
-// component mounted at a different call site. With the colliding keys, the
-// mount cache returns the wrong component type at runtime (e.g. a Markdown
-// where a TextArea was requested).
-func TestGenerator_MountKeysDoNotCollide(t *testing.T) {
+// TestGenerator_MountKeyExpressions pins the mount cache key expressions
+// emitted for component call sites. Standalone sites use a plain int; sites
+// inside loops combine the site id with each enclosing loop's key value via
+// tui.MountKey (which is what makes map-keyed loops compile, issue #92);
+// a key={...} attribute replaces the loop values with user identity.
+func TestGenerator_MountKeyExpressions(t *testing.T) {
 	type tc struct {
-		input    string
-		loopVars []string // loop index variables expected in generated keys
-		iters    int      // iterations to simulate per loop variable
-		wantKeys int      // expected number of mount call sites
+		input        string
+		wantContains []string
 	}
 
 	tests := map[string]tc{
-		"loop component followed by standalone component": {
+		"slice loop with explicit index": {
 			input: `package x
 
 type app struct{}
@@ -58,14 +27,13 @@ templ (c *app) Render() {
 		for i, item := range c.items {
 			<markdown source={item} />
 		}
-		<textarea onSubmit={c.submit} />
 	</div>
 }`,
-			loopVars: []string{"i"},
-			iters:    3,
-			wantKeys: 2,
+			wantContains: []string{
+				"app.MountPersistent(c, tui.MountKey(0, i), func() tui.Component {",
+			},
 		},
-		"loop with discarded index uses synthetic variable": {
+		"slice loop with discarded index uses synthetic variable": {
 			input: `package x
 
 type app struct{}
@@ -75,50 +43,29 @@ templ (c *app) Render() {
 		for _, item := range c.items {
 			<markdown source={item} />
 		}
-		<textarea onSubmit={c.submit} />
 	</div>
 }`,
-			loopVars: []string{"__idx_0"},
-			iters:    3,
-			wantKeys: 2,
+			wantContains: []string{
+				"app.MountPersistent(c, tui.MountKey(0, __idx_0), func() tui.Component {",
+			},
 		},
-		"loop struct component call followed by standalone component": {
+		"map loop keys by the map key (issue 92)": {
 			input: `package x
 
 type app struct{}
 
 templ (c *app) Render() {
 	<div>
-		for i, item := range c.items {
-			@Widget(item)
+		for name, doc := range c.docs {
+			<markdown source={doc} />
 		}
-		<textarea onSubmit={c.submit} />
 	</div>
 }`,
-			loopVars: []string{"i"},
-			iters:    3,
-			wantKeys: 2,
+			wantContains: []string{
+				"app.MountPersistent(c, tui.MountKey(0, name), func() tui.Component {",
+			},
 		},
-		"nested loop component followed by standalone component": {
-			input: `package x
-
-type app struct{}
-
-templ (c *app) Render() {
-	<div>
-		for i, row := range c.rows {
-			for j, item := range row {
-				<markdown source={item} />
-			}
-		}
-		<textarea onSubmit={c.submit} />
-	</div>
-}`,
-			loopVars: []string{"i", "j"},
-			iters:    3,
-			wantKeys: 2,
-		},
-		"nested loop followed by sibling loop": {
+		"nested loops pass both loop keys": {
 			input: `package x
 
 type app struct{}
@@ -130,37 +77,13 @@ templ (c *app) Render() {
 				<markdown source={item} />
 			}
 		}
-		for k, other := range c.others {
-			<markdown source={other} />
-		}
 	</div>
 }`,
-			loopVars: []string{"i", "j", "k"},
-			iters:    3,
-			wantKeys: 2,
+			wantContains: []string{
+				"app.MountPersistent(c, tui.MountKey(0, i, j), func() tui.Component {",
+			},
 		},
-		"three-level nested loop followed by standalone component": {
-			input: `package x
-
-type app struct{}
-
-templ (c *app) Render() {
-	<div>
-		for i, plane := range c.planes {
-			for j, row := range plane {
-				for k, item := range row {
-					<markdown source={item} />
-				}
-			}
-		}
-		<textarea onSubmit={c.submit} />
-	</div>
-}`,
-			loopVars: []string{"i", "j", "k"},
-			iters:    3,
-			wantKeys: 2,
-		},
-		"two sibling loops with components": {
+		"standalone component after loop keeps plain site index": {
 			input: `package x
 
 type app struct{}
@@ -170,14 +93,62 @@ templ (c *app) Render() {
 		for i, item := range c.items {
 			<markdown source={item} />
 		}
-		for j, other := range c.others {
-			<markdown source={other} />
+		<textarea onSubmit={c.submit} />
+	</div>
+}`,
+			wantContains: []string{
+				"app.MountPersistent(c, tui.MountKey(0, i), func() tui.Component {",
+				"app.MountPersistent(c, 1, func() tui.Component {",
+			},
+		},
+		"key attribute replaces loop keys with user identity": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for _, item := range c.items {
+			<markdown key={item.ID} source={item.Text} />
 		}
 	</div>
 }`,
-			loopVars: []string{"i", "j"},
-			iters:    3,
-			wantKeys: 2,
+			wantContains: []string{
+				"app.MountPersistent(c, tui.MountKey(0, item.ID), func() tui.Component {",
+			},
+		},
+		"key attribute still drives RefMap.Put alongside mount identity": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for _, item := range c.items {
+			<textarea ref={c.areas} key={item.ID} placeholder={item.Name} />
+		}
+	</div>
+}`,
+			wantContains: []string{
+				"app.MountPersistent(c, tui.MountKey(0, item.ID), func() tui.Component {",
+				"c.areas.Put(item.ID, __tui_",
+			},
+		},
+		"struct component call in loop": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for i, item := range c.items {
+			@Widget(item)
+		}
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, i), func() tui.Component {",
+			},
 		},
 	}
 
@@ -188,53 +159,9 @@ templ (c *app) Render() {
 				t.Fatalf("generation failed: %v", err)
 			}
 			code := string(output)
-
-			matches := mountIndexRe.FindAllStringSubmatch(code, -1)
-			if len(matches) != tt.wantKeys {
-				t.Fatalf("expected %d mount calls, found %d\nGot:\n%s", tt.wantKeys, len(matches), code)
-			}
-
-			// For each call site, expand the key expression over simulated
-			// loop iterations and record every runtime key it can produce.
-			// Any two distinct (call site, iteration combo) pairs sharing a
-			// key is a collision, including two iterations of the same site.
-			seen := map[int64]string{} // runtime key -> "site/combo" identity
-			for site, m := range matches {
-				expr := m[1]
-
-				// Find which loop variables this expression references.
-				var refs []string
-				for _, v := range tt.loopVars {
-					if regexp.MustCompile(`\b` + regexp.QuoteMeta(v) + `\b`).MatchString(expr) {
-						refs = append(refs, v)
-					}
-				}
-
-				// Enumerate all combinations of iteration values for the
-				// referenced loop variables.
-				combos := [][]int{{}}
-				for range refs {
-					var next [][]int
-					for _, c := range combos {
-						for it := range tt.iters {
-							next = append(next, append(append([]int{}, c...), it))
-						}
-					}
-					combos = next
-				}
-
-				for _, combo := range combos {
-					vars := map[string]int{}
-					for vi, v := range refs {
-						vars[v] = combo[vi]
-					}
-					id := fmt.Sprintf("call site %d (vars %v)", site, vars)
-					key := evalMountKey(t, expr, vars)
-					if prev, ok := seen[key]; ok {
-						t.Errorf("mount key collision: %s expr %q produces key %d already produced by %s",
-							id, expr, key, prev)
-					}
-					seen[key] = id
+			for _, want := range tt.wantContains {
+				if !strings.Contains(code, want) {
+					t.Errorf("output missing %q\nGot:\n%s", want, code)
 				}
 			}
 		})

--- a/mount.go
+++ b/mount.go
@@ -49,11 +49,22 @@ func (a *App) mount(parent Component, key any, factory func() Component) *Elemen
 	app := a
 	ms := app.mounts
 	k := mountKey{parent: parent, key: key}
+	if ms.activeKeys[k] {
+		// Two mounts produced the same key within one render pass: either
+		// two call sites collide or a key={...} expression repeats across
+		// loop items. Both tree positions will share one component instance.
+		debug.Log("Mount: duplicate mount key %v (parent %T) within one render pass", key, parent)
+	}
 	ms.activeKeys[k] = true // Mark as active this render
 
 	instance, cached := ms.cache[k]
 	var fresh Component
 	if cached {
+		// The collision guard below only covers PropsUpdater types: that is
+		// the one path where a fresh instance already exists to compare
+		// against, so the check is free. All framework components implement
+		// PropsUpdater. Checking every cached component would cost a
+		// factory() allocation per cache hit per render.
 		if _, ok := instance.(PropsUpdater); ok {
 			fresh = factory()
 			if reflect.TypeOf(fresh) != reflect.TypeOf(instance) {

--- a/mount.go
+++ b/mount.go
@@ -2,12 +2,13 @@ package tui
 
 import "github.com/grindlemire/go-tui/internal/debug"
 
-// mountKey identifies a component instance by its parent and position.
-// Components at the same (parent, index) are considered the same instance
-// across renders and are reused from cache.
+// mountKey identifies a component instance by its parent and a comparable
+// key. Components at the same (parent, key) are considered the same
+// instance across renders and are reused from cache. Generated code builds
+// keys with MountKey (loop call sites) or a plain int (standalone sites).
 type mountKey struct {
 	parent Component
-	index  int
+	key    any
 }
 
 // mountState is per-App state for component instance caching.
@@ -40,17 +41,17 @@ type PropsUpdater interface {
 }
 
 // mount is the shared implementation for Mount and MountPersistent.
-func (a *App) mount(parent Component, index int, factory func() Component) *Element {
+func (a *App) mount(parent Component, key any, factory func() Component) *Element {
 	app := a
 	ms := app.mounts
-	key := mountKey{parent: parent, index: index}
-	ms.activeKeys[key] = true // Mark as active this render
+	k := mountKey{parent: parent, key: key}
+	ms.activeKeys[k] = true // Mark as active this render
 
-	instance, cached := ms.cache[key]
+	instance, cached := ms.cache[k]
 	if !cached {
 		instance = factory()
-		ms.cache[key] = instance
-		debug.Log("Mount: NEW component at index %d, type %T", index, instance)
+		ms.cache[k] = instance
+		debug.Log("Mount: NEW component at key %v, type %T", key, instance)
 
 		// Bind app before Init so state/events are wired up
 		if binder, ok := instance.(AppBinder); ok {
@@ -61,17 +62,17 @@ func (a *App) mount(parent Component, index int, factory func() Component) *Elem
 		if init, ok := instance.(Initializer); ok {
 			cleanup := init.Init()
 			if cleanup != nil {
-				ms.cleanups[key] = cleanup
+				ms.cleanups[k] = cleanup
 			}
 		}
 	} else {
 		// Component is cached - check if it can receive updated props
 		if updater, ok := instance.(PropsUpdater); ok {
 			fresh := factory()
-			debug.Log("Mount: CACHED component at index %d, calling UpdateProps, type %T", index, instance)
+			debug.Log("Mount: CACHED component at key %v, calling UpdateProps, type %T", key, instance)
 			updater.UpdateProps(fresh)
 		} else {
-			debug.Log("Mount: CACHED component at index %d, NO UpdateProps, type %T", index, instance)
+			debug.Log("Mount: CACHED component at key %v, NO UpdateProps, type %T", key, instance)
 		}
 		// Rebind after props update — fresh Events fields may be unbound
 		if binder, ok := instance.(AppBinder); ok {
@@ -93,17 +94,19 @@ func (a *App) mount(parent Component, index int, factory func() Component) *Elem
 // If the cached instance implements PropsUpdater, UpdateProps is called
 // with a fresh instance to allow prop updates.
 // Mark-and-sweep: marks the key as active. Sweep after render cleans stale entries.
-func (a *App) Mount(parent Component, index int, factory func() Component) *Element {
-	return a.mount(parent, index, factory)
+// The key must be comparable; generated code passes a plain int for
+// standalone call sites and a MountKey composite inside loops.
+func (a *App) Mount(parent Component, key any, factory func() Component) *Element {
+	return a.mount(parent, key, factory)
 }
 
 // MountPersistent is like Mount but marks the component as persistent,
 // preventing it from being cleaned up during sweep even when not active.
 // Use this for components that must survive being hidden by conditionals.
-func (a *App) MountPersistent(parent Component, index int, factory func() Component) *Element {
-	key := mountKey{parent: parent, index: index}
-	a.mounts.persistKeys[key] = true
-	return a.mount(parent, index, factory)
+func (a *App) MountPersistent(parent Component, key any, factory func() Component) *Element {
+	k := mountKey{parent: parent, key: key}
+	a.mounts.persistKeys[k] = true
+	return a.mount(parent, key, factory)
 }
 
 // sweep removes cached instances that were not marked active during the last

--- a/mount.go
+++ b/mount.go
@@ -50,9 +50,7 @@ func (a *App) mount(parent Component, key any, factory func() Component) *Elemen
 	ms := app.mounts
 	k := mountKey{parent: parent, key: key}
 	if ms.activeKeys[k] {
-		// Two mounts produced the same key within one render pass: either
-		// two call sites collide or a key={...} expression repeats across
-		// loop items. Both tree positions will share one component instance.
+		// Same key twice in one render pass: both positions share one instance.
 		debug.Log("Mount: duplicate mount key %v (parent %T) within one render pass", key, parent)
 	}
 	ms.activeKeys[k] = true // Mark as active this render
@@ -60,17 +58,13 @@ func (a *App) mount(parent Component, key any, factory func() Component) *Elemen
 	instance, cached := ms.cache[k]
 	var fresh Component
 	if cached {
-		// The collision guard below only covers PropsUpdater types: that is
-		// the one path where a fresh instance already exists to compare
-		// against, so the check is free. All framework components implement
-		// PropsUpdater. Checking every cached component would cost a
-		// factory() allocation per cache hit per render.
+		// Collision guard, PropsUpdater path only: the fresh instance needed
+		// for UpdateProps makes the type check free; checking every hit
+		// would cost a factory() call per render.
 		if _, ok := instance.(PropsUpdater); ok {
 			fresh = factory()
 			if reflect.TypeOf(fresh) != reflect.TypeOf(instance) {
-				// Key collision: this call site produced a different
-				// component type than the cache holds. Render the right
-				// component loudly instead of the wrong one silently.
+				// Evict and remount rather than render the wrong type silently.
 				debug.Log("Mount: key collision at %v: cached %T, factory produced %T; remounting", key, instance, fresh)
 				ms.evict(k)
 				cached = false

--- a/mount.go
+++ b/mount.go
@@ -1,6 +1,10 @@
 package tui
 
-import "github.com/grindlemire/go-tui/internal/debug"
+import (
+	"reflect"
+
+	"github.com/grindlemire/go-tui/internal/debug"
+)
 
 // mountKey identifies a component instance by its parent and a comparable
 // key. Components at the same (parent, key) are considered the same
@@ -48,8 +52,27 @@ func (a *App) mount(parent Component, key any, factory func() Component) *Elemen
 	ms.activeKeys[k] = true // Mark as active this render
 
 	instance, cached := ms.cache[k]
+	var fresh Component
+	if cached {
+		if _, ok := instance.(PropsUpdater); ok {
+			fresh = factory()
+			if reflect.TypeOf(fresh) != reflect.TypeOf(instance) {
+				// Key collision: this call site produced a different
+				// component type than the cache holds. Render the right
+				// component loudly instead of the wrong one silently.
+				debug.Log("Mount: key collision at %v: cached %T, factory produced %T; remounting", key, instance, fresh)
+				ms.evict(k)
+				cached = false
+			}
+		}
+	}
+
 	if !cached {
-		instance = factory()
+		if fresh != nil {
+			instance = fresh
+		} else {
+			instance = factory()
+		}
 		ms.cache[k] = instance
 		debug.Log("Mount: NEW component at key %v, type %T", key, instance)
 
@@ -66,9 +89,9 @@ func (a *App) mount(parent Component, key any, factory func() Component) *Elemen
 			}
 		}
 	} else {
-		// Component is cached - check if it can receive updated props
+		// Component is cached - check if it can receive updated props.
+		// fresh was already constructed (and type-checked) above.
 		if updater, ok := instance.(PropsUpdater); ok {
-			fresh := factory()
 			debug.Log("Mount: CACHED component at key %v, calling UpdateProps, type %T", key, instance)
 			updater.UpdateProps(fresh)
 		} else {
@@ -114,16 +137,23 @@ func (a *App) MountPersistent(parent Component, key any, factory func() Componen
 func (ms *mountState) sweep() {
 	for key := range ms.cache {
 		if !ms.activeKeys[key] && !ms.persistKeys[key] {
-			if unbinder, ok := ms.cache[key].(AppUnbinder); ok {
-				unbinder.UnbindApp()
-			}
-			if cleanup, ok := ms.cleanups[key]; ok {
-				cleanup()
-				delete(ms.cleanups, key)
-			}
-			delete(ms.cache, key)
+			ms.evict(key)
 		}
 	}
 	// Reset active keys for next render
 	ms.activeKeys = make(map[mountKey]bool)
+}
+
+// evict removes one cached instance, unbinding it and running its cleanup.
+func (ms *mountState) evict(key mountKey) {
+	if instance, ok := ms.cache[key]; ok {
+		if unbinder, ok := instance.(AppUnbinder); ok {
+			unbinder.UnbindApp()
+		}
+	}
+	if cleanup, ok := ms.cleanups[key]; ok {
+		cleanup()
+		delete(ms.cleanups, key)
+	}
+	delete(ms.cache, key)
 }

--- a/mount_key.go
+++ b/mount_key.go
@@ -1,24 +1,28 @@
 package tui
 
-// mountKeyNode chains an outer key with one loop level's key value.
-// Keys built from distinct (site, parts...) inputs never compare equal,
-// and a node never equals a plain int site key, so call sites cannot
-// collide with each other by construction.
+import (
+	"fmt"
+	"reflect"
+)
+
+// mountKeyNode chains an outer key with one loop level's key value. Distinct
+// (site, parts...) inputs never compare equal, so call sites cannot collide.
 type mountKeyNode struct {
 	parent any
 	part   any
 }
 
 // MountKey builds a comparable cache key for a mounted component from its
-// generated call-site id and the key values of the enclosing loops,
-// outermost first. A key={...} attribute in .gsx replaces the loop values
-// with the user's expression. Called by generated code. Every part must be
-// a comparable value (slice indices, map keys, or user-provided ids); a
-// non-comparable part panics at runtime when the key is inserted into the
-// mount cache.
+// generated call-site id and the enclosing loops' key values, outermost
+// first. Called by generated code. Parts must be comparable values (ints,
+// strings, comparable structs, pointers); MountKey panics on a
+// non-comparable part such as a slice or map.
 func MountKey(site int, parts ...any) any {
 	var key any = site
 	for _, part := range parts {
+		if part != nil && !reflect.TypeOf(part).Comparable() {
+			panic(fmt.Sprintf("tui.MountKey: key part of type %T is not comparable; use an int, string, pointer, or comparable struct", part))
+		}
 		key = mountKeyNode{parent: key, part: part}
 	}
 	return key

--- a/mount_key.go
+++ b/mount_key.go
@@ -13,7 +13,9 @@ type mountKeyNode struct {
 // generated call-site id and the key values of the enclosing loops,
 // outermost first. A key={...} attribute in .gsx replaces the loop values
 // with the user's expression. Called by generated code. Every part must be
-// a comparable value (slice indices, map keys, or user-provided ids).
+// a comparable value (slice indices, map keys, or user-provided ids); a
+// non-comparable part panics at runtime when the key is inserted into the
+// mount cache.
 func MountKey(site int, parts ...any) any {
 	var key any = site
 	for _, part := range parts {

--- a/mount_key.go
+++ b/mount_key.go
@@ -1,0 +1,23 @@
+package tui
+
+// mountKeyNode chains an outer key with one loop level's key value.
+// Keys built from distinct (site, parts...) inputs never compare equal,
+// and a node never equals a plain int site key, so call sites cannot
+// collide with each other by construction.
+type mountKeyNode struct {
+	parent any
+	part   any
+}
+
+// MountKey builds a comparable cache key for a mounted component from its
+// generated call-site id and the key values of the enclosing loops,
+// outermost first. A key={...} attribute in .gsx replaces the loop values
+// with the user's expression. Called by generated code. Every part must be
+// a comparable value (slice indices, map keys, or user-provided ids).
+func MountKey(site int, parts ...any) any {
+	var key any = site
+	for _, part := range parts {
+		key = mountKeyNode{parent: key, part: part}
+	}
+	return key
+}

--- a/mount_key_test.go
+++ b/mount_key_test.go
@@ -1,6 +1,10 @@
 package tui
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 func TestMountKey_Equality(t *testing.T) {
 	type tc struct {
@@ -59,4 +63,17 @@ func TestMountKey_UsableAsMapKey(t *testing.T) {
 	if m[MountKey(0, "a")] != "first" {
 		t.Errorf("lookup with rebuilt key failed")
 	}
+}
+
+func TestMountKey_NonComparablePartPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for non-comparable key part")
+		}
+		if !strings.Contains(fmt.Sprint(r), "not comparable") {
+			t.Errorf("panic message %q should name the comparability problem", r)
+		}
+	}()
+	MountKey(0, []string{"a"})
 }

--- a/mount_key_test.go
+++ b/mount_key_test.go
@@ -1,0 +1,62 @@
+package tui
+
+import "testing"
+
+func TestMountKey_Equality(t *testing.T) {
+	type tc struct {
+		a, b      any
+		wantEqual bool
+	}
+
+	tests := map[string]tc{
+		"same site and parts are equal": {
+			a: MountKey(1, 2), b: MountKey(1, 2), wantEqual: true,
+		},
+		"same site and string parts are equal": {
+			a: MountKey(0, "alpha"), b: MountKey(0, "alpha"), wantEqual: true,
+		},
+		"different parts differ": {
+			a: MountKey(0, "alpha"), b: MountKey(0, "beta"), wantEqual: false,
+		},
+		"different sites differ": {
+			a: MountKey(0, "x"), b: MountKey(1, "x"), wantEqual: false,
+		},
+		"issue 88 collision is impossible: loop iteration vs standalone site": {
+			a: MountKey(0, 1), b: MountKey(1), wantEqual: false,
+		},
+		"nested loop iteration vs flat sibling loop iteration differ": {
+			a: MountKey(0, 1, 0), b: MountKey(1, 0), wantEqual: false,
+		},
+		"int part and string part differ": {
+			a: MountKey(0, 1), b: MountKey(0, "1"), wantEqual: false,
+		},
+		"no parts returns the plain site key": {
+			a: MountKey(3), b: any(3), wantEqual: true,
+		},
+		"nested key order matters": {
+			a: MountKey(0, 1, 2), b: MountKey(0, 2, 1), wantEqual: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.a == tt.b; got != tt.wantEqual {
+				t.Errorf("(%v == %v) = %v, want %v", tt.a, tt.b, got, tt.wantEqual)
+			}
+		})
+	}
+}
+
+func TestMountKey_UsableAsMapKey(t *testing.T) {
+	m := map[any]string{}
+	m[MountKey(0, "a")] = "first"
+	m[MountKey(0, "b")] = "second"
+	m[MountKey(1)] = "third"
+
+	if len(m) != 3 {
+		t.Fatalf("expected 3 distinct map entries, got %d", len(m))
+	}
+	if m[MountKey(0, "a")] != "first" {
+		t.Errorf("lookup with rebuilt key failed")
+	}
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -585,7 +585,11 @@ func TestMount_StringAndCompositeKeys(t *testing.T) {
 		t.Fatalf("distinct keys should create 2 instances, got %d factory calls", factories)
 	}
 
-	// Same key again: cache hit, no new instance.
+	// End the render pass so the repeat mount below is a genuine
+	// cross-render cache hit (both keys were active, so they survive).
+	testApp.mounts.sweep()
+
+	// Same key on the next render: cache hit, no new instance.
 	testApp.Mount(parent, MountKey(0, "alpha"), factory)
 	if factories != 2 {
 		t.Errorf("repeat key should hit cache, got %d factory calls", factories)

--- a/mount_test.go
+++ b/mount_test.go
@@ -591,3 +591,62 @@ func TestMount_StringAndCompositeKeys(t *testing.T) {
 		t.Errorf("repeat key should hit cache, got %d factory calls", factories)
 	}
 }
+
+// mockUpdaterA implements Component and PropsUpdater.
+type mockUpdaterA struct {
+	updateCalls int
+}
+
+func (m *mockUpdaterA) Render(app *App) *Element { return New() }
+func (m *mockUpdaterA) UpdateProps(fresh Component) {
+	m.updateCalls++
+}
+
+// mockUpdaterB is a distinct type implementing Component and PropsUpdater,
+// with cleanup tracking to observe eviction.
+type mockUpdaterB struct {
+	initCalled   bool
+	cleanupCalls int
+}
+
+func (m *mockUpdaterB) Render(app *App) *Element    { return New() }
+func (m *mockUpdaterB) UpdateProps(fresh Component) {}
+func (m *mockUpdaterB) Init() func() {
+	m.initCalled = true
+	return func() { m.cleanupCalls++ }
+}
+
+func TestMount_TypeMismatchEvictsAndRemounts(t *testing.T) {
+	cleanup := setupTestMountState()
+	defer cleanup()
+
+	parent := &mockParent{}
+
+	first := &mockUpdaterB{}
+	testApp.Mount(parent, "shared", func() Component { return first })
+	if !first.initCalled {
+		t.Fatal("first mount did not Init")
+	}
+
+	// Same key, different concrete type: must NOT return the cached
+	// mockUpdaterB. The stale instance is evicted (cleanup runs) and the
+	// fresh one is mounted.
+	second := &mockUpdaterA{}
+	el := testApp.Mount(parent, "shared", func() Component { return second })
+
+	if el.component != second {
+		t.Fatalf("mount returned %T, want the fresh *mockUpdaterA", el.component)
+	}
+	if first.cleanupCalls != 1 {
+		t.Errorf("stale instance cleanup ran %d times, want 1", first.cleanupCalls)
+	}
+	if second.updateCalls != 0 {
+		t.Errorf("fresh instance got UpdateProps %d times, want 0 (it is a new mount)", second.updateCalls)
+	}
+
+	// Same key and same type again: normal cache hit with UpdateProps.
+	testApp.Mount(parent, "shared", func() Component { return &mockUpdaterA{} })
+	if second.updateCalls != 1 {
+		t.Errorf("cache hit should call UpdateProps once, got %d", second.updateCalls)
+	}
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -324,7 +324,7 @@ func TestMountState_SweepMultipleComponents(t *testing.T) {
 
 	// Simulate next render where only index 0 is active
 	ms.activeKeys = make(map[mountKey]bool)
-	key0 := mountKey{parent: parent, index: 0}
+	key0 := mountKey{parent: parent, key: 0}
 	ms.activeKeys[key0] = true
 
 	ms.sweep()
@@ -565,5 +565,29 @@ func TestNewMountState(t *testing.T) {
 	}
 	if len(ms.cache) != 0 {
 		t.Errorf("cache should be empty, has %d entries", len(ms.cache))
+	}
+}
+
+func TestMount_StringAndCompositeKeys(t *testing.T) {
+	cleanup := setupTestMountState()
+	defer cleanup()
+
+	parent := &mockParent{}
+	factories := 0
+	factory := func() Component {
+		factories++
+		return &mockComponent{}
+	}
+
+	testApp.Mount(parent, MountKey(0, "alpha"), factory)
+	testApp.Mount(parent, MountKey(0, "beta"), factory)
+	if factories != 2 {
+		t.Fatalf("distinct keys should create 2 instances, got %d factory calls", factories)
+	}
+
+	// Same key again: cache hit, no new instance.
+	testApp.Mount(parent, MountKey(0, "alpha"), factory)
+	if factories != 2 {
+		t.Errorf("repeat key should hit cache, got %d factory calls", factories)
 	}
 }


### PR DESCRIPTION
## Summary

Mount cache identity moves from integer arithmetic to structured keys. The old scheme encoded call site and loop iteration into one int (`(baseIndex+1)*1000000 + i`), which made map-keyed loops a compile error (#92) and meant any keying mistake silently rendered the wrong component (#91). This PR replaces it end to end:

- **`tui.MountKey(site, parts...)`** builds comparable composite keys: a plain int for a component declared once, a chained struct for loop call sites. Distinct call sites and distinct loop values can never compare equal, so the whole collision class from #88/#90 is gone by construction, with no multiplier ceiling and no overflow at deep nesting.
- **`Mount`/`MountPersistent` take `key any`** instead of `index int`. See the breaking change section below.
- **Map loops now work** (fixes #92): `for name, doc := range c.docs { <markdown source={doc} /> }` generates `tui.MountKey(0, name)` and compiles. Verified end to end against the issue's reproducer.
- **The `key={expr}` attribute gains React-like semantics**: on component elements it identifies the cached instance among its innermost-loop siblings, so a textarea's state follows its item when the list reorders, instead of sticking to a position. Outer loops keep contributing their own identity, matching how React scopes keys to the surrounding list. On a standalone element, changing the key remounts the component fresh. The attribute already existed for `RefMap.Put`; both meanings now share one expression.
- **Collisions fail loudly** (fixes #91): on a cache hit whose concrete type differs from what the factory produces, the stale instance is evicted (cleanup and unbind run) and the fresh component mounts, with a debug log. A same-type duplicate key within one render pass is also logged. Previously a colliding textarea would silently render as a markdown block.

Review of the change surfaced two design fixes that went in. Loop and keyed call sites now use `Mount` (mark-and-sweep) instead of `MountPersistent`: persistence exists so a conditionally hidden standalone textarea keeps its draft, but persisting every data-derived key ever seen would leak one component per distinct map key or item ID in exactly the use cases this PR enables. And `key="literal"` (or `ref="literal"`) is now an analyzer error instead of being silently ignored, since a string literal never reached the generator.

Tests: runtime equality tests pin MountKey's collision-impossibility (including the historical #88 and #90 shapes), mount tests cover string/composite keys and the evict-and-remount path, and a generator table test pins the emitted key expression for slice loops, synthetic indices, map loops, nested loops, key attributes (single, nested, and standalone), and struct component calls. Docs updated across CLAUDE.md, the docs site (app reference, gsx syntax, refs, component guides), and LSP completions.

## Breaking change (intentionally shipped as a minor bump)

This is technically a breaking API change, shipped as a minor instead of a major bump because we are pre-1.0 and regenerating fixes everything. What breaks and what you'll see:

**`Mount` and `MountPersistent` signatures changed** from `index int` to `key any`. Plain calls like `app.Mount(c, 0, factory)` keep compiling because an int satisfies `any`, so almost all code, including generated code from older versions, builds unchanged. The only compile error appears if you stored the method in a variable or parameter with the old function type:

```
cannot use app.Mount (value of type func(parent tui.Component, key any, factory func() tui.Component) *tui.Element) as func(tui.Component, int, func() tui.Component) *tui.Element value
```

Fix: change the `int` in your function type to `any`.

**`key="literal"` and `ref="literal"` are now compile errors** at `tui generate` (previously they were silently ignored, which masked bugs):

```
app.gsx:6:12: error: key must be an expression (use key={...} with a Go expression, not a literal)
```

Fix: use an expression, e.g. `key={item.ID}` instead of `key="item"`.

**Component state inside loops is now swept.** A component element hidden inside a loop (the item disappears from the data) loses its internal state, where the old code kept it forever. This is the leak fix; if you need state to survive, keep the item in the data and hide it visually, or lift the state into your component struct.

After upgrading, run `tui generate ./...` to regenerate `.gsx` output. Old generated code still compiles and runs, but it carries the old collision-prone keys until regenerated.

Known follow-up: `key` on `@Component(...)` struct calls needs parser syntax for call-site attributes and is not included.

Fixes #91
Fixes #92
