### PR TITLE
feat(tuigen): key on a container element keys descendant component mounts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,7 +439,7 @@ func helper(s string) string {
 | `class` | `string` | Tailwind-style classes |
 | `disabled` | `bool` | Disable interaction |
 | `ref` | expression | Bind element to a `tui.Ref`/`RefList`/`RefMap` variable |
-| `key` | expression | Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): mount cache key for component elements, RefMap key with `ref` |
+| `key` | expression | Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): mount cache key for component elements, RefMap key with `ref`; a key on a container element keys the components mounted inside it |
 | `deps` | expression | Explicit state dependencies for reactive bindings |
 
 ### Layout Attributes

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -318,7 +318,7 @@ for _, msg := range s.messages {
 }
 ```
 
-Loops nested inside a keyed wrapper still contribute their own identity, and an element's own `key` wins over an inherited one.
+Keys compose by depth. A `key` replaces the loop position at its own level, loops nested inside a keyed wrapper still contribute their own identity, and a `key` nested under another `key` appends to it rather than erasing it. One caveat: components passed into a children slot are mounted at the caller's site, so a keyed wrapper inside the receiving component does not re-key them.
 
 ## Attribute reference
 

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -308,6 +308,18 @@ Without `key`, components in a loop are identified by the loop's index or map ke
 
 A `key` on a component element outside any loop changes identity per value: when the expression changes, the old instance is swept and a fresh one mounts. Use this to reset a component's internal state when the thing it represents changes, such as `<textarea key={c.activeDraftID} />` clearing between drafts.
 
+Struct component calls (`@ChatMessage(item)`) have no attributes, so to key one, put the `key` on a wrapper element. A `key` on any element applies to every component mounted beneath it:
+
+```gsx
+for _, msg := range s.messages {
+    <div key={msg.ID} class="flex-col">
+        @ChatMessage(msg)
+    </div>
+}
+```
+
+Loops nested inside a keyed wrapper still contribute their own identity, and an element's own `key` wins over an inherited one.
+
 ## Attribute reference
 
 ### Generic attributes (all elements)

--- a/internal/lsp/schema/schema.go
+++ b/internal/lsp/schema/schema.go
@@ -242,7 +242,7 @@ func genericAttrs() []AttributeDef {
 		{Name: "disabled", Type: "bool", Description: "Whether the element is disabled", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable (tui.NewRef/NewRefList/NewRefMap)", Category: "ref"},
-		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
+		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref; on a container element it keys descendant component mounts", Category: "generic"},
 	}
 }
 
@@ -384,7 +384,7 @@ func inputAttrs() []AttributeDef {
 		{Name: "onChange", Type: "func", Description: "Callback when text changes: func(string)", Category: "event"},
 		{Name: "autoFocus", Type: "bool", Description: "Automatically focus this input on startup", Category: "event"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
-		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
+		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref; on a container element it keys descendant component mounts", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }
@@ -409,7 +409,7 @@ func textareaAttrs() []AttributeDef {
 		{Name: "onSubmit", Type: "func", Description: "Callback when submit key is pressed: func(string)", Category: "event"},
 		{Name: "autoFocus", Type: "bool", Description: "Automatically focus this text area on startup", Category: "event"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
-		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
+		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref; on a container element it keys descendant component mounts", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }
@@ -426,7 +426,7 @@ func modalAttrs() []AttributeDef {
 		{Name: "trapFocus", Type: "bool", Description: "Tab/Shift+Tab restricted to modal children; when true, also blocks unhandled keys from reaching parent components (default true)", Category: "event"},
 		{Name: "keyMap", Type: "expression", Description: "Custom KeyMap bindings for the modal; fire before the catch-all when trapFocus is true", Category: "event"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
-		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
+		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref; on a container element it keys descendant component mounts", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }
@@ -441,7 +441,7 @@ func markdownAttrs() []AttributeDef {
 		{Name: "width", Type: "int", Description: "Fixed render width in characters (0 = fill available width)", Category: "layout"},
 		{Name: "theme", Type: "expression", Description: "tui.MarkdownTheme overriding the default styling", Category: "visual"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
-		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref", Category: "generic"},
+		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref; on a container element it keys descendant component mounts", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 	}
 }

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -175,7 +175,7 @@ var knownAttributes = map[string]bool{
 
 	// Element refs
 	"ref": true, // ref={varName} for element references
-	"key": true, // key={expr}: loop item identity (mount cache key; RefMap key with ref)
+	"key": true, // key={expr}: identity for mounts (own, or descendants' when on a container); RefMap key with ref
 
 	// Modal
 	"open":                 true,

--- a/internal/tuigen/analyzer_refs.go
+++ b/internal/tuigen/analyzer_refs.go
@@ -11,7 +11,7 @@ import (
 // - Any valid Go expression for struct components (e.g., s.content)
 // - Reserved export name 'Root' (capitalized ref name must not be "Root")
 // - Unique names within the component (for function components only)
-// - key attribute only valid inside for loops
+// - key attribute provides mount/RefMap identity (with ref, only valid inside for loops)
 // - Determines ref kind from context (single, list, or map)
 func (a *Analyzer) validateRefs(comp *Component) []RefInfo {
 	names := make(map[string]Position)

--- a/internal/tuigen/generator.go
+++ b/internal/tuigen/generator.go
@@ -54,6 +54,11 @@ type Generator struct {
 	// Used by generateStructMount to generate unique mount indices per iteration.
 	loopIndexStack []string
 
+	// mountKeyParts tracks the mount key segments in scope: enclosing loops'
+	// key variables with key={...} element overrides applied. Consumed by
+	// mountKeyExpr to build tui.MountKey expressions.
+	mountKeyParts []string
+
 	// fileDecls stores the current file's GoDecl nodes for struct lookup.
 	// Used by generateUpdateProps to find struct definitions for method components.
 	fileDecls []*GoDecl
@@ -340,6 +345,7 @@ func (g *Generator) pushLoopIndex(loop *ForLoop) string {
 		idxVar = fmt.Sprintf("__idx_%d", len(g.loopIndexStack))
 	}
 	g.loopIndexStack = append(g.loopIndexStack, idxVar)
+	g.mountKeyParts = append(slices.Clone(g.mountKeyParts), idxVar)
 	return idxVar
 }
 
@@ -348,25 +354,37 @@ func (g *Generator) popLoopIndex() {
 	if len(g.loopIndexStack) > 0 {
 		g.loopIndexStack = g.loopIndexStack[:len(g.loopIndexStack)-1]
 	}
+	if len(g.mountKeyParts) > 0 {
+		g.mountKeyParts = g.mountKeyParts[:len(g.mountKeyParts)-1]
+	}
+}
+
+// pushElementKey scopes a key={...} identity override: the key replaces the
+// most recent mount key segment (or starts the list) for every mount
+// generated until the returned restore func runs. This is how a keyed
+// wrapper element keys the components inside it.
+func (g *Generator) pushElementKey(key string) func() {
+	saved := g.mountKeyParts
+	parts := slices.Clone(saved)
+	if len(parts) == 0 {
+		parts = []string{key}
+	} else {
+		parts[len(parts)-1] = key
+	}
+	g.mountKeyParts = parts
+	return func() { g.mountKeyParts = saved }
 }
 
 // mountKeyExpr returns the Go expression for a component's mount cache key:
-// the static site index alone, or tui.MountKey(site, loopVars...) inside
-// loops. A userKey (from key={...}) replaces the innermost loop's value,
-// matching React's sibling-scoped key semantics.
-func (g *Generator) mountKeyExpr(baseIndex int, userKey string) string {
-	parts := slices.Clone(g.loopIndexStack)
-	if userKey != "" {
-		if len(parts) == 0 {
-			parts = []string{userKey}
-		} else {
-			parts[len(parts)-1] = userKey
-		}
-	}
-	if len(parts) == 0 {
+// the static site index alone, or tui.MountKey(site, parts...) where the
+// parts are the enclosing loops' key values with key={...} overrides applied
+// (each override replaces the innermost segment, matching React's
+// sibling-scoped key semantics).
+func (g *Generator) mountKeyExpr(baseIndex int) string {
+	if len(g.mountKeyParts) == 0 {
 		return fmt.Sprintf("%d", baseIndex)
 	}
-	return fmt.Sprintf("tui.MountKey(%d, %s)", baseIndex, strings.Join(parts, ", "))
+	return fmt.Sprintf("tui.MountKey(%d, %s)", baseIndex, strings.Join(g.mountKeyParts, ", "))
 }
 
 // stateNameSet returns a set of state variable names for quick lookup.

--- a/internal/tuigen/generator.go
+++ b/internal/tuigen/generator.go
@@ -50,13 +50,10 @@ type Generator struct {
 	// to emit app.Mount(receiverVar, index, factory).
 	currentReceiver string
 
-	// loopIndexStack tracks loop index variable names for nested for loops.
-	// Used by generateStructMount to generate unique mount indices per iteration.
+	// loopIndexStack names synthetic loop index variables (__idx_N) by depth.
 	loopIndexStack []string
 
-	// mountKeyParts tracks the mount key segments in scope: enclosing loops'
-	// key variables with key={...} element overrides applied. Consumed by
-	// mountKeyExpr to build tui.MountKey expressions.
+	// mountKeyParts holds the identity segments in scope for mount key expressions.
 	mountKeyParts []mountKeySegment
 
 	// fileDecls stores the current file's GoDecl nodes for struct lookup.
@@ -359,20 +356,16 @@ func (g *Generator) popLoopIndex() {
 	}
 }
 
-// mountKeySegment is one identity segment of a mount key: a loop's key
-// variable, or a key={...} expression. The kind decides how a nested
-// key={...} composes (replace a loop position, append after another key).
+// mountKeySegment is one mount key identity segment: a loop variable or a
+// key={...} expression.
 type mountKeySegment struct {
 	expr     string
 	fromLoop bool
 }
 
-// pushElementKey scopes a key={...} identity override for every mount
-// generated until the returned restore func runs. A key replaces the
-// innermost segment when it came from a loop (the key substitutes for the
-// item's position at that level, like React keys) and appends when nested
-// under another key (a deeper identity level composes rather than erasing
-// the outer one).
+// pushElementKey scopes a key={...} override until the returned restore func
+// runs: the key replaces the innermost segment when it came from a loop
+// (React sibling scoping) and appends under another key (depths compose).
 func (g *Generator) pushElementKey(key string) func() {
 	saved := g.mountKeyParts
 	parts := slices.Clone(saved)
@@ -385,9 +378,8 @@ func (g *Generator) pushElementKey(key string) func() {
 	return func() { g.mountKeyParts = saved }
 }
 
-// mountKeyExpr returns the Go expression for a component's mount cache key:
-// the static site index alone, or tui.MountKey(site, parts...) built from
-// the in-scope identity segments.
+// mountKeyExpr returns the mount cache key expression: the site index alone,
+// or tui.MountKey(site, parts...) from the in-scope identity segments.
 func (g *Generator) mountKeyExpr(baseIndex int) string {
 	if len(g.mountKeyParts) == 0 {
 		return fmt.Sprintf("%d", baseIndex)

--- a/internal/tuigen/generator.go
+++ b/internal/tuigen/generator.go
@@ -57,7 +57,7 @@ type Generator struct {
 	// mountKeyParts tracks the mount key segments in scope: enclosing loops'
 	// key variables with key={...} element overrides applied. Consumed by
 	// mountKeyExpr to build tui.MountKey expressions.
-	mountKeyParts []string
+	mountKeyParts []mountKeySegment
 
 	// fileDecls stores the current file's GoDecl nodes for struct lookup.
 	// Used by generateUpdateProps to find struct definitions for method components.
@@ -345,7 +345,7 @@ func (g *Generator) pushLoopIndex(loop *ForLoop) string {
 		idxVar = fmt.Sprintf("__idx_%d", len(g.loopIndexStack))
 	}
 	g.loopIndexStack = append(g.loopIndexStack, idxVar)
-	g.mountKeyParts = append(slices.Clone(g.mountKeyParts), idxVar)
+	g.mountKeyParts = append(slices.Clone(g.mountKeyParts), mountKeySegment{expr: idxVar, fromLoop: true})
 	return idxVar
 }
 
@@ -359,32 +359,44 @@ func (g *Generator) popLoopIndex() {
 	}
 }
 
-// pushElementKey scopes a key={...} identity override: the key replaces the
-// most recent mount key segment (or starts the list) for every mount
-// generated until the returned restore func runs. This is how a keyed
-// wrapper element keys the components inside it.
+// mountKeySegment is one identity segment of a mount key: a loop's key
+// variable, or a key={...} expression. The kind decides how a nested
+// key={...} composes (replace a loop position, append after another key).
+type mountKeySegment struct {
+	expr     string
+	fromLoop bool
+}
+
+// pushElementKey scopes a key={...} identity override for every mount
+// generated until the returned restore func runs. A key replaces the
+// innermost segment when it came from a loop (the key substitutes for the
+// item's position at that level, like React keys) and appends when nested
+// under another key (a deeper identity level composes rather than erasing
+// the outer one).
 func (g *Generator) pushElementKey(key string) func() {
 	saved := g.mountKeyParts
 	parts := slices.Clone(saved)
-	if len(parts) == 0 {
-		parts = []string{key}
+	if n := len(parts); n > 0 && parts[n-1].fromLoop {
+		parts[n-1] = mountKeySegment{expr: key}
 	} else {
-		parts[len(parts)-1] = key
+		parts = append(parts, mountKeySegment{expr: key})
 	}
 	g.mountKeyParts = parts
 	return func() { g.mountKeyParts = saved }
 }
 
 // mountKeyExpr returns the Go expression for a component's mount cache key:
-// the static site index alone, or tui.MountKey(site, parts...) where the
-// parts are the enclosing loops' key values with key={...} overrides applied
-// (each override replaces the innermost segment, matching React's
-// sibling-scoped key semantics).
+// the static site index alone, or tui.MountKey(site, parts...) built from
+// the in-scope identity segments.
 func (g *Generator) mountKeyExpr(baseIndex int) string {
 	if len(g.mountKeyParts) == 0 {
 		return fmt.Sprintf("%d", baseIndex)
 	}
-	return fmt.Sprintf("tui.MountKey(%d, %s)", baseIndex, strings.Join(g.mountKeyParts, ", "))
+	exprs := make([]string, len(g.mountKeyParts))
+	for i, part := range g.mountKeyParts {
+		exprs[i] = part.expr
+	}
+	return fmt.Sprintf("tui.MountKey(%d, %s)", baseIndex, strings.Join(exprs, ", "))
 }
 
 // stateNameSet returns a set of state variable names for quick lookup.

--- a/internal/tuigen/generator_children.go
+++ b/internal/tuigen/generator_children.go
@@ -187,8 +187,8 @@ func (g *Generator) generateStructMount(call *ComponentCall, parentVar string) s
 	baseIndex := g.mountIndex
 	g.mountIndex++
 
-	// Component calls have no key attribute.
-	indexExpr := g.mountKeyExpr(baseIndex, "")
+	// Component calls have no key attribute; a keyed wrapper element keys them.
+	indexExpr := g.mountKeyExpr(baseIndex)
 
 	// Build children slice if the component call has children
 	childrenVar := ""

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -17,6 +17,8 @@ func (g *Generator) generateComponent(comp *Component) {
 	g.condCounter = 0
 	g.loopCounter = 0
 	g.mountIndex = 0
+	g.loopIndexStack = nil
+	g.mountKeyParts = nil
 	g.currentReceiver = ""
 	g.componentVars = nil
 	g.componentExprFields = nil

--- a/internal/tuigen/generator_control.go
+++ b/internal/tuigen/generator_control.go
@@ -49,12 +49,9 @@ func (g *Generator) generateLetBinding(let *LetBinding, parentVar string, inCond
 	if !skipTextChildren(let.Element) {
 		// A key={...} on a let-bound element keys the mounts of its descendants.
 		if let.Element.RefKey != nil {
-			restore := g.pushElementKey(let.Element.RefKey.Code)
-			g.generateChildren(let.Name, let.Element.Children)
-			restore()
-		} else {
-			g.generateChildren(let.Name, let.Element.Children)
+			defer g.pushElementKey(let.Element.RefKey.Code)()
 		}
+		g.generateChildren(let.Name, let.Element.Children)
 	}
 
 	// Add to parent if specified

--- a/internal/tuigen/generator_control.go
+++ b/internal/tuigen/generator_control.go
@@ -47,7 +47,14 @@ func (g *Generator) generateLetBinding(let *LetBinding, parentVar string, inCond
 
 	// Generate children for the let-bound element - skip if text element already has content in WithText
 	if !skipTextChildren(let.Element) {
-		g.generateChildren(let.Name, let.Element.Children)
+		// A key={...} on a let-bound element keys the mounts of its descendants.
+		if let.Element.RefKey != nil {
+			restore := g.pushElementKey(let.Element.RefKey.Code)
+			g.generateChildren(let.Name, let.Element.Children)
+			restore()
+		} else {
+			g.generateChildren(let.Name, let.Element.Children)
+		}
 	}
 
 	// Add to parent if specified

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -455,10 +455,8 @@ func (g *Generator) generateComponentElementWithRefs(elem *Element, parentVar st
 		}
 	}
 
-	// Data-derived identities (loops, key={...}) use sweepable Mount since
-	// persisting an unbounded key domain would leak. MountPersistent stays
-	// for positional standalone sites so conditionally hidden components
-	// keep state (e.g. a textarea's draft).
+	// Data-derived identities (loops, key={...}) use sweepable Mount;
+	// persisting an unbounded key domain would leak.
 	mountFunc := "app.MountPersistent"
 	if len(g.mountKeyParts) > 0 {
 		mountFunc = "app.Mount"

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -62,12 +62,9 @@ func (g *Generator) generateElementWithRefs(elem *Element, parentVar string, inL
 	if !skipTextChildren(elem) {
 		// A key={...} on a plain element keys the mounts of its descendants.
 		if elem.RefKey != nil {
-			restore := g.pushElementKey(elem.RefKey.Code)
-			g.generateChildrenWithRefs(varName, elem.Children, inLoop, inConditional, inForLoop)
-			restore()
-		} else {
-			g.generateChildrenWithRefs(varName, elem.Children, inLoop, inConditional, inForLoop)
+			defer g.pushElementKey(elem.RefKey.Code)()
 		}
+		g.generateChildrenWithRefs(varName, elem.Children, inLoop, inConditional, inForLoop)
 	}
 
 	// Add to parent if specified

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -60,7 +60,14 @@ func (g *Generator) generateElementWithRefs(elem *Element, parentVar string, inL
 
 	// Generate children - skip if text element already has content in WithText
 	if !skipTextChildren(elem) {
-		g.generateChildrenWithRefs(varName, elem.Children, inLoop, inConditional, inForLoop)
+		// A key={...} on a plain element keys the mounts of its descendants.
+		if elem.RefKey != nil {
+			restore := g.pushElementKey(elem.RefKey.Code)
+			g.generateChildrenWithRefs(varName, elem.Children, inLoop, inConditional, inForLoop)
+			restore()
+		} else {
+			g.generateChildrenWithRefs(varName, elem.Children, inLoop, inConditional, inForLoop)
+		}
 	}
 
 	// Add to parent if specified
@@ -433,11 +440,11 @@ func (g *Generator) generateComponentElementWithRefs(elem *Element, parentVar st
 	baseIndex := g.mountIndex
 	g.mountIndex++
 
-	userKey := ""
+	// An own key={...} scopes over this mount and its children (modal).
 	if elem.RefKey != nil {
-		userKey = elem.RefKey.Code
+		defer g.pushElementKey(elem.RefKey.Code)()
 	}
-	indexExpr := g.mountKeyExpr(baseIndex, userKey)
+	indexExpr := g.mountKeyExpr(baseIndex)
 
 	// Build component-specific options from attributes
 	elemOpts := g.buildComponentElementOptions(elem)
@@ -456,7 +463,7 @@ func (g *Generator) generateComponentElementWithRefs(elem *Element, parentVar st
 	// for positional standalone sites so conditionally hidden components
 	// keep state (e.g. a textarea's draft).
 	mountFunc := "app.MountPersistent"
-	if len(g.loopIndexStack) > 0 || userKey != "" {
+	if len(g.mountKeyParts) > 0 {
 		mountFunc = "app.Mount"
 	}
 	g.writef("%s := %s(%s, %s, func() tui.Component {\n", varName, mountFunc, g.currentReceiver, indexExpr)

--- a/internal/tuigen/generator_mountkey_test.go
+++ b/internal/tuigen/generator_mountkey_test.go
@@ -238,7 +238,7 @@ templ (c *app) Render() {
 				"app.Mount(c, tui.MountKey(0, item.ID), func() tui.Component {",
 			},
 		},
-		"own key wins over inherited wrapper key": {
+		"own key composes after inherited wrapper key": {
 			input: `package x
 
 type app struct{}
@@ -253,7 +253,73 @@ templ (c *app) Render() {
 	</div>
 }`,
 			wantContains: []string{
-				"app.Mount(c, tui.MountKey(0, item.Sub), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(0, item.ID, item.Sub), func() tui.Component {",
+			},
+		},
+		"nested keyed wrappers compose": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div key={c.userID}>
+		<div key={c.tabID}>
+			<textarea placeholder="notes" />
+		</div>
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, c.userID, c.tabID), func() tui.Component {",
+			},
+		},
+		"let-bound keyed wrapper keys descendants": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	label := <div key={c.activeID}>
+		<textarea placeholder="notes" />
+	</div>
+	<div>{label}</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, c.activeID), func() tui.Component {",
+			},
+		},
+		"modal children inherit the modal's own key": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<modal key={c.sessionID} open={c.show}>
+		<textarea placeholder="notes" />
+	</modal>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, c.sessionID), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(1, c.sessionID), func() tui.Component {",
+			},
+		},
+		"keyed wrapper inside conditional": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for _, item := range c.items {
+			if item.Visible {
+				<div key={item.ID}>
+					<textarea placeholder={item.Name} />
+				</div>
+			}
+		}
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, item.ID), func() tui.Component {",
 			},
 		},
 		"sibling after keyed wrapper falls back to loop key": {

--- a/internal/tuigen/generator_mountkey_test.go
+++ b/internal/tuigen/generator_mountkey_test.go
@@ -182,6 +182,114 @@ templ (c *app) Render() {
 				"app.Mount(c, tui.MountKey(0, i), func() tui.Component {",
 			},
 		},
+		"keyed wrapper div keys struct component call": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for _, item := range c.items {
+			<div key={item.ID}>
+				@ChatMessage(item)
+			</div>
+		}
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, item.ID), func() tui.Component {",
+			},
+		},
+		"keyed wrapper outside inner loop prefixes inner loop keys": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for _, group := range c.groups {
+			<div key={group.ID}>
+				for _, item := range group.Items {
+					@Widget(item)
+				}
+			</div>
+		}
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, group.ID, __idx_1), func() tui.Component {",
+			},
+		},
+		"component element inherits wrapper key": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for _, item := range c.items {
+			<div key={item.ID}>
+				<textarea placeholder={item.Name} />
+			</div>
+		}
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, item.ID), func() tui.Component {",
+			},
+		},
+		"own key wins over inherited wrapper key": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for _, item := range c.items {
+			<div key={item.ID}>
+				<markdown key={item.Sub} source={item.Text} />
+			</div>
+		}
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, item.Sub), func() tui.Component {",
+			},
+		},
+		"sibling after keyed wrapper falls back to loop key": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div>
+		for i, item := range c.items {
+			<div key={item.ID}>
+				<textarea placeholder={item.Name} />
+			</div>
+			<markdown source={item.Text} />
+		}
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, item.ID), func() tui.Component {",
+				"app.Mount(c, tui.MountKey(1, i), func() tui.Component {",
+			},
+		},
+		"standalone keyed wrapper uses sweepable Mount": {
+			input: `package x
+
+type app struct{}
+
+templ (c *app) Render() {
+	<div key={c.activeID}>
+		<textarea placeholder="notes" />
+	</div>
+}`,
+			wantContains: []string{
+				"app.Mount(c, tui.MountKey(0, c.activeID), func() tui.Component {",
+			},
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
## Summary

Follow-up to #93. Struct component calls (`@ChatMessage(item)`) had no way to opt into keyed identity because the call syntax has no attributes, so their state stuck to loop position when a list reordered. Rather than inventing call-site attribute syntax, this makes `key={...}` on any element apply to every component mounted beneath it:

```gsx
for _, msg := range s.messages {
    <div key={msg.ID} class="flex-col">
        @ChatMessage(msg)
    </div>
}
```

The generator now tracks identity segments (loop variables and key overrides) as a scoped stack. A key replaces the segment at its own level when that segment came from a loop, exactly as the attribute already behaved on component elements. Loops nested inside a keyed wrapper append their own segments after it, so `<div key={group.ID}>` around an inner item loop produces `MountKey(site, group.ID, item_index)`.

Review of the first cut caught a semantics gap worth fixing rather than documenting: a key nested under another key used to replace it, silently dropping the outer wrapper's identity. Keys now compose by depth instead; `<div key={c.userID}><div key={c.tabID}>` yields `MountKey(site, c.userID, c.tabID)`, and a component element's own key inside a keyed wrapper appends the same way. The other review findings went in too: the segment stacks reset per templ as defensive hygiene, the new let-binding and modal paths are pinned by tests, and the docs note the one escape hatch (children passed into a slot are mounted at the caller's site, so the receiving component's wrappers don't re-key them).

Existing behavior is unchanged for everything that compiled before: plain loop mounts, component-element keys, and standalone positional sites generate identical code, and a keyed wrapper's sibling correctly falls back to the loop key (pinned by test). Wrapper keys choose sweepable `Mount` like all data-derived identity, so changing a standalone wrapper's key remounts fresh instead of leaking.

Tests cover the wrapper-keys-struct-call case, wrapper-outside-inner-loop, inheritance into component elements, depth composition for both nested wrappers and own-key-under-wrapper, sibling restore, conditionals, let bindings, modal children, and standalone wrappers.
