### PR TITLE
fix!: measure and render text by grapheme cluster

### DIFF
--- a/app_integration_test.go
+++ b/app_integration_test.go
@@ -21,16 +21,16 @@ func TestIntegration_RenderPipeline(t *testing.T) {
 	// Verify the content is in the mock terminal
 	for i, r := range "Hello" {
 		cell := term.CellAt(5+i, 2)
-		if cell.Rune != r {
-			t.Errorf("Cell(%d, 2).Rune = %q, want %q", 5+i, cell.Rune, r)
+		if cell.Text != string(r) {
+			t.Errorf("Cell(%d, 2).Rune = %q, want %q", 5+i, cell.Text, r)
 		}
 	}
 
 	// Verify surrounding cells are spaces
-	if term.CellAt(4, 2).Rune != ' ' {
+	if term.CellAt(4, 2).Text != " " {
 		t.Error("Cell before text should be space")
 	}
-	if term.CellAt(10, 2).Rune != ' ' {
+	if term.CellAt(10, 2).Text != " " {
 		t.Error("Cell after text should be space")
 	}
 }
@@ -53,17 +53,17 @@ func TestIntegration_BorderedBoxWithTitle(t *testing.T) {
 	// "  └─────────────┘"
 
 	// Check corners
-	if term.CellAt(2, 1).Rune != '┌' {
-		t.Errorf("TopLeft = %q, want '┌'", term.CellAt(2, 1).Rune)
+	if term.CellAt(2, 1).Text != "┌" {
+		t.Errorf("TopLeft = %q, want '┌'", term.CellAt(2, 1).Text)
 	}
-	if term.CellAt(16, 1).Rune != '┐' {
-		t.Errorf("TopRight = %q, want '┐'", term.CellAt(16, 1).Rune)
+	if term.CellAt(16, 1).Text != "┐" {
+		t.Errorf("TopRight = %q, want '┐'", term.CellAt(16, 1).Text)
 	}
-	if term.CellAt(2, 4).Rune != '└' {
-		t.Errorf("BottomLeft = %q, want '└'", term.CellAt(2, 4).Rune)
+	if term.CellAt(2, 4).Text != "└" {
+		t.Errorf("BottomLeft = %q, want '└'", term.CellAt(2, 4).Text)
 	}
-	if term.CellAt(16, 4).Rune != '┘' {
-		t.Errorf("BottomRight = %q, want '┘'", term.CellAt(16, 4).Rune)
+	if term.CellAt(16, 4).Text != "┘" {
+		t.Errorf("BottomRight = %q, want '┘'", term.CellAt(16, 4).Text)
 	}
 
 	// Check that "Title" appears in the top border
@@ -89,19 +89,19 @@ func TestIntegration_StyledTextInBox(t *testing.T) {
 	Render(term, buf)
 
 	// Verify box corners (rounded)
-	if term.CellAt(1, 1).Rune != '╭' {
-		t.Errorf("TopLeft = %q, want '╭'", term.CellAt(1, 1).Rune)
+	if term.CellAt(1, 1).Text != "╭" {
+		t.Errorf("TopLeft = %q, want '╭'", term.CellAt(1, 1).Text)
 	}
-	if term.CellAt(20, 1).Rune != '╮' {
-		t.Errorf("TopRight = %q, want '╮'", term.CellAt(20, 1).Rune)
+	if term.CellAt(20, 1).Text != "╮" {
+		t.Errorf("TopRight = %q, want '╮'", term.CellAt(20, 1).Text)
 	}
 
 	// Verify text
 	expected := "Hello, World!"
 	for i, r := range expected {
 		cell := term.CellAt(3+i, 3)
-		if cell.Rune != r {
-			t.Errorf("Text char %d = %q, want %q", i, cell.Rune, r)
+		if cell.Text != string(r) {
+			t.Errorf("Text char %d = %q, want %q", i, cell.Text, r)
 		}
 		if !cell.Style.HasAttr(AttrBold) {
 			t.Errorf("Text char %d should be bold", i)
@@ -128,23 +128,23 @@ func TestIntegration_WideCharacters(t *testing.T) {
 
 	// Verify wide characters
 	// "你好世界" = 4 wide chars = 8 columns
-	if term.CellAt(2, 1).Rune != '你' {
-		t.Errorf("Position 2 = %q, want '你'", term.CellAt(2, 1).Rune)
+	if term.CellAt(2, 1).Text != "你" {
+		t.Errorf("Position 2 = %q, want '你'", term.CellAt(2, 1).Text)
 	}
 	if !term.CellAt(3, 1).IsContinuation() {
 		t.Error("Position 3 should be continuation")
 	}
-	if term.CellAt(4, 1).Rune != '好' {
-		t.Errorf("Position 4 = %q, want '好'", term.CellAt(4, 1).Rune)
+	if term.CellAt(4, 1).Text != "好" {
+		t.Errorf("Position 4 = %q, want '好'", term.CellAt(4, 1).Text)
 	}
 	if !term.CellAt(5, 1).IsContinuation() {
 		t.Error("Position 5 should be continuation")
 	}
-	if term.CellAt(6, 1).Rune != '世' {
-		t.Errorf("Position 6 = %q, want '世'", term.CellAt(6, 1).Rune)
+	if term.CellAt(6, 1).Text != "世" {
+		t.Errorf("Position 6 = %q, want '世'", term.CellAt(6, 1).Text)
 	}
-	if term.CellAt(8, 1).Rune != '界' {
-		t.Errorf("Position 8 = %q, want '界'", term.CellAt(8, 1).Rune)
+	if term.CellAt(8, 1).Text != "界" {
+		t.Errorf("Position 8 = %q, want '界'", term.CellAt(8, 1).Text)
 	}
 }
 
@@ -158,7 +158,7 @@ func TestIntegration_ResizeAndRerender(t *testing.T) {
 	Render(term, buf)
 
 	// Verify initial render
-	if term.CellAt(0, 0).Rune != 'H' {
+	if term.CellAt(0, 0).Text != "H" {
 		t.Fatal("Initial render failed")
 	}
 
@@ -174,10 +174,10 @@ func TestIntegration_ResizeAndRerender(t *testing.T) {
 	Render(term, buf)
 
 	// Verify both old and new content
-	if term.CellAt(0, 0).Rune != 'H' {
+	if term.CellAt(0, 0).Text != "H" {
 		t.Error("Original content should be preserved")
 	}
-	if term.CellAt(10, 6).Rune != 'N' {
+	if term.CellAt(10, 6).Text != "N" {
 		t.Error("New content should be visible")
 	}
 }
@@ -201,8 +201,8 @@ func TestIntegration_DiffMinimalChanges(t *testing.T) {
 	if len(changes) != 1 {
 		t.Errorf("Diff() returned %d changes, want 1", len(changes))
 	}
-	if len(changes) > 0 && changes[0].Cell.Rune != 'B' {
-		t.Errorf("Change rune = %q, want 'B'", changes[0].Cell.Rune)
+	if len(changes) > 0 && changes[0].Cell.Text != "B" {
+		t.Errorf("Change rune = %q, want 'B'", changes[0].Cell.Text)
 	}
 }
 
@@ -239,10 +239,10 @@ func TestIntegration_RenderFull(t *testing.T) {
 	RenderFull(term, buf)
 
 	// Verify content is present
-	if term.CellAt(2, 2).Rune != 'T' {
+	if term.CellAt(2, 2).Text != "T" {
 		t.Error("RenderFull should render all content")
 	}
-	if term.CellAt(3, 2).Rune != 'e' {
+	if term.CellAt(3, 2).Text != "e" {
 		t.Error("RenderFull should render all content")
 	}
 }
@@ -262,13 +262,13 @@ func TestIntegration_ClearAndRedraw(t *testing.T) {
 	Render(term, buf)
 
 	// Verify new content
-	if term.CellAt(0, 0).Rune != 'W' {
-		t.Errorf("After clear, Cell(0, 0) = %q, want 'W'", term.CellAt(0, 0).Rune)
+	if term.CellAt(0, 0).Text != "W" {
+		t.Errorf("After clear, Cell(0, 0) = %q, want 'W'", term.CellAt(0, 0).Text)
 	}
 
 	// Verify old content is gone (position 4 was 'o' in "Hello", now 'd' in "World")
-	if term.CellAt(4, 0).Rune != 'd' {
-		t.Errorf("After clear, Cell(4, 0) = %q, want 'd'", term.CellAt(4, 0).Rune)
+	if term.CellAt(4, 0).Text != "d" {
+		t.Errorf("After clear, Cell(4, 0) = %q, want 'd'", term.CellAt(4, 0).Text)
 	}
 }
 
@@ -287,20 +287,20 @@ func TestIntegration_MultipleBorders(t *testing.T) {
 
 	// Verify each box type
 	// Single
-	if term.CellAt(0, 0).Rune != '┌' {
-		t.Errorf("Single top-left = %q, want '┌'", term.CellAt(0, 0).Rune)
+	if term.CellAt(0, 0).Text != "┌" {
+		t.Errorf("Single top-left = %q, want '┌'", term.CellAt(0, 0).Text)
 	}
 	// Double
-	if term.CellAt(12, 0).Rune != '╔' {
-		t.Errorf("Double top-left = %q, want '╔'", term.CellAt(12, 0).Rune)
+	if term.CellAt(12, 0).Text != "╔" {
+		t.Errorf("Double top-left = %q, want '╔'", term.CellAt(12, 0).Text)
 	}
 	// Rounded
-	if term.CellAt(0, 5).Rune != '╭' {
-		t.Errorf("Rounded top-left = %q, want '╭'", term.CellAt(0, 5).Rune)
+	if term.CellAt(0, 5).Text != "╭" {
+		t.Errorf("Rounded top-left = %q, want '╭'", term.CellAt(0, 5).Text)
 	}
 	// Thick
-	if term.CellAt(12, 5).Rune != '┏' {
-		t.Errorf("Thick top-left = %q, want '┏'", term.CellAt(12, 5).Rune)
+	if term.CellAt(12, 5).Text != "┏" {
+		t.Errorf("Thick top-left = %q, want '┏'", term.CellAt(12, 5).Text)
 	}
 }
 
@@ -321,18 +321,18 @@ func TestIntegration_NestedBoxes(t *testing.T) {
 	Render(term, buf)
 
 	// Verify outer box
-	if term.CellAt(0, 0).Rune != '╔' {
-		t.Errorf("Outer top-left = %q, want '╔'", term.CellAt(0, 0).Rune)
+	if term.CellAt(0, 0).Text != "╔" {
+		t.Errorf("Outer top-left = %q, want '╔'", term.CellAt(0, 0).Text)
 	}
 
 	// Verify inner box
-	if term.CellAt(2, 1).Rune != '┌' {
-		t.Errorf("Inner top-left = %q, want '┌'", term.CellAt(2, 1).Rune)
+	if term.CellAt(2, 1).Text != "┌" {
+		t.Errorf("Inner top-left = %q, want '┌'", term.CellAt(2, 1).Text)
 	}
 
 	// Verify content
-	if term.CellAt(4, 4).Rune != 'C' {
-		t.Errorf("Content = %q, want 'C'", term.CellAt(4, 4).Rune)
+	if term.CellAt(4, 4).Text != "C" {
+		t.Errorf("Content = %q, want 'C'", term.CellAt(4, 4).Text)
 	}
 }
 

--- a/app_render_test.go
+++ b/app_render_test.go
@@ -320,20 +320,20 @@ func TestRenderInline_PreservesEraseToEOL(t *testing.T) {
 
 	// After renderInline: tail must be blank (EraseToEOL cleared it).
 	for x := 2; x < w; x++ {
-		if c := term.CellAt(x, 0+inlineStartRow); c.Rune != ' ' {
+		if c := term.CellAt(x, 0+inlineStartRow); c.Text != " " {
 			t.Errorf("cell (%d, %d): got %q, want space — EraseToEOL not applied. "+
 				"Check app_render.go:128 copies EraseToEOL.",
-				x, 0+inlineStartRow, string(c.Rune))
+				x, 0+inlineStartRow, c.Text)
 			return
 		}
 	}
 
 	// Cols 0-1 ("hi") must be intact.
-	if c := term.CellAt(0, 0+inlineStartRow); c.Rune != 'h' {
-		t.Errorf("col 0: got %q, want 'h'", string(c.Rune))
+	if c := term.CellAt(0, 0+inlineStartRow); c.Text != "h" {
+		t.Errorf("col 0: got %q, want 'h'", c.Text)
 	}
-	if c := term.CellAt(1, 0+inlineStartRow); c.Rune != 'i' {
-		t.Errorf("col 1: got %q, want 'i'", string(c.Rune))
+	if c := term.CellAt(1, 0+inlineStartRow); c.Text != "i" {
+		t.Errorf("col 1: got %q, want 'i'", c.Text)
 	}
 }
 

--- a/border.go
+++ b/border.go
@@ -382,62 +382,72 @@ func DrawBoxWithTitle(buf *Buffer, rect Rect, border BorderStyle, title string, 
 	drawBoxTitle(buf, rect, title, style)
 }
 
+// titleCluster is one grapheme cluster of a border title with its display width.
+type titleCluster struct {
+	text  string
+	width int
+}
+
 // drawBoxTitle draws a centered title string on the top border line of the box.
 // drawBoxTitle does not draw the box itself — use DrawBoxWithTitle for that.
 func drawBoxTitle(buf *Buffer, rect Rect, title string, style Style) {
-	runes, startX, ok := prepareTitle(title, rect)
+	clusters, startX, ok := prepareTitle(title, rect)
 	if !ok {
 		return
 	}
 	x := startX
-	for _, r := range runes {
-		buf.SetRune(x, rect.Y, r, style)
-		x += RuneWidth(r)
+	for _, c := range clusters {
+		buf.setCluster(x, rect.Y, c.text, c.width, style, "")
+		x += c.width
 	}
 }
 
 // drawBoxTitleClipped draws a centered title string on the top border line,
-// skipping any rune outside the given clip rectangle.
+// skipping any cluster outside the given clip rectangle.
 func drawBoxTitleClipped(buf *Buffer, rect Rect, title string, style Style, clipRect Rect) {
 	// Reject if the title row is outside the clip rect's Y range.
 	if rect.Y < clipRect.Y || rect.Y >= clipRect.Y+clipRect.Height {
 		return
 	}
-	runes, startX, ok := prepareTitle(title, rect)
+	clusters, startX, ok := prepareTitle(title, rect)
 	if !ok {
 		return
 	}
 	x := startX
-	for _, r := range runes {
-		if x >= clipRect.X && x+RuneWidth(r) <= clipRect.X+clipRect.Width {
-			buf.SetRune(x, rect.Y, r, style)
+	for _, c := range clusters {
+		if x >= clipRect.X && x+c.width <= clipRect.X+clipRect.Width {
+			buf.setCluster(x, rect.Y, c.text, c.width, style, "")
 		}
-		x += RuneWidth(r)
+		x += c.width
 	}
 }
 
-// prepareTitle truncates and centers a title for the given rectangle.
-func prepareTitle(title string, rect Rect) (runes []rune, startX int, ok bool) {
+// prepareTitle truncates and centers a title for the given rectangle, breaking
+// on grapheme-cluster boundaries so a cluster is never split at the clip edge.
+func prepareTitle(title string, rect Rect) (clusters []titleCluster, startX int, ok bool) {
 	availableWidth := rect.Width - 2
 	if availableWidth <= 0 {
 		return nil, 0, false
 	}
-	titleRunes := []rune(title)
 	titleWidth := 0
-	truncatedRunes := make([]rune, 0, len(titleRunes))
-	for _, r := range titleRunes {
-		w := RuneWidth(r)
+	rest := title
+	for len(rest) > 0 {
+		cluster, w, size := nextCluster(rest)
+		if size == 0 {
+			break
+		}
 		if titleWidth+w > availableWidth {
 			break
 		}
-		truncatedRunes = append(truncatedRunes, r)
+		clusters = append(clusters, titleCluster{text: cluster, width: w})
 		titleWidth += w
+		rest = rest[size:]
 	}
-	if len(truncatedRunes) == 0 {
+	if len(clusters) == 0 {
 		return nil, 0, false
 	}
 	startX = rect.X + 1 + (availableWidth-titleWidth)/2
-	return truncatedRunes, startX, true
+	return clusters, startX, true
 }
 
 // FillBox fills the interior of a box (excluding the border) with a character and style.

--- a/border_test.go
+++ b/border_test.go
@@ -107,47 +107,47 @@ func TestDrawBox_SingleBorder(t *testing.T) {
 	DrawBox(buf, NewRect(1, 1, 5, 3), BorderSingle, style)
 
 	// Check corners
-	if buf.Cell(1, 1).Rune != '┌' {
-		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(1, 1).Rune)
+	if buf.Cell(1, 1).Text != "┌" {
+		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(1, 1).Text)
 	}
-	if buf.Cell(5, 1).Rune != '┐' {
-		t.Errorf("TopRight = %q, want '┐'", buf.Cell(5, 1).Rune)
+	if buf.Cell(5, 1).Text != "┐" {
+		t.Errorf("TopRight = %q, want '┐'", buf.Cell(5, 1).Text)
 	}
-	if buf.Cell(1, 3).Rune != '└' {
-		t.Errorf("BottomLeft = %q, want '└'", buf.Cell(1, 3).Rune)
+	if buf.Cell(1, 3).Text != "└" {
+		t.Errorf("BottomLeft = %q, want '└'", buf.Cell(1, 3).Text)
 	}
-	if buf.Cell(5, 3).Rune != '┘' {
-		t.Errorf("BottomRight = %q, want '┘'", buf.Cell(5, 3).Rune)
+	if buf.Cell(5, 3).Text != "┘" {
+		t.Errorf("BottomRight = %q, want '┘'", buf.Cell(5, 3).Text)
 	}
 
 	// Check top edge
 	for x := 2; x <= 4; x++ {
-		if buf.Cell(x, 1).Rune != '─' {
-			t.Errorf("Top edge at %d = %q, want '─'", x, buf.Cell(x, 1).Rune)
+		if buf.Cell(x, 1).Text != "─" {
+			t.Errorf("Top edge at %d = %q, want '─'", x, buf.Cell(x, 1).Text)
 		}
 	}
 
 	// Check bottom edge
 	for x := 2; x <= 4; x++ {
-		if buf.Cell(x, 3).Rune != '─' {
-			t.Errorf("Bottom edge at %d = %q, want '─'", x, buf.Cell(x, 3).Rune)
+		if buf.Cell(x, 3).Text != "─" {
+			t.Errorf("Bottom edge at %d = %q, want '─'", x, buf.Cell(x, 3).Text)
 		}
 	}
 
 	// Check left edge
-	if buf.Cell(1, 2).Rune != '│' {
-		t.Errorf("Left edge = %q, want '│'", buf.Cell(1, 2).Rune)
+	if buf.Cell(1, 2).Text != "│" {
+		t.Errorf("Left edge = %q, want '│'", buf.Cell(1, 2).Text)
 	}
 
 	// Check right edge
-	if buf.Cell(5, 2).Rune != '│' {
-		t.Errorf("Right edge = %q, want '│'", buf.Cell(5, 2).Rune)
+	if buf.Cell(5, 2).Text != "│" {
+		t.Errorf("Right edge = %q, want '│'", buf.Cell(5, 2).Text)
 	}
 
 	// Check interior is untouched (still spaces)
 	for x := 2; x <= 4; x++ {
-		if buf.Cell(x, 2).Rune != ' ' {
-			t.Errorf("Interior at (%d, 2) = %q, want ' '", x, buf.Cell(x, 2).Rune)
+		if buf.Cell(x, 2).Text != " " {
+			t.Errorf("Interior at (%d, 2) = %q, want ' '", x, buf.Cell(x, 2).Text)
 		}
 	}
 }
@@ -160,17 +160,17 @@ func TestDrawBox_MinimalSize(t *testing.T) {
 	DrawBox(buf, NewRect(1, 1, 2, 2), BorderSingle, style)
 
 	// Should draw just corners
-	if buf.Cell(1, 1).Rune != '┌' {
-		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(1, 1).Rune)
+	if buf.Cell(1, 1).Text != "┌" {
+		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(1, 1).Text)
 	}
-	if buf.Cell(2, 1).Rune != '┐' {
-		t.Errorf("TopRight = %q, want '┐'", buf.Cell(2, 1).Rune)
+	if buf.Cell(2, 1).Text != "┐" {
+		t.Errorf("TopRight = %q, want '┐'", buf.Cell(2, 1).Text)
 	}
-	if buf.Cell(1, 2).Rune != '└' {
-		t.Errorf("BottomLeft = %q, want '└'", buf.Cell(1, 2).Rune)
+	if buf.Cell(1, 2).Text != "└" {
+		t.Errorf("BottomLeft = %q, want '└'", buf.Cell(1, 2).Text)
 	}
-	if buf.Cell(2, 2).Rune != '┘' {
-		t.Errorf("BottomRight = %q, want '┘'", buf.Cell(2, 2).Rune)
+	if buf.Cell(2, 2).Text != "┘" {
+		t.Errorf("BottomRight = %q, want '┘'", buf.Cell(2, 2).Text)
 	}
 }
 
@@ -198,7 +198,7 @@ func TestDrawBox_TooSmall(t *testing.T) {
 			DrawBox(buf, NewRect(0, 0, tt.width, tt.height), BorderSingle, style)
 
 			// The 'X' should still be there (nothing drawn)
-			if buf.Cell(0, 0).Rune != 'X' {
+			if buf.Cell(0, 0).Text != "X" {
 				t.Error("DrawBox should do nothing for rect smaller than 2x2")
 			}
 		})
@@ -215,7 +215,7 @@ func TestDrawBox_BorderNone(t *testing.T) {
 	DrawBox(buf, NewRect(1, 1, 5, 3), BorderNone, style)
 
 	// The 'X' should still be there
-	if buf.Cell(1, 1).Rune != 'X' {
+	if buf.Cell(1, 1).Text != "X" {
 		t.Error("DrawBox with BorderNone should do nothing")
 	}
 }
@@ -247,21 +247,21 @@ func TestDrawBox_ClipsToBuffer(t *testing.T) {
 
 	// Only the visible portion should be drawn
 	// Top-left corner of the box at (5,5)
-	if buf.Cell(5, 5).Rune != '┌' {
-		t.Errorf("Visible top-left corner should be drawn, got %q", buf.Cell(5, 5).Rune)
+	if buf.Cell(5, 5).Text != "┌" {
+		t.Errorf("Visible top-left corner should be drawn, got %q", buf.Cell(5, 5).Text)
 	}
 	// Top edge
-	if buf.Cell(6, 5).Rune != '─' {
-		t.Errorf("Visible top edge should be drawn, got %q", buf.Cell(6, 5).Rune)
+	if buf.Cell(6, 5).Text != "─" {
+		t.Errorf("Visible top edge should be drawn, got %q", buf.Cell(6, 5).Text)
 	}
 	// Left edge
-	if buf.Cell(5, 6).Rune != '│' {
-		t.Errorf("Visible left edge should be drawn, got %q", buf.Cell(5, 6).Rune)
+	if buf.Cell(5, 6).Text != "│" {
+		t.Errorf("Visible left edge should be drawn, got %q", buf.Cell(5, 6).Text)
 	}
 	// The right and bottom edges are clipped but should still draw what's visible
 	// Right edge at x=9 (buffer boundary) - clipped to visible part
-	if buf.Cell(9, 5).Rune != '─' && buf.Cell(9, 5).Rune != '┐' {
-		t.Errorf("Right boundary should have border char, got %q", buf.Cell(9, 5).Rune)
+	if buf.Cell(9, 5).Text != "─" && buf.Cell(9, 5).Text != "┐" {
+		t.Errorf("Right boundary should have border char, got %q", buf.Cell(9, 5).Text)
 	}
 }
 
@@ -277,11 +277,11 @@ func TestDrawBoxWithTitle_Centered(t *testing.T) {
 	// Start position = 1 + (13-4)/2 = 1 + 4 = 5
 
 	// Check corners are still correct
-	if buf.Cell(0, 0).Rune != '┌' {
-		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Rune)
+	if buf.Cell(0, 0).Text != "┌" {
+		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Text)
 	}
-	if buf.Cell(14, 0).Rune != '┐' {
-		t.Errorf("TopRight = %q, want '┐'", buf.Cell(14, 0).Rune)
+	if buf.Cell(14, 0).Text != "┐" {
+		t.Errorf("TopRight = %q, want '┐'", buf.Cell(14, 0).Text)
 	}
 
 	// Check title is present
@@ -289,8 +289,8 @@ func TestDrawBoxWithTitle_Centered(t *testing.T) {
 	startX := 1 + (13-4)/2 // = 5
 	for i, r := range title {
 		cell := buf.Cell(startX+i, 0)
-		if cell.Rune != r {
-			t.Errorf("Title at %d = %q, want %q", startX+i, cell.Rune, r)
+		if cell.Text != string(r) {
+			t.Errorf("Title at %d = %q, want %q", startX+i, cell.Text, r)
 		}
 	}
 }
@@ -305,16 +305,16 @@ func TestDrawBoxWithTitle_LongTitle(t *testing.T) {
 	// Available width = 6 - 2 = 4
 	// Title should be truncated to fit
 	// Check that corners are intact
-	if buf.Cell(0, 0).Rune != '┌' {
-		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Rune)
+	if buf.Cell(0, 0).Text != "┌" {
+		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Text)
 	}
-	if buf.Cell(5, 0).Rune != '┐' {
-		t.Errorf("TopRight = %q, want '┐'", buf.Cell(5, 0).Rune)
+	if buf.Cell(5, 0).Text != "┐" {
+		t.Errorf("TopRight = %q, want '┐'", buf.Cell(5, 0).Text)
 	}
 
 	// Check that some of the title is visible
-	if buf.Cell(1, 0).Rune != 'V' {
-		t.Errorf("First title char = %q, want 'V'", buf.Cell(1, 0).Rune)
+	if buf.Cell(1, 0).Text != "V" {
+		t.Errorf("First title char = %q, want 'V'", buf.Cell(1, 0).Text)
 	}
 }
 
@@ -325,14 +325,14 @@ func TestDrawBoxWithTitle_EmptyTitle(t *testing.T) {
 	DrawBoxWithTitle(buf, NewRect(0, 0, 6, 3), BorderSingle, "", style)
 
 	// Should just draw a normal box
-	if buf.Cell(0, 0).Rune != '┌' {
-		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Rune)
+	if buf.Cell(0, 0).Text != "┌" {
+		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Text)
 	}
 
 	// Top edge should be all horizontal lines (no title)
 	for x := 1; x < 5; x++ {
-		if buf.Cell(x, 0).Rune != '─' {
-			t.Errorf("Top edge at %d = %q, want '─'", x, buf.Cell(x, 0).Rune)
+		if buf.Cell(x, 0).Text != "─" {
+			t.Errorf("Top edge at %d = %q, want '─'", x, buf.Cell(x, 0).Text)
 		}
 	}
 }
@@ -345,11 +345,11 @@ func TestDrawBoxWithTitle_TooSmallForTitle(t *testing.T) {
 	DrawBoxWithTitle(buf, NewRect(0, 0, 2, 2), BorderSingle, "X", style)
 
 	// Should still draw the box
-	if buf.Cell(0, 0).Rune != '┌' {
-		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Rune)
+	if buf.Cell(0, 0).Text != "┌" {
+		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Text)
 	}
-	if buf.Cell(1, 0).Rune != '┐' {
-		t.Errorf("TopRight = %q, want '┐'", buf.Cell(1, 0).Rune)
+	if buf.Cell(1, 0).Text != "┐" {
+		t.Errorf("TopRight = %q, want '┐'", buf.Cell(1, 0).Text)
 	}
 }
 
@@ -365,15 +365,15 @@ func TestDrawBoxWithTitle_WideCharTitle(t *testing.T) {
 	// Start position = 1 + (8-4)/2 = 1 + 2 = 3
 
 	// Check corners
-	if buf.Cell(0, 0).Rune != '┌' {
-		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Rune)
+	if buf.Cell(0, 0).Text != "┌" {
+		t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Text)
 	}
 
 	// Check that the wide characters are present
 	// They should be centered
 	found := false
 	for x := 1; x < 9; x++ {
-		if buf.Cell(x, 0).Rune == '你' {
+		if buf.Cell(x, 0).Text == "你" {
 			found = true
 			// Next cell should be continuation
 			if !buf.Cell(x+1, 0).IsContinuation() {
@@ -472,15 +472,15 @@ func TestDrawBoxClipped(t *testing.T) {
 			DrawBoxClipped(buf, tt.boxRect, BorderSingle, style, tt.clipRect)
 
 			for pos, wantRune := range tt.wantDrawn {
-				got := buf.Cell(pos[0], pos[1]).Rune
-				if got != wantRune {
+				got := buf.Cell(pos[0], pos[1]).Text
+				if got != string(wantRune) {
 					t.Errorf("(%d,%d) = %q, want %q", pos[0], pos[1], got, wantRune)
 				}
 			}
 
 			for _, pos := range tt.wantSpace {
-				got := buf.Cell(pos[0], pos[1]).Rune
-				if got != ' ' {
+				got := buf.Cell(pos[0], pos[1]).Text
+				if got != " " {
 					t.Errorf("clipped (%d,%d) = %q, want ' '", pos[0], pos[1], got)
 				}
 			}
@@ -501,24 +501,24 @@ func TestDrawBoxGradientClipped(t *testing.T) {
 	chars := BorderSingle.Chars()
 
 	// Top row (y=0) should be clipped
-	if buf.Cell(1, 0).Rune != ' ' {
-		t.Errorf("clipped top-left = %q, want ' '", buf.Cell(1, 0).Rune)
+	if buf.Cell(1, 0).Text != " " {
+		t.Errorf("clipped top-left = %q, want ' '", buf.Cell(1, 0).Text)
 	}
 
 	// Bottom row (y=3) should be drawn
-	if buf.Cell(1, 3).Rune != chars.BottomLeft {
-		t.Errorf("bottom-left = %q, want %q", buf.Cell(1, 3).Rune, chars.BottomLeft)
+	if buf.Cell(1, 3).Text != string(chars.BottomLeft) {
+		t.Errorf("bottom-left = %q, want %q", buf.Cell(1, 3).Text, chars.BottomLeft)
 	}
-	if buf.Cell(5, 3).Rune != chars.BottomRight {
-		t.Errorf("bottom-right = %q, want %q", buf.Cell(5, 3).Rune, chars.BottomRight)
+	if buf.Cell(5, 3).Text != string(chars.BottomRight) {
+		t.Errorf("bottom-right = %q, want %q", buf.Cell(5, 3).Text, chars.BottomRight)
 	}
 
 	// Side edges should be drawn at visible rows
-	if buf.Cell(1, 1).Rune != chars.Left {
-		t.Errorf("left edge at y=1 = %q, want %q", buf.Cell(1, 1).Rune, chars.Left)
+	if buf.Cell(1, 1).Text != string(chars.Left) {
+		t.Errorf("left edge at y=1 = %q, want %q", buf.Cell(1, 1).Text, chars.Left)
 	}
-	if buf.Cell(5, 2).Rune != chars.Right {
-		t.Errorf("right edge at y=2 = %q, want %q", buf.Cell(5, 2).Rune, chars.Right)
+	if buf.Cell(5, 2).Text != string(chars.Right) {
+		t.Errorf("right edge at y=2 = %q, want %q", buf.Cell(5, 2).Text, chars.Right)
 	}
 
 	// Verify gradient colors are non-default on visible border chars
@@ -543,14 +543,14 @@ func TestFillBox(t *testing.T) {
 	for y := 2; y <= 3; y++ {
 		for x := 2; x <= 5; x++ {
 			cell := buf.Cell(x, y)
-			if cell.Rune != '.' {
-				t.Errorf("Interior at (%d, %d) = %q, want '.'", x, y, cell.Rune)
+			if cell.Text != "." {
+				t.Errorf("Interior at (%d, %d) = %q, want '.'", x, y, cell.Text)
 			}
 		}
 	}
 
 	// Check border is unchanged
-	if buf.Cell(1, 1).Rune != '┌' {
+	if buf.Cell(1, 1).Text != "┌" {
 		t.Error("Border should be unchanged")
 	}
 }
@@ -564,7 +564,7 @@ func TestFillBox_TooSmall(t *testing.T) {
 	FillBox(buf, NewRect(0, 0, 2, 2), '.', style)
 
 	// Should do nothing
-	if buf.Cell(0, 0).Rune != 'X' {
+	if buf.Cell(0, 0).Text != "X" {
 		t.Error("FillBox should do nothing for box without interior")
 	}
 }

--- a/buffer.go
+++ b/buffer.go
@@ -298,54 +298,53 @@ func (b *Buffer) Fill(rect Rect, r rune, style Style) {
 	}
 }
 
-// SetStringGradient writes a string with a gradient applied per-character.
-// The gradient is applied horizontally along the string.
+// SetStringGradient writes a string with a gradient applied per grapheme cluster.
+// The gradient is applied horizontally along the string; each cluster (CJK, emoji,
+// flag, ZWJ family) gets a single color and occupies its full display width.
 // Returns the total display width consumed (handles wide characters).
 func (b *Buffer) SetStringGradient(x, y int, s string, g Gradient, baseStyle Style) int {
-	if y < 0 || y >= b.height {
+	if y < 0 || y >= b.height || s == "" {
 		return 0
 	}
 
-	runes := []rune(s)
-	if len(runes) == 0 {
-		return 0
-	}
-
+	total := clusterCount(s)
 	totalWidth := 0
 	curX := x
+	idx := 0
 
-	for i, r := range runes {
+	for len(s) > 0 {
+		cluster, width, size := nextCluster(s)
+		if size == 0 {
+			break
+		}
+		s = s[size:]
+
 		if curX >= b.width {
 			break
 		}
 		if curX < 0 {
-			// Skip characters before the visible area
-			curX += RuneWidth(r)
+			// Skip clusters before the visible area.
+			curX += width
+			idx++
 			continue
 		}
-
-		width := RuneWidth(r)
-
-		// Check if wide char fits
+		// Wide cluster that does not fit at the right edge: stop.
 		if width == 2 && curX+1 >= b.width {
-			// Wide char doesn't fit, stop here
 			break
 		}
 
-		// Calculate gradient position t in [0, 1]
-		t := float64(i) / float64(len(runes)-1)
-		if len(runes) == 1 {
-			t = 0
+		// Gradient position t in [0, 1], one step per cluster.
+		t := 0.0
+		if total > 1 {
+			t = float64(idx) / float64(total-1)
 		}
-
-		// Get gradient color and apply to style
-		gradColor := g.At(t)
 		style := baseStyle
-		style.Fg = gradColor
+		style.Fg = g.At(t)
 
-		b.SetRune(curX, y, r, style)
+		b.setCluster(curX, y, cluster, width, style, "")
 		curX += width
 		totalWidth += width
+		idx++
 	}
 
 	return totalWidth

--- a/buffer.go
+++ b/buffer.go
@@ -104,11 +104,18 @@ func (b *Buffer) SetCell(x, y int, c Cell) {
 // Handles wide characters by setting continuation cells.
 // Properly clears overlapped wide characters.
 func (b *Buffer) SetRune(x, y int, r rune, style Style) {
+	b.setCluster(x, y, string(r), RuneWidth(r), style, "")
+}
+
+// setCluster writes a grapheme cluster (text with display width 1 or 2) at
+// position (x, y) with the given style and optional hyperlink. It applies the
+// same overlap/continuation clearing as a single rune and clones text that is a
+// slice of a larger source so the cell owns its bytes.
+func (b *Buffer) setCluster(x, y int, text string, width int, style Style, link string) {
 	if x < 0 || x >= b.width || y < 0 || y >= b.height {
 		return
 	}
 
-	width := RuneWidth(r)
 	currentCell := b.Cell(x, y)
 
 	// If target position is a continuation cell, clear the originating wide char
@@ -141,8 +148,8 @@ func (b *Buffer) SetRune(x, y int, r rune, style Style) {
 		return
 	}
 
-	// Set the primary cell
-	b.SetCell(x, y, NewCellWithWidth(r, style, uint8(width)))
+	// Set the primary cell (cloning multi-rune text it owns).
+	b.SetCell(x, y, newClusterCell(text, uint8(width), style, link))
 
 	// Set continuation cell for wide characters
 	if width == 2 {
@@ -153,13 +160,7 @@ func (b *Buffer) SetRune(x, y int, r rune, style Style) {
 // SetRuneLink sets a rune like SetRune and, when link is non-empty, attaches it
 // as the cell's OSC 8 hyperlink target. Wide-character handling matches SetRune.
 func (b *Buffer) SetRuneLink(x, y int, r rune, style Style, link string) {
-	b.SetRune(x, y, r, style)
-	if link == "" {
-		return
-	}
-	if idx := b.idx(x, y); idx >= 0 {
-		b.back[idx].Link = link
-	}
+	b.setCluster(x, y, string(r), RuneWidth(r), style, link)
 }
 
 // clearWideCharAt clears a wide character that includes position (x, y).
@@ -195,25 +196,29 @@ func (b *Buffer) SetString(x, y int, s string, style Style) int {
 	totalWidth := 0
 	curX := x
 
-	for _, r := range s {
+	for len(s) > 0 {
+		cluster, width, size := nextCluster(s)
+		if size == 0 {
+			break
+		}
+		s = s[size:]
+
 		if curX >= b.width {
 			break
 		}
 		if curX < 0 {
-			// Skip characters before the visible area
-			curX += RuneWidth(r)
+			// Skip clusters before the visible area
+			curX += width
 			continue
 		}
 
-		width := RuneWidth(r)
-
-		// Check if wide char fits
+		// Check if wide cluster fits
 		if width == 2 && curX+1 >= b.width {
-			// Wide char doesn't fit, stop here
+			// Wide cluster doesn't fit, stop here
 			break
 		}
 
-		b.SetRune(curX, y, r, style)
+		b.setCluster(curX, y, cluster, width, style, "")
 		curX += width
 		totalWidth += width
 	}
@@ -232,8 +237,12 @@ func (b *Buffer) SetStringClipped(x, y int, s string, style Style, clipRect Rect
 	totalWidth := 0
 	curX := x
 
-	for _, r := range s {
-		width := RuneWidth(r)
+	for len(s) > 0 {
+		cluster, width, size := nextCluster(s)
+		if size == 0 {
+			break
+		}
+		s = s[size:]
 
 		// Skip if entirely before clip region
 		if curX+width <= clipRect.X {
@@ -248,13 +257,13 @@ func (b *Buffer) SetStringClipped(x, y int, s string, style Style, clipRect Rect
 
 		// Render if within clip (also check buffer bounds)
 		if curX >= clipRect.X && curX < clipRect.Right() {
-			// For wide characters, ensure both cells fit in clip region
+			// For wide clusters, ensure both cells fit in clip region
 			if width == 2 && curX+1 >= clipRect.Right() {
-				// Wide char doesn't fit, skip it
+				// Wide cluster doesn't fit, skip it
 				curX += width
 				continue
 			}
-			b.SetRune(curX, y, r, style)
+			b.setCluster(curX, y, cluster, width, style, "")
 			totalWidth += width
 		}
 
@@ -543,10 +552,10 @@ func (b *Buffer) String() string {
 			if cell.IsContinuation() {
 				continue // Skip continuation cells
 			}
-			if cell.Rune == 0 {
+			if cell.Text == "" {
 				sb.WriteRune(' ')
 			} else {
-				sb.WriteRune(cell.Rune)
+				sb.WriteString(cell.Text)
 			}
 		}
 		if y < b.height-1 {
@@ -566,10 +575,10 @@ func (b *Buffer) StringTrimmed() string {
 			if cell.IsContinuation() {
 				continue
 			}
-			if cell.Rune == 0 {
+			if cell.Text == "" {
 				line.WriteRune(' ')
 			} else {
-				line.WriteRune(cell.Rune)
+				line.WriteString(cell.Text)
 			}
 		}
 		sb.WriteString(strings.TrimRight(line.String(), " "))

--- a/buffer_diff_test.go
+++ b/buffer_diff_test.go
@@ -28,8 +28,8 @@ func TestBuffer_Diff_SingleChange(t *testing.T) {
 	if changes[0].X != 2 || changes[0].Y != 1 {
 		t.Errorf("Change at (%d, %d), want (2, 1)", changes[0].X, changes[0].Y)
 	}
-	if changes[0].Cell.Rune != 'A' {
-		t.Errorf("Change cell rune = %q, want 'A'", changes[0].Cell.Rune)
+	if changes[0].Cell.Text != "A" {
+		t.Errorf("Change cell rune = %q, want 'A'", changes[0].Cell.Text)
 	}
 }
 
@@ -60,8 +60,8 @@ func TestBuffer_Diff_MultipleChanges(t *testing.T) {
 		if changes[i].X != e.x || changes[i].Y != e.y {
 			t.Errorf("Change %d at (%d, %d), want (%d, %d)", i, changes[i].X, changes[i].Y, e.x, e.y)
 		}
-		if changes[i].Cell.Rune != e.r {
-			t.Errorf("Change %d rune = %q, want %q", i, changes[i].Cell.Rune, e.r)
+		if changes[i].Cell.Text != string(e.r) {
+			t.Errorf("Change %d rune = %q, want %q", i, changes[i].Cell.Text, e.r)
 		}
 	}
 }

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -71,8 +71,8 @@ func TestBuffer_InitializedWithSpaces(t *testing.T) {
 	for y := range 3 {
 		for x := range 5 {
 			cell := b.Cell(x, y)
-			if cell.Rune != ' ' {
-				t.Errorf("Cell(%d, %d).Rune = %q, want ' '", x, y, cell.Rune)
+			if cell.Text != " " {
+				t.Errorf("Cell(%d, %d).Rune = %q, want ' '", x, y, cell.Text)
 			}
 			if !cell.Style.Equal(defaultStyle) {
 				t.Errorf("Cell(%d, %d) has non-default style", x, y)
@@ -165,8 +165,8 @@ func TestBuffer_Fill(t *testing.T) {
 	for y := 1; y <= 2; y++ {
 		for x := 2; x <= 5; x++ {
 			cell := b.Cell(x, y)
-			if cell.Rune != '#' {
-				t.Errorf("Cell(%d, %d).Rune = %q, want '#'", x, y, cell.Rune)
+			if cell.Text != "#" {
+				t.Errorf("Cell(%d, %d).Rune = %q, want '#'", x, y, cell.Text)
 			}
 			if !cell.Style.Equal(style) {
 				t.Errorf("Cell(%d, %d) has wrong style", x, y)
@@ -175,10 +175,10 @@ func TestBuffer_Fill(t *testing.T) {
 	}
 
 	// Check unfilled area (outside rect)
-	if b.Cell(1, 1).Rune != ' ' {
+	if b.Cell(1, 1).Text != " " {
 		t.Error("Cell outside fill rect should be unchanged")
 	}
-	if b.Cell(6, 1).Rune != ' ' {
+	if b.Cell(6, 1).Text != " " {
 		t.Error("Cell outside fill rect should be unchanged")
 	}
 }
@@ -194,8 +194,8 @@ func TestBuffer_Fill_WideChar(t *testing.T) {
 	// Should have 3 wide chars (each taking 2 columns)
 	for i := range 3 {
 		x := i * 2
-		if b.Cell(x, 0).Rune != '好' {
-			t.Errorf("Cell(%d, 0).Rune = %q, want '好'", x, b.Cell(x, 0).Rune)
+		if b.Cell(x, 0).Text != "好" {
+			t.Errorf("Cell(%d, 0).Rune = %q, want '好'", x, b.Cell(x, 0).Text)
 		}
 		if !b.Cell(x+1, 0).IsContinuation() {
 			t.Errorf("Cell(%d, 0) should be continuation", x+1)
@@ -214,8 +214,8 @@ func TestBuffer_Fill_ClipsToBuffer(t *testing.T) {
 	// All cells should be filled
 	for y := range 3 {
 		for x := range 5 {
-			if b.Cell(x, y).Rune != 'X' {
-				t.Errorf("Cell(%d, %d).Rune = %q, want 'X'", x, y, b.Cell(x, y).Rune)
+			if b.Cell(x, y).Text != "X" {
+				t.Errorf("Cell(%d, %d).Rune = %q, want 'X'", x, y, b.Cell(x, y).Text)
 			}
 		}
 	}
@@ -240,8 +240,8 @@ func TestBuffer_Clear(t *testing.T) {
 	for y := range 3 {
 		for x := range 5 {
 			cell := b.Cell(x, y)
-			if cell.Rune != ' ' {
-				t.Errorf("Cell(%d, %d).Rune = %q, want ' '", x, y, cell.Rune)
+			if cell.Text != " " {
+				t.Errorf("Cell(%d, %d).Rune = %q, want ' '", x, y, cell.Text)
 			}
 			if !cell.Style.Equal(defaultStyle) {
 				t.Errorf("Cell(%d, %d) should have default style", x, y)
@@ -266,8 +266,8 @@ func TestBuffer_ClearRect(t *testing.T) {
 	for y := 1; y <= 2; y++ {
 		for x := 2; x <= 4; x++ {
 			cell := b.Cell(x, y)
-			if cell.Rune != ' ' {
-				t.Errorf("Cell(%d, %d).Rune = %q, want ' ' (cleared)", x, y, cell.Rune)
+			if cell.Text != " " {
+				t.Errorf("Cell(%d, %d).Rune = %q, want ' ' (cleared)", x, y, cell.Text)
 			}
 			if !cell.Style.Equal(defaultStyle) {
 				t.Errorf("Cell(%d, %d) should have default style", x, y)
@@ -276,10 +276,10 @@ func TestBuffer_ClearRect(t *testing.T) {
 	}
 
 	// Check non-cleared area
-	if b.Cell(1, 1).Rune != 'X' {
+	if b.Cell(1, 1).Text != "X" {
 		t.Error("Cell outside clear rect should be unchanged")
 	}
-	if b.Cell(5, 1).Rune != 'X' {
+	if b.Cell(5, 1).Text != "X" {
 		t.Error("Cell outside clear rect should be unchanged")
 	}
 }
@@ -297,13 +297,13 @@ func TestBuffer_ClearRect_ClearsWideCharEdges(t *testing.T) {
 	b.ClearRect(rect)
 
 	// Position 1 should be cleared (was start of wide char, continuation was in clear zone)
-	if b.Cell(1, 0).Rune != ' ' {
-		t.Errorf("Cell(1, 0).Rune = %q, want ' ' (wide char cleared)", b.Cell(1, 0).Rune)
+	if b.Cell(1, 0).Text != " " {
+		t.Errorf("Cell(1, 0).Rune = %q, want ' ' (wide char cleared)", b.Cell(1, 0).Text)
 	}
 
 	// Position 5 should be cleared (was continuation, start was in clear zone)
-	if b.Cell(5, 0).Rune != ' ' {
-		t.Errorf("Cell(5, 0).Rune = %q, want ' ' (continuation cleared)", b.Cell(5, 0).Rune)
+	if b.Cell(5, 0).Text != " " {
+		t.Errorf("Cell(5, 0).Rune = %q, want ' ' (continuation cleared)", b.Cell(5, 0).Text)
 	}
 }
 
@@ -323,16 +323,16 @@ func TestBuffer_Resize_Grow(t *testing.T) {
 	}
 
 	// Original content should be preserved
-	if b.Cell(0, 0).Rune != 'A' {
-		t.Errorf("Cell(0, 0).Rune = %q, want 'A'", b.Cell(0, 0).Rune)
+	if b.Cell(0, 0).Text != "A" {
+		t.Errorf("Cell(0, 0).Rune = %q, want 'A'", b.Cell(0, 0).Text)
 	}
-	if b.Cell(2, 1).Rune != 'B' {
-		t.Errorf("Cell(2, 1).Rune = %q, want 'B'", b.Cell(2, 1).Rune)
+	if b.Cell(2, 1).Text != "B" {
+		t.Errorf("Cell(2, 1).Rune = %q, want 'B'", b.Cell(2, 1).Text)
 	}
 
 	// New area should be spaces
-	if b.Cell(4, 3).Rune != ' ' {
-		t.Errorf("Cell(4, 3).Rune = %q, want ' '", b.Cell(4, 3).Rune)
+	if b.Cell(4, 3).Text != " " {
+		t.Errorf("Cell(4, 3).Rune = %q, want ' '", b.Cell(4, 3).Text)
 	}
 }
 
@@ -353,15 +353,15 @@ func TestBuffer_Resize_Shrink(t *testing.T) {
 	}
 
 	// Content within new bounds preserved
-	if b.Cell(0, 0).Rune != 'A' {
-		t.Errorf("Cell(0, 0).Rune = %q, want 'A'", b.Cell(0, 0).Rune)
+	if b.Cell(0, 0).Text != "A" {
+		t.Errorf("Cell(0, 0).Rune = %q, want 'A'", b.Cell(0, 0).Text)
 	}
-	if b.Cell(2, 1).Rune != 'M' {
-		t.Errorf("Cell(2, 1).Rune = %q, want 'M'", b.Cell(2, 1).Rune)
+	if b.Cell(2, 1).Text != "M" {
+		t.Errorf("Cell(2, 1).Rune = %q, want 'M'", b.Cell(2, 1).Text)
 	}
 
 	// Old position (4, 3) is now out of bounds
-	if b.Cell(4, 3).Rune != 0 {
+	if b.Cell(4, 3).Text != "" {
 		t.Error("Cell outside new bounds should return empty")
 	}
 }
@@ -378,7 +378,7 @@ func TestBuffer_Resize_SameSize(t *testing.T) {
 	if b.Width() != 5 || b.Height() != 3 {
 		t.Errorf("Size changed unexpectedly")
 	}
-	if b.Cell(2, 1).Rune != 'X' {
+	if b.Cell(2, 1).Text != "X" {
 		t.Errorf("Content changed unexpectedly")
 	}
 }
@@ -405,7 +405,7 @@ func TestBuffer_Resize_PreservesFrontBuffer(t *testing.T) {
 	// Should have change for 'B' at (1,0) since it wasn't swapped
 	found := false
 	for _, c := range changes {
-		if c.X == 1 && c.Y == 0 && c.Cell.Rune == 'B' {
+		if c.X == 1 && c.Y == 0 && c.Cell.Text == "B" {
 			found = true
 		}
 	}
@@ -450,8 +450,8 @@ func TestBuffer_SetStringGradient(t *testing.T) {
 			// Verify first character has start color
 			if len(tt.text) > 0 {
 				cell := buf.Cell(0, 0)
-				if cell.Rune != rune(tt.text[0]) {
-					t.Errorf("First cell rune = %c, want %c", cell.Rune, rune(tt.text[0]))
+				if cell.Text != tt.text[:1] {
+					t.Errorf("First cell rune = %s, want %s", cell.Text, tt.text[:1])
 				}
 			}
 		})
@@ -472,8 +472,8 @@ func TestBuffer_ApplyDim(t *testing.T) {
 	if !cell.Style.HasAttr(AttrBold) {
 		t.Error("expected cell to retain bold attribute after ApplyDim")
 	}
-	if cell.Rune != 'A' {
-		t.Errorf("expected rune 'A', got %q", cell.Rune)
+	if cell.Text != "A" {
+		t.Errorf("expected rune 'A', got %q", cell.Text)
 	}
 }
 
@@ -484,8 +484,8 @@ func TestBuffer_FillBlank(t *testing.T) {
 	buf.FillBlank()
 
 	cell := buf.Cell(0, 0)
-	if cell.Rune != ' ' {
-		t.Errorf("expected space after FillBlank, got %q", cell.Rune)
+	if cell.Text != " " {
+		t.Errorf("expected space after FillBlank, got %q", cell.Text)
 	}
 	if cell.Style != NewStyle() {
 		t.Error("expected default style after FillBlank")
@@ -534,12 +534,12 @@ func TestBuffer_FillGradient(t *testing.T) {
 func TestSetRuneLink(t *testing.T) {
 	buf := NewBuffer(4, 1)
 	buf.SetRuneLink(0, 0, 'a', NewStyle(), "https://example.com")
-	if got := buf.Cell(0, 0); got.Rune != 'a' || got.Link != "https://example.com" {
-		t.Errorf("got rune=%q link=%q, want 'a' / the URL", got.Rune, got.Link)
+	if got := buf.Cell(0, 0); got.Text != "a" || got.Link != "https://example.com" {
+		t.Errorf("got rune=%q link=%q, want 'a' / the URL", got.Text, got.Link)
 	}
 	// Empty link leaves Link clear (and still writes the rune).
 	buf.SetRuneLink(1, 0, 'b', NewStyle(), "")
-	if got := buf.Cell(1, 0); got.Rune != 'b' || got.Link != "" {
-		t.Errorf("got rune=%q link=%q, want 'b' / empty", got.Rune, got.Link)
+	if got := buf.Cell(1, 0); got.Text != "b" || got.Link != "" {
+		t.Errorf("got rune=%q link=%q, want 'b' / empty", got.Text, got.Link)
 	}
 }

--- a/buffer_text_test.go
+++ b/buffer_text_test.go
@@ -11,8 +11,8 @@ func TestBuffer_SetRune_ASCII(t *testing.T) {
 	b.SetRune(3, 2, 'A', style)
 
 	cell := b.Cell(3, 2)
-	if cell.Rune != 'A' {
-		t.Errorf("Cell(3, 2).Rune = %q, want 'A'", cell.Rune)
+	if cell.Text != "A" {
+		t.Errorf("Cell(3, 2).Rune = %q, want 'A'", cell.Text)
 	}
 	if !cell.Style.Equal(style) {
 		t.Error("Cell(3, 2) has wrong style")
@@ -25,8 +25,8 @@ func TestBuffer_SetRune_ASCII(t *testing.T) {
 	neighbors := []struct{ x, y int }{{2, 2}, {4, 2}, {3, 1}, {3, 3}}
 	for _, n := range neighbors {
 		c := b.Cell(n.x, n.y)
-		if c.Rune != ' ' {
-			t.Errorf("Cell(%d, %d).Rune = %q, want ' ' (unchanged)", n.x, n.y, c.Rune)
+		if c.Text != " " {
+			t.Errorf("Cell(%d, %d).Rune = %q, want ' ' (unchanged)", n.x, n.y, c.Text)
 		}
 	}
 }
@@ -39,8 +39,8 @@ func TestBuffer_SetRune_WideChar(t *testing.T) {
 
 	// Primary cell
 	cell := b.Cell(3, 2)
-	if cell.Rune != '你' {
-		t.Errorf("Cell(3, 2).Rune = %q, want '你'", cell.Rune)
+	if cell.Text != "你" {
+		t.Errorf("Cell(3, 2).Rune = %q, want '你'", cell.Text)
 	}
 	if cell.Width != 2 {
 		t.Errorf("Cell(3, 2).Width = %d, want 2", cell.Width)
@@ -51,8 +51,8 @@ func TestBuffer_SetRune_WideChar(t *testing.T) {
 	if !cont.IsContinuation() {
 		t.Error("Cell(4, 2) should be a continuation cell")
 	}
-	if cont.Rune != 0 {
-		t.Errorf("Cell(4, 2).Rune = %q, want 0", cont.Rune)
+	if cont.Text != "" {
+		t.Errorf("Cell(4, 2).Rune = %q, want 0", cont.Text)
 	}
 	if cont.Width != 0 {
 		t.Errorf("Cell(4, 2).Width = %d, want 0", cont.Width)
@@ -67,7 +67,7 @@ func TestBuffer_SetRune_OverwriteContinuation(t *testing.T) {
 	b.SetRune(2, 0, '好', style)
 
 	// Verify initial state
-	if b.Cell(2, 0).Rune != '好' {
+	if b.Cell(2, 0).Text != "好" {
 		t.Fatal("Failed to set initial wide char")
 	}
 	if !b.Cell(3, 0).IsContinuation() {
@@ -78,13 +78,13 @@ func TestBuffer_SetRune_OverwriteContinuation(t *testing.T) {
 	b.SetRune(3, 0, 'X', style)
 
 	// The wide char should be cleared (replaced with space)
-	if b.Cell(2, 0).Rune != ' ' {
-		t.Errorf("Cell(2, 0).Rune = %q, want ' ' (cleared)", b.Cell(2, 0).Rune)
+	if b.Cell(2, 0).Text != " " {
+		t.Errorf("Cell(2, 0).Rune = %q, want ' ' (cleared)", b.Cell(2, 0).Text)
 	}
 
 	// Position 3 should now have 'X'
-	if b.Cell(3, 0).Rune != 'X' {
-		t.Errorf("Cell(3, 0).Rune = %q, want 'X'", b.Cell(3, 0).Rune)
+	if b.Cell(3, 0).Text != "X" {
+		t.Errorf("Cell(3, 0).Rune = %q, want 'X'", b.Cell(3, 0).Text)
 	}
 }
 
@@ -99,13 +99,13 @@ func TestBuffer_SetRune_OverwriteWideCharStart(t *testing.T) {
 	b.SetRune(2, 0, 'Y', style)
 
 	// Position 2 should now have 'Y'
-	if b.Cell(2, 0).Rune != 'Y' {
-		t.Errorf("Cell(2, 0).Rune = %q, want 'Y'", b.Cell(2, 0).Rune)
+	if b.Cell(2, 0).Text != "Y" {
+		t.Errorf("Cell(2, 0).Rune = %q, want 'Y'", b.Cell(2, 0).Text)
 	}
 
 	// Position 3 should be cleared (the continuation was replaced)
-	if b.Cell(3, 0).Rune != ' ' {
-		t.Errorf("Cell(3, 0).Rune = %q, want ' ' (cleared)", b.Cell(3, 0).Rune)
+	if b.Cell(3, 0).Text != " " {
+		t.Errorf("Cell(3, 0).Rune = %q, want ' ' (cleared)", b.Cell(3, 0).Text)
 	}
 }
 
@@ -121,16 +121,16 @@ func TestBuffer_SetRune_WideCharOverlapExisting(t *testing.T) {
 	b.SetRune(2, 0, '文', style)
 
 	// Position 2 should have '文'
-	if b.Cell(2, 0).Rune != '文' {
-		t.Errorf("Cell(2, 0).Rune = %q, want '文'", b.Cell(2, 0).Rune)
+	if b.Cell(2, 0).Text != "文" {
+		t.Errorf("Cell(2, 0).Rune = %q, want '文'", b.Cell(2, 0).Text)
 	}
 	// Position 3 should be continuation of '文'
 	if !b.Cell(3, 0).IsContinuation() {
 		t.Error("Cell(3, 0) should be continuation")
 	}
 	// Position 4 should be cleared (was continuation of '中')
-	if b.Cell(4, 0).Rune != ' ' {
-		t.Errorf("Cell(4, 0).Rune = %q, want ' ' (cleared)", b.Cell(4, 0).Rune)
+	if b.Cell(4, 0).Text != " " {
+		t.Errorf("Cell(4, 0).Rune = %q, want ' ' (cleared)", b.Cell(4, 0).Text)
 	}
 }
 
@@ -143,8 +143,8 @@ func TestBuffer_SetRune_WideCharAtLastColumn(t *testing.T) {
 
 	// Should place a space instead (wide char doesn't fit)
 	cell := b.Cell(4, 0)
-	if cell.Rune != ' ' {
-		t.Errorf("Cell(4, 0).Rune = %q, want ' ' (wide char doesn't fit)", cell.Rune)
+	if cell.Text != " " {
+		t.Errorf("Cell(4, 0).Rune = %q, want ' ' (wide char doesn't fit)", cell.Text)
 	}
 }
 
@@ -161,8 +161,8 @@ func TestBuffer_SetString_ASCII(t *testing.T) {
 	expected := "Hello"
 	for i, r := range expected {
 		cell := b.Cell(2+i, 1)
-		if cell.Rune != r {
-			t.Errorf("Cell(%d, 1).Rune = %q, want %q", 2+i, cell.Rune, r)
+		if cell.Text != string(r) {
+			t.Errorf("Cell(%d, 1).Rune = %q, want %q", 2+i, cell.Text, r)
 		}
 		if !cell.Style.Equal(style) {
 			t.Errorf("Cell(%d, 1) has wrong style", 2+i)
@@ -182,19 +182,19 @@ func TestBuffer_SetString_MixedWidths(t *testing.T) {
 	}
 
 	// Check each position
-	if b.Cell(0, 0).Rune != 'H' {
+	if b.Cell(0, 0).Text != "H" {
 		t.Error("Position 0 should be 'H'")
 	}
-	if b.Cell(1, 0).Rune != 'i' {
+	if b.Cell(1, 0).Text != "i" {
 		t.Error("Position 1 should be 'i'")
 	}
-	if b.Cell(2, 0).Rune != '你' {
+	if b.Cell(2, 0).Text != "你" {
 		t.Error("Position 2 should be '你'")
 	}
 	if !b.Cell(3, 0).IsContinuation() {
 		t.Error("Position 3 should be continuation")
 	}
-	if b.Cell(4, 0).Rune != '好' {
+	if b.Cell(4, 0).Text != "好" {
 		t.Error("Position 4 should be '好'")
 	}
 	if !b.Cell(5, 0).IsContinuation() {
@@ -216,8 +216,8 @@ func TestBuffer_SetString_Truncation(t *testing.T) {
 	// Only "Hello" should fit
 	expected := "Hello"
 	for i, r := range expected {
-		if b.Cell(i, 0).Rune != r {
-			t.Errorf("Cell(%d, 0).Rune = %q, want %q", i, b.Cell(i, 0).Rune, r)
+		if b.Cell(i, 0).Text != string(r) {
+			t.Errorf("Cell(%d, 0).Rune = %q, want %q", i, b.Cell(i, 0).Text, r)
 		}
 	}
 }
@@ -251,8 +251,8 @@ func TestBuffer_SetString_NegativeStart(t *testing.T) {
 	if width != 3 {
 		t.Errorf("SetString returned width %d, want 3", width)
 	}
-	if b.Cell(0, 0).Rune != 'l' {
-		t.Errorf("Cell(0, 0).Rune = %q, want 'l'", b.Cell(0, 0).Rune)
+	if b.Cell(0, 0).Text != "l" {
+		t.Errorf("Cell(0, 0).Rune = %q, want 'l'", b.Cell(0, 0).Text)
 	}
 }
 
@@ -281,13 +281,13 @@ func TestBuffer_WideChar_ChainedOverwrite(t *testing.T) {
 	b.SetRune(4, 0, '吗', style) // occupies 4-5
 
 	// Verify initial state
-	if b.Cell(0, 0).Rune != '你' {
+	if b.Cell(0, 0).Text != "你" {
 		t.Error("Initial: position 0 should be '你'")
 	}
-	if b.Cell(2, 0).Rune != '好' {
+	if b.Cell(2, 0).Text != "好" {
 		t.Error("Initial: position 2 should be '好'")
 	}
-	if b.Cell(4, 0).Rune != '吗' {
+	if b.Cell(4, 0).Text != "吗" {
 		t.Error("Initial: position 4 should be '吗'")
 	}
 
@@ -296,18 +296,18 @@ func TestBuffer_WideChar_ChainedOverwrite(t *testing.T) {
 	b.SetRune(3, 0, 'Y', style)
 
 	// Position 2 should be X, position 3 should be Y
-	if b.Cell(2, 0).Rune != 'X' {
-		t.Errorf("Cell(2, 0).Rune = %q, want 'X'", b.Cell(2, 0).Rune)
+	if b.Cell(2, 0).Text != "X" {
+		t.Errorf("Cell(2, 0).Rune = %q, want 'X'", b.Cell(2, 0).Text)
 	}
-	if b.Cell(3, 0).Rune != 'Y' {
-		t.Errorf("Cell(3, 0).Rune = %q, want 'Y'", b.Cell(3, 0).Rune)
+	if b.Cell(3, 0).Text != "Y" {
+		t.Errorf("Cell(3, 0).Rune = %q, want 'Y'", b.Cell(3, 0).Text)
 	}
 
 	// Surrounding wide chars should still be intact
-	if b.Cell(0, 0).Rune != '你' {
-		t.Errorf("Cell(0, 0).Rune = %q, want '你'", b.Cell(0, 0).Rune)
+	if b.Cell(0, 0).Text != "你" {
+		t.Errorf("Cell(0, 0).Rune = %q, want '你'", b.Cell(0, 0).Text)
 	}
-	if b.Cell(4, 0).Rune != '吗' {
-		t.Errorf("Cell(4, 0).Rune = %q, want '吗'", b.Cell(4, 0).Rune)
+	if b.Cell(4, 0).Text != "吗" {
+		t.Errorf("Cell(4, 0).Rune = %q, want '吗'", b.Cell(4, 0).Text)
 	}
 }

--- a/cell.go
+++ b/cell.go
@@ -163,6 +163,10 @@ var emojiWideRanges = []runeRange{
 	{min: 0x1FA70, max: 0x1FAFF}, // Symbols/pictographs ext. A
 }
 
+// isZeroWidthRune feeds the per-rune RuneWidth fallback only, where the broad
+// unicode.Cf is harmless. It is intentionally broader than graphemeExtend in
+// grapheme.go (which excludes general Cf for cluster boundaries); do not unify
+// the two.
 func isZeroWidthRune(r rune) bool {
 	return unicode.In(r, unicode.Mn, unicode.Me, unicode.Cf, unicode.Variation_Selector, unicode.Join_Control)
 }

--- a/cell.go
+++ b/cell.go
@@ -1,33 +1,68 @@
 package tui
 
-import "unicode"
+import (
+	"strings"
+	"unicode"
+)
 
 // Cell represents a single character cell in the terminal buffer.
-// Wide characters (CJK, emoji) occupy multiple cells; the first cell holds
-// the rune, subsequent cells are marked as continuations.
+// Wide characters (CJK, emoji) and grapheme clusters (flags, ZWJ families,
+// skin-tone emoji, accented letters) occupy multiple cells; the first cell
+// holds the cluster's text, subsequent cells are marked as continuations.
+//
+// Cells own their text: a single rune is stored as string(r) (ASCII is
+// staticbytes-backed, no allocation) and a multi-rune cluster sliced from a
+// larger source is cloned before storage, so front/back buffers never pin a
+// large source string alive.
 type Cell struct {
-	Rune  rune   // The character (0 for continuation cells)
+	Text  string // The cluster's display text ("" for continuation/blank cells)
 	Style Style  // Visual styling
 	Width uint8  // Display width (1 or 2; 0 for continuation)
 	Link  string // Optional OSC 8 hyperlink target ("" = none)
 }
 
-// NewCell creates a new Cell with automatic width detection.
+// NewCell creates a new Cell from a single rune with automatic width detection.
 func NewCell(r rune, style Style) Cell {
 	return Cell{
-		Rune:  r,
+		Text:  string(r),
 		Style: style,
 		Width: uint8(RuneWidth(r)),
 	}
 }
 
-// NewCellWithWidth creates a new Cell with an explicit width.
+// NewCellWithWidth creates a new Cell from a single rune with an explicit width.
 // Use this for continuation cells (width 0) or when width is already known.
+// A continuation cell (width 0) or a zero rune stores empty text, so the cell
+// reads as empty.
 func NewCellWithWidth(r rune, style Style, width uint8) Cell {
+	text := ""
+	if width != 0 && r != 0 {
+		text = string(r)
+	}
 	return Cell{
-		Rune:  r,
+		Text:  text,
 		Style: style,
 		Width: width,
+	}
+}
+
+// newClusterCell creates a Cell holding a multi-rune (or single-rune) grapheme
+// cluster. The text is cloned when it is a slice of a larger source so the cell
+// owns an independent backing array. Pass width 0 for continuation cells.
+func newClusterCell(text string, width uint8, style Style, link string) Cell {
+	if width != 0 && len(text) > 0 {
+		// Clone multi-byte text sliced from a larger source so the cell does not
+		// pin the source alive. A single ASCII byte is staticbytes-backed; a
+		// single multibyte rune is short enough that cloning is cheap and safe.
+		text = strings.Clone(text)
+	} else if width == 0 {
+		text = ""
+	}
+	return Cell{
+		Text:  text,
+		Style: style,
+		Width: width,
+		Link:  link,
 	}
 }
 
@@ -39,18 +74,18 @@ func (c Cell) IsContinuation() bool {
 
 // Equal returns true if both cells are identical.
 func (c Cell) Equal(other Cell) bool {
-	return c.Rune == other.Rune && c.Style.Equal(other.Style) && c.Width == other.Width && c.Link == other.Link
+	return c.Text == other.Text && c.Style.Equal(other.Style) && c.Width == other.Width && c.Link == other.Link
 }
 
 // IsEmpty returns true if this cell represents an empty/blank cell.
-// A cell is empty if it's a space (or zero rune) with default styling.
+// A cell is empty if its text is empty (or a single space) with default styling.
 func (c Cell) IsEmpty() bool {
-	// Zero rune with any style is considered empty
-	if c.Rune == 0 {
+	// Empty text (zero/continuation cell) is considered empty
+	if c.Text == "" {
 		return true
 	}
 	// Space with default style is considered empty
-	if c.Rune == ' ' {
+	if c.Text == " " {
 		return c.Style.Equal(NewStyle())
 	}
 	return false

--- a/cell_test.go
+++ b/cell_test.go
@@ -37,8 +37,8 @@ func TestNewCell(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := NewCell(tt.r, tt.style)
-			if c.Rune != tt.r {
-				t.Errorf("NewCell().Rune = %q, want %q", c.Rune, tt.r)
+			if c.Text != string(tt.r) {
+				t.Errorf("NewCell().Text = %q, want %q", c.Text, string(tt.r))
 			}
 			if !c.Style.Equal(tt.style) {
 				t.Errorf("NewCell().Style doesn't match expected style")
@@ -53,10 +53,10 @@ func TestNewCell(t *testing.T) {
 func TestNewCellWithWidth(t *testing.T) {
 	style := NewStyle().Foreground(Red)
 
-	// Test explicit width for continuation cell
+	// Test explicit width for continuation cell (empty text)
 	c := NewCellWithWidth(0, style, 0)
-	if c.Rune != 0 {
-		t.Errorf("NewCellWithWidth().Rune = %q, want 0", c.Rune)
+	if c.Text != "" {
+		t.Errorf("NewCellWithWidth().Text = %q, want \"\"", c.Text)
 	}
 	if c.Width != 0 {
 		t.Errorf("NewCellWithWidth().Width = %d, want 0", c.Width)
@@ -344,8 +344,8 @@ func TestCell_ZeroValue(t *testing.T) {
 	var c Cell
 
 	// Zero value cell
-	if c.Rune != 0 {
-		t.Errorf("zero value Cell.Rune = %q, want 0", c.Rune)
+	if c.Text != "" {
+		t.Errorf("zero value Cell.Text = %q, want \"\"", c.Text)
 	}
 	if c.Width != 0 {
 		t.Errorf("zero value Cell.Width = %d, want 0", c.Width)

--- a/element_accessors.go
+++ b/element_accessors.go
@@ -168,10 +168,18 @@ func (e *Element) Component() Component {
 }
 
 // stringWidth returns the display width of a string in terminal cells.
+// Width is measured per grapheme cluster, so a flag, ZWJ family emoji, skin-tone
+// emoji, or decomposed accented letter counts as the single glyph the terminal
+// paints rather than the sum of its code points.
 func stringWidth(s string) int {
 	width := 0
-	for _, r := range s {
-		width += RuneWidth(r)
+	for len(s) > 0 {
+		_, cw, size := nextCluster(s)
+		if size == 0 {
+			break
+		}
+		width += cw
+		s = s[size:]
 	}
 	return width
 }

--- a/element_integration_render_test.go
+++ b/element_integration_render_test.go
@@ -134,7 +134,7 @@ func TestIntegration_RenderOutput(t *testing.T) {
 		var row strings.Builder
 		for x := range 10 {
 			cell := buf.Cell(x, y)
-			row.WriteRune(cell.Rune)
+			row.WriteString(cell.Text)
 		}
 		if row.String() != expected[y] {
 			t.Errorf("row %d = %q, want %q", y, row.String(), expected[y])
@@ -249,8 +249,8 @@ func extractBufferLine(buf *Buffer, y, width int) string {
 	var b strings.Builder
 	for x := range width {
 		cell := buf.Cell(x, y)
-		if cell.Rune != 0 {
-			b.WriteRune(cell.Rune)
+		if cell.Text != "" {
+			b.WriteString(cell.Text)
 		} else {
 			b.WriteByte(' ')
 		}
@@ -304,7 +304,7 @@ func TestIntegration_TextAlignment(t *testing.T) {
 			// Find where 'H' appears
 			foundX := -1
 			for x := 0; x < tt.boxWidth; x++ {
-				if buf.Cell(x, 0).Rune == 'H' {
+				if buf.Cell(x, 0).Text == "H" {
 					foundX = x
 					break
 				}

--- a/element_integration_test.go
+++ b/element_integration_test.go
@@ -35,8 +35,8 @@ func TestIntegration_BasicFlow(t *testing.T) {
 
 	// Verify border was rendered (check top-left corner)
 	cell := buf.Cell(panelRect.X, panelRect.Y)
-	if cell.Rune != '┌' {
-		t.Errorf("top-left cell = %q, want '┌'", cell.Rune)
+	if cell.Text != "┌" {
+		t.Errorf("top-left cell = %q, want '┌'", cell.Text)
 	}
 }
 
@@ -264,8 +264,8 @@ func TestIntegration_MixedElementAndText(t *testing.T) {
 
 	// Check border was drawn
 	topLeft := buf.Cell(panelRect.X, panelRect.Y)
-	if topLeft.Rune != '╭' {
-		t.Errorf("border top-left = %q, want '╭'", topLeft.Rune)
+	if topLeft.Text != "╭" {
+		t.Errorf("border top-left = %q, want '╭'", topLeft.Text)
 	}
 
 	// Verify text was rendered
@@ -277,7 +277,7 @@ func TestIntegration_MixedElementAndText(t *testing.T) {
 	foundX := -1
 	for y := contentRect.Y; y < contentRect.Bottom(); y++ {
 		for x := contentRect.X; x < contentRect.Right(); x++ {
-			if buf.Cell(x, y).Rune == 'H' {
+			if buf.Cell(x, y).Text == "H" {
 				found = true
 				foundX = x
 				break
@@ -322,14 +322,14 @@ func TestIntegration_BackgroundAndBorder(t *testing.T) {
 
 	interiorCell := buf.Cell(interiorX, interiorY)
 	// Background should be space with blue background
-	if interiorCell.Rune != ' ' {
-		t.Errorf("interior cell rune = %q, want ' '", interiorCell.Rune)
+	if interiorCell.Text != " " {
+		t.Errorf("interior cell rune = %q, want ' '", interiorCell.Text)
 	}
 
 	// Check border style (red foreground)
 	borderCell := buf.Cell(panel.Rect().X, panel.Rect().Y)
-	if borderCell.Rune != '┌' {
-		t.Errorf("border cell = %q, want '┌'", borderCell.Rune)
+	if borderCell.Text != "┌" {
+		t.Errorf("border cell = %q, want '┌'", borderCell.Text)
 	}
 	if borderCell.Style.Fg != Red {
 		t.Errorf("border foreground = %d, want %d (Red)", borderCell.Style.Fg, Red)

--- a/element_render.go
+++ b/element_render.go
@@ -336,18 +336,26 @@ func renderClippedElement(buf *Buffer, e *Element, clipRect Rect, scrollX, scrol
 			}
 
 			if needPerCell {
-				runes := []rune(line)
-				if len(runes) > 0 {
+				totalClusters := clusterCount(line)
+				if totalClusters > 0 {
 					curX := textX
-					for i, r := range runes {
+					rest := line
+					clusterIdx := 0
+					for len(rest) > 0 {
+						cluster, width, size := nextCluster(rest)
+						if size == 0 {
+							break
+						}
+						rest = rest[size:]
+						idx := clusterIdx
+						clusterIdx++
 						if curX >= clipRect.Right() {
 							break
 						}
 						if curX < clipRect.X {
-							curX += RuneWidth(r)
+							curX += width
 							continue
 						}
-						width := RuneWidth(r)
 						if width == 2 && curX+1 >= clipRect.Right() {
 							break
 						}
@@ -360,13 +368,13 @@ func renderClippedElement(buf *Buffer, e *Element, clipRect Rect, scrollX, scrol
 								}
 							}
 							if e.textGradient != nil {
-								t := float64(i) / float64(len(runes)-1)
-								if len(runes) == 1 {
+								t := float64(idx) / float64(totalClusters-1)
+								if totalClusters == 1 {
 									t = 0
 								}
 								style.Fg = e.textGradient.At(t)
 							}
-							buf.SetRune(curX, textY, r, style)
+							buf.setCluster(curX, textY, cluster, width, style, "")
 						}
 						curX += width
 					}
@@ -438,15 +446,20 @@ func truncateText(text string, maxWidth int) string {
 	if textWidth <= maxWidth {
 		return text
 	}
-	// Need to truncate: fit as many runes as possible + ellipsis (1 cell wide)
-	runes := []rune(text)
+	// Need to truncate: fit as many clusters as possible + ellipsis (1 cell wide),
+	// never splitting a cluster.
 	curWidth := 0
-	for i, r := range runes {
-		w := RuneWidth(r)
+	consumed := 0
+	for consumed < len(text) {
+		_, w, size := nextCluster(text[consumed:])
+		if size == 0 {
+			break
+		}
 		if curWidth+w+1 > maxWidth { // +1 for ellipsis
-			return string(runes[:i]) + "…"
+			return text[:consumed] + "…"
 		}
 		curWidth += w
+		consumed += size
 	}
 	return text
 }
@@ -529,16 +542,17 @@ func renderTextContent(buf *Buffer, e *Element, textStyle Style, bg *Style) {
 		maxLines = contentRect.Height
 	}
 
-	// Total rune count across visible lines (for gradient calculation)
-	totalRunes := 0
+	// Total cluster count across visible lines (for gradient calculation).
+	// One gradient color is applied per cluster.
+	totalClusters := 0
 	if e.textGradient != nil {
 		for i := startLine; i < startLine+maxLines && i < len(lines); i++ {
-			totalRunes += len([]rune(lines[i]))
+			totalClusters += clusterCount(lines[i])
 		}
 	}
 
 	needPerCell := e.textGradient != nil || ts.Bg.IsDefault()
-	runeOffset := 0 // running offset for gradient
+	clusterOffset := 0 // running offset for gradient
 
 	for lineIdx := 0; lineIdx < maxLines; lineIdx++ {
 		srcIdx := startLine + lineIdx
@@ -566,11 +580,16 @@ func renderTextContent(buf *Buffer, e *Element, textStyle Style, bg *Style) {
 
 		if needPerCell {
 			curX := x
-			for _, r := range line {
+			rest := line
+			for len(rest) > 0 {
+				cluster, width, size := nextCluster(rest)
+				if size == 0 {
+					break
+				}
+				rest = rest[size:]
 				if curX >= contentRect.Right() {
 					break
 				}
-				width := RuneWidth(r)
 				if width == 2 && curX+1 >= contentRect.Right() {
 					break
 				}
@@ -583,13 +602,13 @@ func renderTextContent(buf *Buffer, e *Element, textStyle Style, bg *Style) {
 				}
 				if e.textGradient != nil {
 					t := 0.0
-					if totalRunes > 1 {
-						t = float64(runeOffset) / float64(totalRunes-1)
+					if totalClusters > 1 {
+						t = float64(clusterOffset) / float64(totalClusters-1)
 					}
 					style.Fg = e.textGradient.At(t)
-					runeOffset++
+					clusterOffset++
 				}
-				buf.SetRune(curX, y, r, style)
+				buf.setCluster(curX, y, cluster, width, style, "")
 				curX += width
 			}
 		} else {
@@ -619,30 +638,30 @@ nextLine:
 				x += contentWidth - lw
 			}
 		}
-		for _, span := range line {
-			st := mergeSpanStyle(base, span.Style)
-			for _, r := range span.Text {
-				// Reached the right clip edge: clip this line and move to the
-				// next one (matching the plain-text paths' per-line break),
-				// rather than abandoning all remaining lines.
-				if x >= clip.Right() {
-					continue nextLine
-				}
-				w := RuneWidth(r)
-				if w == 2 && x+1 >= clip.Right() {
-					continue nextLine
-				}
-				if x >= clip.X {
-					style := st
-					if style.Bg.IsDefault() {
-						if cellBg := buf.Cell(x, y).Style.Bg; !cellBg.IsDefault() {
-							style.Bg = cellBg
-						}
-					}
-					buf.SetRuneLink(x, y, r, style, span.Link)
-				}
-				x += w
+		// Flatten the line's spans into a styled-rune stream, then segment into
+		// clusters so a cluster whose base and combining mark fall in adjacent
+		// spans stays one cell. Each cluster takes its base rune's style/link.
+		clusters := segmentLineClusters(line, base)
+		for _, cl := range clusters {
+			// Reached the right clip edge: clip this line and move to the next
+			// (matching the plain-text paths' per-line break), rather than
+			// abandoning all remaining lines.
+			if x >= clip.Right() {
+				continue nextLine
 			}
+			if cl.width == 2 && x+1 >= clip.Right() {
+				continue nextLine
+			}
+			if x >= clip.X {
+				style := cl.st
+				if style.Bg.IsDefault() {
+					if cellBg := buf.Cell(x, y).Style.Bg; !cellBg.IsDefault() {
+						style.Bg = cellBg
+					}
+				}
+				buf.setCluster(x, y, cl.text, cl.width, style, cl.link)
+			}
+			x += cl.width
 		}
 	}
 }

--- a/element_render_hr_test.go
+++ b/element_render_hr_test.go
@@ -17,16 +17,16 @@ func TestRenderHRDefault(t *testing.T) {
 	// HR should draw '─' characters across its width
 	for x := range 10 {
 		cell := buf.Cell(x, 0)
-		if cell.Rune != '─' {
-			t.Errorf("HR at x=%d = %q, want '─'", x, cell.Rune)
+		if cell.Text != "─" {
+			t.Errorf("HR at x=%d = %q, want '─'", x, cell.Text)
 		}
 	}
 
 	// Beyond the HR width should be untouched (spaces)
 	for x := 10; x < 20; x++ {
 		cell := buf.Cell(x, 0)
-		if cell.Rune != ' ' {
-			t.Errorf("beyond HR at x=%d = %q, want ' '", x, cell.Rune)
+		if cell.Text != " " {
+			t.Errorf("beyond HR at x=%d = %q, want ' '", x, cell.Text)
 		}
 	}
 }
@@ -42,8 +42,8 @@ func TestRenderHRDouble(t *testing.T) {
 	// HR with BorderDouble should draw '═' characters
 	for x := range 10 {
 		cell := buf.Cell(x, 0)
-		if cell.Rune != '═' {
-			t.Errorf("HR double at x=%d = %q, want '═'", x, cell.Rune)
+		if cell.Text != "═" {
+			t.Errorf("HR double at x=%d = %q, want '═'", x, cell.Text)
 		}
 	}
 }
@@ -59,8 +59,8 @@ func TestRenderHRThick(t *testing.T) {
 	// HR with BorderThick should draw '━' characters
 	for x := range 10 {
 		cell := buf.Cell(x, 0)
-		if cell.Rune != '━' {
-			t.Errorf("HR thick at x=%d = %q, want '━'", x, cell.Rune)
+		if cell.Text != "━" {
+			t.Errorf("HR thick at x=%d = %q, want '━'", x, cell.Text)
 		}
 	}
 }
@@ -80,8 +80,8 @@ func TestRenderHRWithColor(t *testing.T) {
 	// HR should respect textStyle for color
 	for x := range 10 {
 		cell := buf.Cell(x, 0)
-		if cell.Rune != '─' {
-			t.Errorf("HR at x=%d = %q, want '─'", x, cell.Rune)
+		if cell.Text != "─" {
+			t.Errorf("HR at x=%d = %q, want '─'", x, cell.Text)
 		}
 		if cell.Style.Fg != Cyan {
 			t.Errorf("HR style at x=%d Fg = %v, want Cyan", x, cell.Style.Fg)
@@ -113,8 +113,8 @@ func TestRenderHRInContainer(t *testing.T) {
 	// Check that HR drew '─' characters across the full width
 	for x := range 20 {
 		cell := buf.Cell(x, 0)
-		if cell.Rune != '─' {
-			t.Errorf("HR at x=%d = %q, want '─'", x, cell.Rune)
+		if cell.Text != "─" {
+			t.Errorf("HR at x=%d = %q, want '─'", x, cell.Text)
 		}
 	}
 }
@@ -176,8 +176,8 @@ func TestRenderHRInScrollableContainer(t *testing.T) {
 	// The container starts at (0,0), padding is 1, so HR line is at y=1, x=1 to x=18
 	for x := 1; x < 19; x++ {
 		cell := buf.Cell(x, 1)
-		if cell.Rune != '─' {
-			t.Errorf("HR at x=%d, y=1 = %q, want '─'", x, cell.Rune)
+		if cell.Text != "─" {
+			t.Errorf("HR at x=%d, y=1 = %q, want '─'", x, cell.Text)
 		}
 	}
 }

--- a/element_render_test.go
+++ b/element_render_test.go
@@ -19,8 +19,8 @@ func TestRichText_BoldSurvivesWrap(t *testing.T) {
 	RenderTree(buf, para)
 
 	// Row 0 starts "see " (plain) then "this" (bold).
-	if buf.Cell(0, 0).Rune != 's' || buf.Cell(0, 0).Style.Attrs&AttrBold != 0 {
-		t.Errorf("cell(0,0) should be plain 's', got %q attrs=%v", buf.Cell(0, 0).Rune, buf.Cell(0, 0).Style.Attrs)
+	if buf.Cell(0, 0).Text != "s" || buf.Cell(0, 0).Style.Attrs&AttrBold != 0 {
+		t.Errorf("cell(0,0) should be plain 's', got %q attrs=%v", buf.Cell(0, 0).Text, buf.Cell(0, 0).Style.Attrs)
 	}
 	// "see " is 4 cells; the bold word "this" begins at x=4 on row 0.
 	if buf.Cell(4, 0).Style.Attrs&AttrBold == 0 {
@@ -30,7 +30,7 @@ func TestRichText_BoldSurvivesWrap(t *testing.T) {
 	rowsWithText := 0
 	for y := range 6 {
 		for x := range 10 {
-			if buf.Cell(x, y).Rune != ' ' {
+			if buf.Cell(x, y).Text != " " {
 				rowsWithText++
 				break
 			}
@@ -61,16 +61,16 @@ func TestRichText_ClippedLinesBelowAnOverflowingLineStillRender(t *testing.T) {
 	RenderTree(buf, parent)
 
 	// Line 0 is clipped to 3 columns.
-	if buf.Cell(0, 0).Rune != 'a' || buf.Cell(2, 0).Rune != 'a' {
+	if buf.Cell(0, 0).Text != "a" || buf.Cell(2, 0).Text != "a" {
 		t.Errorf("line 0 not rendered/clipped as expected: %q%q",
-			buf.Cell(0, 0).Rune, buf.Cell(2, 0).Rune)
+			buf.Cell(0, 0).Text, buf.Cell(2, 0).Text)
 	}
-	if buf.Cell(3, 0).Rune == 'a' {
+	if buf.Cell(3, 0).Text == "a" {
 		t.Errorf("line 0 leaked past the clip at x=3")
 	}
 	// The regression assertion: line 1 must still render after line 0 overflowed.
-	if buf.Cell(0, 1).Rune != 'b' {
-		t.Errorf("line 1 was dropped after line 0 hit the clip edge: cell(0,1)=%q, want 'b'", buf.Cell(0, 1).Rune)
+	if buf.Cell(0, 1).Text != "b" {
+		t.Errorf("line 1 was dropped after line 0 hit the clip edge: cell(0,1)=%q, want 'b'", buf.Cell(0, 1).Text)
 	}
 }
 
@@ -92,7 +92,7 @@ func TestRichText_RendersInsideScrollableContainer(t *testing.T) {
 	RenderTree(buf, container)
 
 	// Text must appear (this is the bug the spec warns about).
-	if got := buf.Cell(0, 0).Rune; got != 'a' {
+	if got := buf.Cell(0, 0).Text; got != "a" {
 		t.Errorf("rich text not rendered in scroll container: cell(0,0)=%q, want 'a'", got)
 	}
 	if buf.Cell(2, 0).Style.Attrs&AttrBold == 0 {
@@ -114,7 +114,7 @@ func TestRenderTree_RichTextStylesPerSegment(t *testing.T) {
 
 	// "abcd" laid out left to right.
 	for x, want := range []rune{'a', 'b', 'c', 'd'} {
-		if got := buf.Cell(x, 0).Rune; got != want {
+		if got := buf.Cell(x, 0).Text; got != string(want) {
 			t.Errorf("cell(%d,0).Rune = %q, want %q", x, got, want)
 		}
 	}
@@ -146,8 +146,8 @@ func TestRenderTree_DrawsBackground(t *testing.T) {
 	for y := range 5 {
 		for x := range 10 {
 			cell := buf.Cell(x, y)
-			if cell.Rune != ' ' {
-				t.Errorf("cell(%d,%d).Rune = %q, want ' '", x, y, cell.Rune)
+			if cell.Text != " " {
+				t.Errorf("cell(%d,%d).Rune = %q, want ' '", x, y, cell.Text)
 			}
 			if cell.Style.Bg != Blue {
 				t.Errorf("cell(%d,%d).Style.Bg = %v, want Blue", x, y, cell.Style.Bg)
@@ -169,49 +169,49 @@ func TestRenderTree_DrawsBorder(t *testing.T) {
 
 	// Check corners
 	topLeft := buf.Cell(0, 0)
-	if topLeft.Rune != '┌' {
-		t.Errorf("top-left corner = %q, want '┌'", topLeft.Rune)
+	if topLeft.Text != "┌" {
+		t.Errorf("top-left corner = %q, want '┌'", topLeft.Text)
 	}
 	if topLeft.Style.Fg != Red {
 		t.Errorf("top-left color = %v, want Red", topLeft.Style.Fg)
 	}
 
 	topRight := buf.Cell(9, 0)
-	if topRight.Rune != '┐' {
-		t.Errorf("top-right corner = %q, want '┐'", topRight.Rune)
+	if topRight.Text != "┐" {
+		t.Errorf("top-right corner = %q, want '┐'", topRight.Text)
 	}
 
 	bottomLeft := buf.Cell(0, 4)
-	if bottomLeft.Rune != '└' {
-		t.Errorf("bottom-left corner = %q, want '└'", bottomLeft.Rune)
+	if bottomLeft.Text != "└" {
+		t.Errorf("bottom-left corner = %q, want '└'", bottomLeft.Text)
 	}
 
 	bottomRight := buf.Cell(9, 4)
-	if bottomRight.Rune != '┘' {
-		t.Errorf("bottom-right corner = %q, want '┘'", bottomRight.Rune)
+	if bottomRight.Text != "┘" {
+		t.Errorf("bottom-right corner = %q, want '┘'", bottomRight.Text)
 	}
 
 	// Check horizontal edges
 	for x := 1; x < 9; x++ {
 		top := buf.Cell(x, 0)
-		if top.Rune != '─' {
-			t.Errorf("top edge at %d = %q, want '─'", x, top.Rune)
+		if top.Text != "─" {
+			t.Errorf("top edge at %d = %q, want '─'", x, top.Text)
 		}
 		bottom := buf.Cell(x, 4)
-		if bottom.Rune != '─' {
-			t.Errorf("bottom edge at %d = %q, want '─'", x, bottom.Rune)
+		if bottom.Text != "─" {
+			t.Errorf("bottom edge at %d = %q, want '─'", x, bottom.Text)
 		}
 	}
 
 	// Check vertical edges
 	for y := 1; y < 4; y++ {
 		left := buf.Cell(0, y)
-		if left.Rune != '│' {
-			t.Errorf("left edge at %d = %q, want '│'", y, left.Rune)
+		if left.Text != "│" {
+			t.Errorf("left edge at %d = %q, want '│'", y, left.Text)
 		}
 		right := buf.Cell(9, y)
-		if right.Rune != '│' {
-			t.Errorf("right edge at %d = %q, want '│'", y, right.Rune)
+		if right.Text != "│" {
+			t.Errorf("right edge at %d = %q, want '│'", y, right.Text)
 		}
 	}
 }
@@ -244,8 +244,8 @@ func TestRenderTree_NestedElements(t *testing.T) {
 
 	// Check child border corner exists
 	topLeft := buf.Cell(2, 2)
-	if topLeft.Rune != '┌' {
-		t.Errorf("child top-left = %q, want '┌'", topLeft.Rune)
+	if topLeft.Text != "┌" {
+		t.Errorf("child top-left = %q, want '┌'", topLeft.Text)
 	}
 }
 
@@ -265,8 +265,8 @@ func TestRenderTree_CullsElementsOutsideBuffer(t *testing.T) {
 	for y := range 10 {
 		for x := range 10 {
 			cell := buf.Cell(x, y)
-			if cell.Rune != ' ' {
-				t.Errorf("cell(%d,%d) should be space, got %q", x, y, cell.Rune)
+			if cell.Text != " " {
+				t.Errorf("cell(%d,%d) should be space, got %q", x, y, cell.Text)
 			}
 		}
 	}
@@ -311,12 +311,12 @@ func TestRenderTree_TextCenterAlignment(t *testing.T) {
 	// Center position: (10 - 2) / 2 = 4
 	// Text should be at x=4
 	cell := buf.Cell(4, 0)
-	if cell.Rune != 'H' {
-		t.Errorf("centered text at x=4 = %q, want 'H'", cell.Rune)
+	if cell.Text != "H" {
+		t.Errorf("centered text at x=4 = %q, want 'H'", cell.Text)
 	}
 	cell = buf.Cell(5, 0)
-	if cell.Rune != 'i' {
-		t.Errorf("centered text at x=5 = %q, want 'i'", cell.Rune)
+	if cell.Text != "i" {
+		t.Errorf("centered text at x=5 = %q, want 'i'", cell.Text)
 	}
 }
 
@@ -335,12 +335,12 @@ func TestRenderTree_TextRightAlignment(t *testing.T) {
 	// "Hi" is 2 chars wide, in a 10-wide container
 	// Right-aligned position: 10 - 2 = 8
 	cell := buf.Cell(8, 0)
-	if cell.Rune != 'H' {
-		t.Errorf("right-aligned text at x=8 = %q, want 'H'", cell.Rune)
+	if cell.Text != "H" {
+		t.Errorf("right-aligned text at x=8 = %q, want 'H'", cell.Text)
 	}
 	cell = buf.Cell(9, 0)
-	if cell.Rune != 'i' {
-		t.Errorf("right-aligned text at x=9 = %q, want 'i'", cell.Rune)
+	if cell.Text != "i" {
+		t.Errorf("right-aligned text at x=9 = %q, want 'i'", cell.Text)
 	}
 }
 
@@ -361,8 +361,8 @@ func TestRenderTree_TextWithBorderAndPadding(t *testing.T) {
 
 	// Border should be drawn at edge
 	corner := buf.Cell(0, 0)
-	if corner.Rune != '┌' {
-		t.Errorf("border corner = %q, want '┌'", corner.Rune)
+	if corner.Text != "┌" {
+		t.Errorf("border corner = %q, want '┌'", corner.Text)
 	}
 
 	// Content rect accounts for border (1) + padding (1) = 2
@@ -392,8 +392,8 @@ func TestElement_Render_CalculatesIfDirty(t *testing.T) {
 
 	// Border should be drawn
 	corner := buf.Cell(0, 0)
-	if corner.Rune != '┌' {
-		t.Errorf("border corner = %q, want '┌'", corner.Rune)
+	if corner.Text != "┌" {
+		t.Errorf("border corner = %q, want '┌'", corner.Text)
 	}
 }
 
@@ -503,8 +503,8 @@ func checkString(t *testing.T, buf *Buffer, x, y int, expected string) {
 	curX := x
 	for _, r := range expected {
 		cell := buf.Cell(curX, y)
-		if cell.Rune != r {
-			t.Errorf("buf.Cell(%d,%d).Rune = %q, want %q", curX, y, cell.Rune, r)
+		if cell.Text != string(r) {
+			t.Errorf("buf.Cell(%d,%d).Rune = %q, want %q", curX, y, cell.Text, r)
 		}
 		curX += RuneWidth(r)
 	}
@@ -557,20 +557,20 @@ func TestRenderTree_TextWithBorder(t *testing.T) {
 
 			// Check border corners render correctly
 			topLeft := buf.Cell(rect.X, rect.Y)
-			if topLeft.Rune != '┌' {
-				t.Errorf("top-left = %q, want '┌'", topLeft.Rune)
+			if topLeft.Text != "┌" {
+				t.Errorf("top-left = %q, want '┌'", topLeft.Text)
 			}
 			topRight := buf.Cell(rect.X+rect.Width-1, rect.Y)
-			if topRight.Rune != '┐' {
-				t.Errorf("top-right = %q, want '┐'", topRight.Rune)
+			if topRight.Text != "┐" {
+				t.Errorf("top-right = %q, want '┐'", topRight.Text)
 			}
 			bottomLeft := buf.Cell(rect.X, rect.Y+rect.Height-1)
-			if bottomLeft.Rune != '└' {
-				t.Errorf("bottom-left = %q, want '└'", bottomLeft.Rune)
+			if bottomLeft.Text != "└" {
+				t.Errorf("bottom-left = %q, want '└'", bottomLeft.Text)
 			}
 			bottomRight := buf.Cell(rect.X+rect.Width-1, rect.Y+rect.Height-1)
-			if bottomRight.Rune != '┘' {
-				t.Errorf("bottom-right = %q, want '┘'", bottomRight.Rune)
+			if bottomRight.Text != "┘" {
+				t.Errorf("bottom-right = %q, want '┘'", bottomRight.Text)
 			}
 
 			// Text inside border
@@ -610,23 +610,23 @@ func TestRenderTree_TextBorderInScrollable(t *testing.T) {
 	sy := parentCR.Y + spanR.Y
 
 	topLeft := buf.Cell(sx, sy)
-	if topLeft.Rune != '┌' {
-		t.Errorf("span top-left at (%d,%d) = %q, want '┌'", sx, sy, topLeft.Rune)
+	if topLeft.Text != "┌" {
+		t.Errorf("span top-left at (%d,%d) = %q, want '┌'", sx, sy, topLeft.Text)
 	}
 
 	topRight := buf.Cell(sx+spanR.Width-1, sy)
-	if topRight.Rune != '┐' {
-		t.Errorf("span top-right at (%d,%d) = %q, want '┐'", sx+spanR.Width-1, sy, topRight.Rune)
+	if topRight.Text != "┐" {
+		t.Errorf("span top-right at (%d,%d) = %q, want '┐'", sx+spanR.Width-1, sy, topRight.Text)
 	}
 
 	bottomLeft := buf.Cell(sx, sy+spanR.Height-1)
-	if bottomLeft.Rune != '└' {
-		t.Errorf("span bottom-left at (%d,%d) = %q, want '└'", sx, sy+spanR.Height-1, bottomLeft.Rune)
+	if bottomLeft.Text != "└" {
+		t.Errorf("span bottom-left at (%d,%d) = %q, want '└'", sx, sy+spanR.Height-1, bottomLeft.Text)
 	}
 
 	bottomRight := buf.Cell(sx+spanR.Width-1, sy+spanR.Height-1)
-	if bottomRight.Rune != '┘' {
-		t.Errorf("span bottom-right at (%d,%d) = %q, want '┘'", sx+spanR.Width-1, sy+spanR.Height-1, bottomRight.Rune)
+	if bottomRight.Text != "┘" {
+		t.Errorf("span bottom-right at (%d,%d) = %q, want '┘'", sx+spanR.Width-1, sy+spanR.Height-1, bottomRight.Text)
 	}
 
 	// Text should be inside the border
@@ -774,8 +774,8 @@ func TestRenderTree_BorderStyleDoesNotInherit(t *testing.T) {
 	// Child's border should use default style, not parent's red border style
 	childRect := child.Rect()
 	corner := buf.Cell(childRect.X, childRect.Y)
-	if corner.Rune != '┌' {
-		t.Errorf("child border corner = %q, want '┌'", corner.Rune)
+	if corner.Text != "┌" {
+		t.Errorf("child border corner = %q, want '┌'", corner.Text)
 	}
 	if corner.Style.Fg != DefaultColor() {
 		t.Errorf("child border Fg = %v, want Default (border should not inherit)", corner.Style.Fg)
@@ -797,8 +797,8 @@ func TestRenderTree_HRInheritsTextStyle(t *testing.T) {
 	// HR should render with inherited cyan color
 	hrRect := hr.Rect()
 	cell := buf.Cell(hrRect.X, hrRect.Y)
-	if cell.Rune != '─' {
-		t.Errorf("HR rune = %q, want '─'", cell.Rune)
+	if cell.Text != "─" {
+		t.Errorf("HR rune = %q, want '─'", cell.Text)
 	}
 	if cell.Style.Fg != Cyan {
 		t.Errorf("HR inherited Fg = %v, want Cyan", cell.Style.Fg)

--- a/element_scroll_test.go
+++ b/element_scroll_test.go
@@ -127,8 +127,8 @@ func TestElement_ScrollbarHidden(t *testing.T) {
 		// Rightmost column should be the scrollbar, not the child's red fill.
 		for y := range height {
 			cell := buf.Cell(width-1, y)
-			if cell.Rune != '█' && cell.Rune != '│' {
-				t.Errorf("row %d rightmost column rune = %q, want scrollbar glyph", y, cell.Rune)
+			if cell.Text != "█" && cell.Text != "│" {
+				t.Errorf("row %d rightmost column rune = %q, want scrollbar glyph", y, cell.Text)
 			}
 			if cell.Style.Bg.Equal(Red) {
 				t.Errorf("row %d rightmost column bg = Red, expected scrollbar to cover child", y)

--- a/examples/13-testing/counter_test.go
+++ b/examples/13-testing/counter_test.go
@@ -121,8 +121,8 @@ func TestPanel_RendersBorder(t *testing.T) {
 	}
 
 	cell := buf.Cell(rect.X, rect.Y)
-	if cell.Rune != '┌' {
-		t.Errorf("top-left = %q, want '┌'", cell.Rune)
+	if cell.Text != "┌" {
+		t.Errorf("top-left = %q, want '┌'", cell.Text)
 	}
 }
 

--- a/grapheme.go
+++ b/grapheme.go
@@ -1,0 +1,281 @@
+package tui
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// nextCluster returns the next grapheme cluster at the start of s, its display
+// width in terminal cells, and the number of bytes it consumed. The returned
+// cluster is a slice of s (no allocation); callers that persist it must clone it.
+//
+// The cluster profile targets terminal text: combining marks, ZWJ emoji
+// sequences, regional-indicator pairs, emoji modifiers (skin tones), and
+// variation selectors. It is not full UAX #29 (see GRAPHEME_CLUSTER_SPEC.md
+// section 15 for documented limitations). Width 0 is never returned: the buffer
+// model reserves 0 for continuation cells, and a defective leading combining
+// mark becomes a width-1 cluster.
+func nextCluster(s string) (cluster string, width, size int) {
+	if len(s) == 0 {
+		return "", 0, 0
+	}
+
+	// ASCII fast path: only when the next byte is also ASCII (or we are at the
+	// end). A non-ASCII next byte (leading byte >= 0x80, e.g. 0xCC starting a
+	// combining accent) is NOT a continuation byte but could still attach to
+	// this base, so it forces the full decode below.
+	if s[0] < 0x80 {
+		if len(s) == 1 || s[1] < 0x80 {
+			return s[:1], 1, 1
+		}
+	}
+
+	w, size, _ := clusterAdvance(decodeStringStep(s))
+	return s[:size], w, size
+}
+
+// nextClusterBytes is the []byte variant for the inline byte scanner. It shares
+// the cluster state machine with nextCluster (one implementation, two decode
+// steps). It reports the cluster's display width, the number of bytes consumed,
+// and the cluster's base rune.
+func nextClusterBytes(b []byte) (width, size int, base rune) {
+	if len(b) == 0 {
+		return 0, 0, 0
+	}
+
+	if b[0] < 0x80 {
+		if len(b) == 1 || b[1] < 0x80 {
+			return 1, 1, rune(b[0])
+		}
+	}
+
+	return clusterAdvance(decodeBytesStep(b))
+}
+
+// decodeStep decodes one rune at a byte offset. Returns the rune, its byte
+// size, and the total length of the underlying buffer. A decode at or past the
+// end returns size 0.
+type decodeStep func(pos int) (r rune, size, length int)
+
+func decodeStringStep(s string) decodeStep {
+	return func(pos int) (rune, int, int) {
+		if pos >= len(s) {
+			return 0, 0, len(s)
+		}
+		r, size := utf8.DecodeRuneInString(s[pos:])
+		return r, size, len(s)
+	}
+}
+
+func decodeBytesStep(b []byte) decodeStep {
+	return func(pos int) (rune, int, int) {
+		if pos >= len(b) {
+			return 0, 0, len(b)
+		}
+		r, size := utf8.DecodeRune(b[pos:])
+		return r, size, len(b)
+	}
+}
+
+// clusterAdvance runs the shared grapheme state machine over a decode step,
+// starting at offset 0. It returns the cluster's display width, the number of
+// bytes consumed, and the base rune.
+func clusterAdvance(decode decodeStep) (width, size int, base rune) {
+	r0, s0, length := decode(0)
+	if s0 == 0 {
+		return 0, 0, 0
+	}
+	pos := s0
+	w := baseRuneWidth(r0)
+
+	if regionalIndicator(r0) {
+		if pos < length {
+			r1, s1, _ := decode(pos)
+			if s1 > 0 && regionalIndicator(r1) {
+				pos += s1
+				return 2, pos, r0
+			}
+		}
+		// Lone RI: w is already 2 (RI is in emojiWideRanges). Fall through so a
+		// trailing combining mark or ZWJ sequence still attaches.
+	}
+
+	lastWasZWJ := false
+	for pos < length {
+		r, sz, _ := decode(pos)
+		if sz == 0 {
+			break
+		}
+		if graphemeExtend(r) {
+			pos += sz
+			if isVS16(r) {
+				w = 2 // emoji presentation forces wide
+			}
+			lastWasZWJ = isZWJ(r)
+			continue
+		}
+		if lastWasZWJ {
+			// Emoji (or any base) after a ZWJ joins the cluster.
+			pos += sz
+			w = 2
+			lastWasZWJ = false
+			continue
+		}
+		break
+	}
+
+	return w, pos, r0
+}
+
+// baseRuneWidth returns the display width of a base rune ignoring the
+// zero-width override: 2 for East Asian wide / emoji-wide ranges, else 1.
+func baseRuneWidth(r rune) int {
+	if r < 0 || r > unicode.MaxRune {
+		return 1
+	}
+	// C0 and C1 controls render narrow.
+	if r < 0x20 || (r >= 0x7F && r < 0xA0) {
+		return 1
+	}
+	if inRuneRanges(r, eastAsianWideRanges) || inRuneRanges(r, emojiWideRanges) {
+		return 2
+	}
+	return 1
+}
+
+// graphemeExtend reports whether r attaches to the preceding base, contributing
+// zero width. This covers combining marks (Mn/Me/Mc), the join controls (ZWNJ
+// and ZWJ, exactly U+200C and U+200D), variation selectors, and the emoji
+// modifier range U+1F3FB..U+1F3FF (skin tones).
+//
+// It deliberately does NOT include the whole unicode.Cf category: most format
+// characters (bidi controls, ZWSP U+200B) have UAX #29 GCB=Control and must
+// break, not glue. The cost is that emoji tag sequences (Cf tag chars) do not
+// cluster, documented in GRAPHEME_CLUSTER_SPEC.md section 15.
+func graphemeExtend(r rune) bool {
+	if r >= 0x1F3FB && r <= 0x1F3FF {
+		return true
+	}
+	return unicode.In(r, unicode.Mn, unicode.Me, unicode.Mc, unicode.Join_Control, unicode.Variation_Selector)
+}
+
+// isZWJ reports whether r is the ZERO WIDTH JOINER.
+func isZWJ(r rune) bool {
+	return r == 0x200D
+}
+
+// isVS16 reports whether r is VARIATION SELECTOR-16 (emoji presentation).
+func isVS16(r rune) bool {
+	return r == 0xFE0F
+}
+
+// regionalIndicator reports whether r is a regional indicator symbol (used in
+// pairs to form flag emoji).
+func regionalIndicator(r rune) bool {
+	return r >= 0x1F1E6 && r <= 0x1F1FF
+}
+
+// clusterCount returns the number of grapheme clusters in s.
+func clusterCount(s string) int {
+	n := 0
+	for len(s) > 0 {
+		_, _, size := nextCluster(s)
+		if size == 0 {
+			break
+		}
+		n++
+		s = s[size:]
+	}
+	return n
+}
+
+// clusterRuneStarts returns the rune index where each grapheme cluster begins,
+// followed by the total rune count. For "ab" it returns [0,1,2]; for the family
+// emoji (7 runes, one cluster) it returns [0,7]. Used by editable widgets to
+// snap a cursor rune index onto a cluster boundary.
+func clusterRuneStarts(s string) []int {
+	starts := []int{0}
+	runeIdx := 0
+	for len(s) > 0 {
+		_, _, size := nextCluster(s)
+		if size == 0 {
+			break
+		}
+		// Count runes in this cluster.
+		for i := 0; i < size; {
+			_, rs := utf8.DecodeRuneInString(s[i:])
+			if rs == 0 {
+				break
+			}
+			i += rs
+			runeIdx++
+		}
+		starts = append(starts, runeIdx)
+		s = s[size:]
+	}
+	return starts
+}
+
+// clusterEndAfterInsert returns the rune index at the end of the cluster that
+// contains the rune at insertedRuneIdx in s. It re-segments from the cluster
+// start at/under insertedRuneIdx, so a combining mark inserted after a base lands
+// the cursor after the combined cluster, and a base char lands one cluster on.
+func clusterEndAfterInsert(s string, insertedRuneIdx int) int {
+	starts := clusterRuneStarts(s)
+	// Find the cluster whose [start, end) range contains insertedRuneIdx.
+	for i := 0; i+1 < len(starts); i++ {
+		if insertedRuneIdx >= starts[i] && insertedRuneIdx < starts[i+1] {
+			return starts[i+1]
+		}
+	}
+	// At or past the end (e.g. appended at the very end): cursor at total.
+	return starts[len(starts)-1]
+}
+
+// snapRuneToClusterStart snaps a rune index down to the nearest cluster start at
+// or before it (clamped to [0, total]).
+func snapRuneToClusterStart(s string, runeIdx int) int {
+	starts := clusterRuneStarts(s)
+	if runeIdx <= 0 {
+		return 0
+	}
+	last := starts[len(starts)-1]
+	if runeIdx >= last {
+		return last
+	}
+	snapped := 0
+	for _, st := range starts {
+		if st <= runeIdx {
+			snapped = st
+		} else {
+			break
+		}
+	}
+	return snapped
+}
+
+// runeIndexToDisplayCol returns the display column at the given rune index,
+// summing cluster widths from the start of s. The index is snapped to a cluster
+// boundary first so a position inside a cluster reports that cluster's start col.
+func runeIndexToDisplayCol(s string, runeIdx int) int {
+	col := 0
+	runeAt := 0
+	for len(s) > 0 {
+		if runeAt >= runeIdx {
+			break
+		}
+		_, w, size := nextCluster(s)
+		if size == 0 {
+			break
+		}
+		clusterRunes := utf8.RuneCountInString(s[:size])
+		if runeAt+clusterRunes > runeIdx {
+			// Inside this cluster: report its starting column (snap behavior).
+			break
+		}
+		col += w
+		runeAt += clusterRunes
+		s = s[size:]
+	}
+	return col
+}

--- a/grapheme.go
+++ b/grapheme.go
@@ -11,10 +11,10 @@ import (
 //
 // The cluster profile targets terminal text: combining marks, ZWJ emoji
 // sequences, regional-indicator pairs, emoji modifiers (skin tones), and
-// variation selectors. It is not full UAX #29 (see GRAPHEME_CLUSTER_SPEC.md
-// section 15 for documented limitations). Width 0 is never returned: the buffer
-// model reserves 0 for continuation cells, and a defective leading combining
-// mark becomes a width-1 cluster.
+// variation selectors. It is not full UAX #29: Hangul jamo composition, Prepend,
+// Indic conjuncts, and emoji tag sequences (subdivision flags) are not handled.
+// Width 0 is never returned: the buffer model reserves 0 for continuation cells,
+// and a defective leading combining mark becomes a width-1 cluster.
 func nextCluster(s string) (cluster string, width, size int) {
 	if len(s) == 0 {
 		return "", 0, 0
@@ -151,7 +151,11 @@ func baseRuneWidth(r rune) int {
 // It deliberately does NOT include the whole unicode.Cf category: most format
 // characters (bidi controls, ZWSP U+200B) have UAX #29 GCB=Control and must
 // break, not glue. The cost is that emoji tag sequences (Cf tag chars) do not
-// cluster, documented in GRAPHEME_CLUSTER_SPEC.md section 15.
+// cluster.
+//
+// Keep this deliberately narrower than isZeroWidthRune in cell.go (which uses the
+// broad unicode.Cf, fine for per-rune width). Do not unify the two predicates, or
+// format controls would wrongly glue into grapheme clusters.
 func graphemeExtend(r rune) bool {
 	if r >= 0x1F3FB && r <= 0x1F3FF {
 		return true

--- a/grapheme_render_test.go
+++ b/grapheme_render_test.go
@@ -1,0 +1,107 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuffer_SetString_Cluster verifies the Tier-2 buffer path: a multi-rune
+// grapheme cluster is stored whole in one leading cell (width 2) with a single
+// continuation cell, and survives round-trip through the buffer's text emission.
+func TestBuffer_SetString_Cluster(t *testing.T) {
+	b := NewBuffer(10, 1)
+	b.SetString(0, 0, emojiFlagUS+"x", NewStyle())
+
+	lead := b.Cell(0, 0)
+	if lead.Text != emojiFlagUS {
+		t.Errorf("cell(0,0).Text = %q, want the whole flag %q", lead.Text, emojiFlagUS)
+	}
+	if lead.Width != 2 {
+		t.Errorf("cell(0,0).Width = %d, want 2", lead.Width)
+	}
+	if !b.Cell(1, 0).IsContinuation() {
+		t.Errorf("cell(1,0) should be a continuation cell")
+	}
+	// The trailing 'x' lands at column 2, not 4: the flag consumed two columns.
+	if got := b.Cell(2, 0).Text; got != "x" {
+		t.Errorf("cell(2,0).Text = %q, want \"x\" (flag is 2 cols wide, not 4)", got)
+	}
+
+	// Emission writes the cluster's full bytes back out.
+	if line := b.String(); !strings.Contains(line, emojiFlagUS) {
+		t.Errorf("buffer text %q does not contain the flag cluster", line)
+	}
+}
+
+// TestWrapText_KeepsClustersWhole verifies wrapping measures by cluster width and
+// never breaks inside a cluster. This is the wrap symptom from issue #95.
+func TestWrapText_KeepsClustersWhole(t *testing.T) {
+	type tc struct {
+		text  string
+		width int
+		want  []string
+	}
+
+	tests := map[string]tc{
+		// flag(2) + "abcd"(4) = 6 columns: fits a width-6 line. A per-code-point
+		// sum would score the flag as 4 and wrap to two lines.
+		"flag plus text fits one line": {text: emojiFlagUS + "abcd", width: 6, want: []string{emojiFlagUS + "abcd"}},
+		// A hard break falls between clusters, never inside the flag.
+		"break between clusters": {text: "a" + emojiFlagUS + "b", width: 2, want: []string{"a", emojiFlagUS, "b"}},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := wrapText(tt.text, tt.width)
+			if len(got) != len(tt.want) {
+				t.Fatalf("wrapText(%q, %d) = %q, want %q", tt.text, tt.width, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("line[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestRenderTree_ClusterBoxNoWrap is the issue #95 reproduction turned regression
+// test: a width-8 single-border box (content width 6) holding a flag plus four
+// ASCII chars renders on one content row, because the flag is two columns wide.
+func TestRenderTree_ClusterBoxNoWrap(t *testing.T) {
+	buf := NewBuffer(8, 5)
+	box := New(
+		WithWidth(8),
+		WithBorder(BorderSingle),
+		WithText(emojiFlagUS+"abcd"),
+	)
+	box.Calculate(8, 5)
+	RenderTree(buf, box)
+
+	// Content row 1 holds the whole string; content row 2 must be blank (no wrap).
+	row1 := contentRow(buf, 1)
+	if !strings.Contains(row1, emojiFlagUS) || !strings.Contains(row1, "abcd") {
+		t.Fatalf("content row 1 = %q, want it to hold the flag and \"abcd\" on one line", row1)
+	}
+	if row2 := strings.TrimSpace(contentRow(buf, 2)); row2 != "" {
+		t.Errorf("content row 2 = %q, want empty (text must not wrap)", row2)
+	}
+}
+
+// contentRow returns the interior of a single-border box row as text (border
+// columns and continuation cells skipped).
+func contentRow(b *Buffer, y int) string {
+	var sb strings.Builder
+	for x := 1; x < b.Width()-1; x++ {
+		cell := b.Cell(x, y)
+		if cell.IsContinuation() {
+			continue
+		}
+		if cell.Text == "" {
+			sb.WriteRune(' ')
+		} else {
+			sb.WriteString(cell.Text)
+		}
+	}
+	return sb.String()
+}

--- a/grapheme_render_test.go
+++ b/grapheme_render_test.go
@@ -33,6 +33,31 @@ func TestBuffer_SetString_Cluster(t *testing.T) {
 	}
 }
 
+// TestBuffer_SetStringGradient_Cluster verifies the gradient writer is cluster
+// aware: a flag occupies one width-2 cell plus a continuation, not two cells.
+func TestBuffer_SetStringGradient_Cluster(t *testing.T) {
+	b := NewBuffer(10, 1)
+	g := NewGradient(Red, Blue)
+	w := b.SetStringGradient(0, 0, emojiFlagUS+"x", g, NewStyle())
+
+	if w != 3 {
+		t.Errorf("SetStringGradient returned width %d, want 3 (flag 2 + x 1)", w)
+	}
+	lead := b.Cell(0, 0)
+	if lead.Text != emojiFlagUS || lead.Width != 2 {
+		t.Errorf("cell(0,0) = {%q, w%d}, want the flag at width 2", lead.Text, lead.Width)
+	}
+	if !b.Cell(1, 0).IsContinuation() {
+		t.Errorf("cell(1,0) should be a continuation cell")
+	}
+	if got := b.Cell(2, 0).Text; got != "x" {
+		t.Errorf("cell(2,0).Text = %q, want \"x\"", got)
+	}
+	if lead.Style.Fg.IsDefault() {
+		t.Errorf("gradient color was not applied to the flag cell")
+	}
+}
+
 // TestWrapText_KeepsClustersWhole verifies wrapping measures by cluster width and
 // never breaks inside a cluster. This is the wrap symptom from issue #95.
 func TestWrapText_KeepsClustersWhole(t *testing.T) {
@@ -85,6 +110,27 @@ func TestRenderTree_ClusterBoxNoWrap(t *testing.T) {
 	}
 	if row2 := strings.TrimSpace(contentRow(buf, 2)); row2 != "" {
 		t.Errorf("content row 2 = %q, want empty (text must not wrap)", row2)
+	}
+}
+
+// TestTextArea_BlockCursorKeepsClusterWhole guards the block-cursor overlay used
+// when a display-full line ends in a hard newline: it must drop the whole final
+// grapheme cluster for the cursor, not just the last rune (which would split a
+// flag / ZWJ family / decomposed accent).
+func TestTextArea_BlockCursorKeepsClusterWhole(t *testing.T) {
+	ta := NewTextArea(WithTextAreaWidth(2))
+	ta.BindApp(testApp)
+	ta.SetText(emojiFlagUS + "\nx") // flag fills the width-2 row, then a hard break
+	ta.Focus()
+	ta.cursorPos.Set(2) // end of row 0 (after the flag, before '\n')
+	ta.blink.Set(true)
+
+	got := ta.lineWithCursor(0)
+	if strings.ContainsRune(got, '\U0001F1FA') || strings.ContainsRune(got, '\U0001F1F8') {
+		t.Fatalf("lineWithCursor(0) = %q, want the flag cluster dropped whole (no lone regional indicator)", got)
+	}
+	if got != string(ta.cursorRune) {
+		t.Errorf("lineWithCursor(0) = %q, want %q", got, string(ta.cursorRune))
 	}
 }
 

--- a/grapheme_test.go
+++ b/grapheme_test.go
@@ -1,0 +1,181 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// Test data uses escapes so the intent is unambiguous in source:
+//
+//	\U0001F680                          rocket
+//	\U0001F1FA\U0001F1F8                US flag (regional-indicator pair)
+//	\U0001F44D\U0001F3FD                thumbs up + medium skin tone
+//	\U0001F468‍...\U0001F466       man ZWJ woman ZWJ girl ZWJ boy (family)
+//	❤️                        heavy heart + VS16 (emoji presentation)
+//	1️⃣                       keycap digit one
+//	é                             "e" + combining acute ("é", decomposed)
+//	a​b                            "a" + zero-width space + "b"
+const (
+	emojiRocket  = "\U0001F680"
+	emojiFlagUS  = "\U0001F1FA\U0001F1F8"
+	emojiThumbs  = "\U0001F44D\U0001F3FD"
+	emojiFamily  = "\U0001F468‍\U0001F469‍\U0001F467‍\U0001F466"
+	emojiHeart   = "❤️"
+	emojiKeycap1 = "1️⃣"
+	accentE      = "é"
+)
+
+func TestNextCluster_SegmentationAndWidth(t *testing.T) {
+	type tc struct {
+		in       string
+		clusters []string
+		width    int
+	}
+
+	tests := map[string]tc{
+		"ascii":        {in: "ab", clusters: []string{"a", "b"}, width: 2},
+		"cjk":          {in: "你好", clusters: []string{"你", "好"}, width: 4},
+		"single emoji": {in: emojiRocket, clusters: []string{emojiRocket}, width: 2},
+		// Regional-indicator pair, skin-tone, ZWJ family, heart+VS16, and keycap are
+		// each one cluster two columns wide, not the sum of their code points.
+		"flag":       {in: emojiFlagUS, clusters: []string{emojiFlagUS}, width: 2},
+		"skin tone":  {in: emojiThumbs, clusters: []string{emojiThumbs}, width: 2},
+		"zwj family": {in: emojiFamily, clusters: []string{emojiFamily}, width: 2},
+		"heart vs16": {in: emojiHeart, clusters: []string{emojiHeart}, width: 2},
+		"keycap":     {in: emojiKeycap1, clusters: []string{emojiKeycap1}, width: 2},
+		// ASCII fast path must not split a base from a following combining mark:
+		// the byte after 'e' is 0xCC (a leading byte), not ASCII, so it decodes.
+		"decomposed accent":  {in: accentE, clusters: []string{accentE}, width: 1},
+		"decomposed in word": {in: "café", clusters: []string{"c", "a", "f", accentE}, width: 4},
+		// A format control with GCB=Control (ZWSP) must NOT glue to its neighbours.
+		"zwsp does not glue": {in: "a​b", clusters: []string{"a", "​", "b"}, width: 3},
+		// Regional indicators pair at most two at a time; a third stands alone.
+		"three regional indicators": {
+			in:       emojiFlagUS + "\U0001F1EB",
+			clusters: []string{emojiFlagUS, "\U0001F1EB"},
+			width:    4,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got []string
+			total := 0
+			for rest := tt.in; len(rest) > 0; {
+				cl, w, size := nextCluster(rest)
+				if size == 0 {
+					t.Fatalf("nextCluster(%q) returned size 0", rest)
+				}
+				got = append(got, cl)
+				total += w
+				rest = rest[size:]
+			}
+
+			if len(got) != len(tt.clusters) {
+				t.Fatalf("clusters = %q, want %q", got, tt.clusters)
+			}
+			for i := range got {
+				if got[i] != tt.clusters[i] {
+					t.Errorf("cluster[%d] = %q, want %q", i, got[i], tt.clusters[i])
+				}
+			}
+			if strings.Join(got, "") != tt.in {
+				t.Errorf("clusters %q do not reconstruct input %q", got, tt.in)
+			}
+			if total != tt.width {
+				t.Errorf("summed cluster width = %d, want %d", total, tt.width)
+			}
+			if sw := stringWidth(tt.in); sw != tt.width {
+				t.Errorf("stringWidth(%q) = %d, want %d", tt.in, sw, tt.width)
+			}
+		})
+	}
+}
+
+// TestStringWidth_Clusters documents the exact divergence from issue #95: a
+// per-code-point sum over-counts these, the grapheme-aware width does not.
+func TestStringWidth_Clusters(t *testing.T) {
+	type tc struct {
+		in    string
+		width int
+	}
+
+	tests := map[string]tc{
+		"flag":         {in: emojiFlagUS, width: 2},
+		"skin tone":    {in: emojiThumbs, width: 2},
+		"zwj family":   {in: emojiFamily, width: 2},
+		"decomposed":   {in: "café", width: 4},
+		"flag in text": {in: "x" + emojiFlagUS + "y", width: 4},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := stringWidth(tt.in); got != tt.width {
+				t.Errorf("stringWidth(%q) = %d, want %d", tt.in, got, tt.width)
+			}
+		})
+	}
+}
+
+// TestNextClusterBytes_MatchesNextCluster pins that the []byte scanner variant
+// segments identically to the string variant (same shared state machine).
+func TestNextClusterBytes_MatchesNextCluster(t *testing.T) {
+	inputs := map[string]string{
+		"ascii":      "ab",
+		"cjk":        "你好",
+		"rocket":     emojiRocket,
+		"flag":       emojiFlagUS,
+		"skin tone":  emojiThumbs,
+		"zwj family": emojiFamily,
+		"heart vs16": emojiHeart,
+		"keycap":     emojiKeycap1,
+		"accent":     accentE,
+		"zwsp":       "a​b",
+	}
+
+	for name, in := range inputs {
+		t.Run(name, func(t *testing.T) {
+			for rest := in; len(rest) > 0; {
+				cl, w, size := nextCluster(rest)
+				bw, bsize, base := nextClusterBytes([]byte(rest))
+				if bw != w || bsize != size {
+					t.Fatalf("nextClusterBytes = (w=%d size=%d), nextCluster = (w=%d size=%d)", bw, bsize, w, size)
+				}
+				wantBase, _ := utf8.DecodeRuneInString(cl)
+				if base != wantBase {
+					t.Errorf("base rune = %q, want %q", base, wantBase)
+				}
+				rest = rest[size:]
+			}
+		})
+	}
+}
+
+func TestClusterRuneStarts(t *testing.T) {
+	type tc struct {
+		in   string
+		want []int
+	}
+
+	tests := map[string]tc{
+		"ascii":                 {in: "ab", want: []int{0, 1, 2}},
+		"family is one cluster": {in: emojiFamily, want: []int{0, 7}},
+		// c, a, f are one rune each; the final "é" is two runes (e + combining).
+		"decomposed in word": {in: "café", want: []int{0, 1, 2, 3, 5}},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := clusterRuneStarts(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("clusterRuneStarts(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("clusterRuneStarts(%q) = %v, want %v", tt.in, got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/inline_scan.go
+++ b/inline_scan.go
@@ -67,7 +67,7 @@ func (s *styledByteScanner) next() bool {
 			return true
 		}
 
-		// Decode UTF-8 rune.
+		// Decode UTF-8 rune to validate and to drop control chars.
 		r, size := utf8.DecodeRune(s.data[s.pos:])
 		if r == utf8.RuneError && size == 1 {
 			s.pos++
@@ -80,12 +80,16 @@ func (s *styledByteScanner) next() bool {
 			continue
 		}
 
+		// Consume a whole grapheme cluster so flags, ZWJ families, skin-tone
+		// emoji, and combining marks stay together. The base rune is reported in
+		// runeVal; bytes() spans the full cluster; runeWidth is the cluster width.
+		clusterWidth, clusterSize, base := nextClusterBytes(s.data[s.pos:])
 		s.kind = tokenRune
 		s.start = s.pos
-		s.pos += size
+		s.pos += clusterSize
 		s.end = s.pos
-		s.runeVal = r
-		s.runeWidth = RuneWidth(r)
+		s.runeVal = base
+		s.runeWidth = clusterWidth
 		return true
 	}
 	return false

--- a/inline_wrap.go
+++ b/inline_wrap.go
@@ -191,16 +191,21 @@ func wrapInlineStyledRows(text string, width int) []string {
 		}
 
 		r, size := utf8.DecodeRuneInString(text[i:])
-		i += size
 
 		if r == '\n' {
+			i += size
 			flush()
 			continue
 		}
 
-		w := max(RuneWidth(r), 1)
+		// Consume a whole grapheme cluster so a flag, ZWJ family, or combining
+		// mark is never split across a wrapped row.
+		cluster, cw, csize := nextCluster(text[i:])
+		i += csize
+		w := max(cw, 1)
 		if w > width {
-			r = '?'
+			// A cluster wider than the whole row degrades to '?' as before.
+			cluster = "?"
 			w = 1
 		}
 
@@ -208,7 +213,7 @@ func wrapInlineStyledRows(text string, width int) []string {
 			flush()
 		}
 
-		row.WriteRune(r)
+		row.WriteString(cluster)
 		col += w
 	}
 
@@ -219,7 +224,7 @@ func wrapInlineStyledRows(text string, width int) []string {
 	return rows
 }
 
-// wrapInlineVisualRows converts text into terminal visual rows using RuneWidth.
+// wrapInlineVisualRows converts text into terminal visual rows using cluster widths.
 func wrapInlineVisualRows(text string, width int) []string {
 	if width < 1 {
 		width = 1
@@ -238,15 +243,23 @@ func wrapInlineVisualRows(text string, width int) []string {
 		col = 0
 	}
 
-	for _, r := range text {
-		if r == '\n' {
+	for i := 0; i < len(text); {
+		if text[i] == '\n' {
+			i++
 			flush()
 			continue
 		}
 
-		w := max(RuneWidth(r), 1)
+		// Consume a whole grapheme cluster so a flag, ZWJ family, or combining
+		// mark is never split across a visual row.
+		cluster, cw, csize := nextCluster(text[i:])
+		if csize == 0 {
+			break
+		}
+		i += csize
+		w := max(cw, 1)
 		if w > width {
-			r = '?'
+			cluster = "?"
 			w = 1
 		}
 
@@ -254,7 +267,7 @@ func wrapInlineVisualRows(text string, width int) []string {
 			flush()
 		}
 
-		row.WriteRune(r)
+		row.WriteString(cluster)
 		col += w
 	}
 

--- a/input.go
+++ b/input.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -25,7 +26,7 @@ type Input struct {
 	// Reactive state
 	text      *State[string]
 	cursorPos *State[int]
-	scrollPos *State[int] // horizontal scroll offset (first visible rune index)
+	scrollPos *State[int] // horizontal scroll offset (first visible display column, snapped to a cluster boundary)
 	blink     *State[bool]
 	focused   *State[bool]
 }
@@ -105,26 +106,56 @@ func (inp *Input) visibleWidth() int {
 	return w
 }
 
-// ensureCursorVisible adjusts scrollPos so the cursor is within the visible window.
+// ensureCursorVisible adjusts scrollPos (a display column, always snapped to a
+// cluster boundary) so the cursor column is within the visible window.
 func (inp *Input) ensureCursorVisible() {
+	text := inp.text.Get()
 	pos := inp.clampCursorPos()
+	cursorCol := runeIndexToDisplayCol(text, pos)
 	scroll := inp.scrollPos.Get()
 	visible := inp.visibleWidth()
 	if visible <= 0 {
 		return
 	}
 
-	// Cursor is left of the visible window
-	if pos < scroll {
-		inp.scrollPos.Set(pos)
+	// Cursor is left of the visible window: scroll so the cursor's column is the
+	// first visible column (already a cluster boundary).
+	if cursorCol < scroll {
+		inp.scrollPos.Set(cursorCol)
 		return
 	}
 
-	// Cursor is right of the visible window.
-	// Reserve 1 column for the cursor character itself.
-	if pos >= scroll+visible {
-		inp.scrollPos.Set(pos - visible + 1)
+	// Cursor is right of the visible window. Reserve 1 column for the cursor
+	// character itself, then snap the new scroll column down to a cluster start.
+	if cursorCol >= scroll+visible {
+		want := cursorCol - visible + 1
+		inp.scrollPos.Set(inp.snapColToClusterStart(want))
 	}
+}
+
+// snapColToClusterStart snaps a display column down to the nearest cluster-start
+// column at or before it.
+func (inp *Input) snapColToClusterStart(col int) int {
+	if col <= 0 {
+		return 0
+	}
+	text := inp.text.Get()
+	cur := 0
+	for len(text) > 0 {
+		_, w, size := nextCluster(text)
+		if size == 0 {
+			break
+		}
+		if cur+w > col {
+			return cur
+		}
+		cur += w
+		text = text[size:]
+		if cur == col {
+			return cur
+		}
+	}
+	return cur
 }
 
 // Render returns the element tree for the input.
@@ -262,7 +293,11 @@ func (inp *Input) Watchers() []Watcher {
 
 // --- Key Handlers ---
 
-// insertChar inserts a character at the cursor position.
+// insertChar inserts a character at the cursor position. After inserting, the
+// cursor lands on the cluster boundary immediately following the resulting
+// cluster: a base char advances one cluster; a combining mark typed after a base
+// merges into the preceding cluster, and the cursor lands after that combined
+// cluster.
 func (inp *Input) insertChar(ke KeyEvent) {
 	runes := []rune(inp.text.Get())
 	pos := inp.clampCursorPos()
@@ -270,8 +305,12 @@ func (inp *Input) insertChar(ke KeyEvent) {
 	newRunes = append(newRunes, runes[:pos]...)
 	newRunes = append(newRunes, ke.Rune)
 	newRunes = append(newRunes, runes[pos:]...)
-	inp.text.Set(string(newRunes))
-	inp.cursorPos.Set(pos + 1)
+	newText := string(newRunes)
+	inp.text.Set(newText)
+
+	// Re-segment from the previous cluster boundary at/under the old position and
+	// move to the end of the cluster that now contains the inserted rune.
+	inp.cursorPos.Set(clusterEndAfterInsert(newText, pos))
 	inp.blink.Set(true)
 	inp.ensureCursorVisible()
 	if inp.onChange != nil {
@@ -279,66 +318,81 @@ func (inp *Input) insertChar(ke KeyEvent) {
 	}
 }
 
-// backspace deletes the character before the cursor.
+// backspace deletes the cluster before the cursor.
 func (inp *Input) backspace(ke KeyEvent) {
 	runes := []rune(inp.text.Get())
 	pos := inp.clampCursorPos()
 	if pos > 0 {
-		newRunes := append(runes[:pos-1], runes[pos:]...)
+		prev := inp.prevClusterBoundary(pos)
+		newRunes := append(runes[:prev], runes[pos:]...)
 		inp.text.Set(string(newRunes))
-		newPos := pos - 1
-		inp.cursorPos.Set(newPos)
-		// Pin cursor to the right edge while text exceeds visible width,
-		// so each delete scrolls one more character into view.
-		visible := inp.visibleWidth()
-		if len(newRunes) >= visible && newPos >= visible {
-			inp.scrollPos.Set(newPos - visible + 1)
-		} else {
-			inp.scrollPos.Set(0)
-		}
+		inp.cursorPos.Set(prev)
+		inp.ensureCursorVisible()
 		if inp.onChange != nil {
 			inp.onChange(inp.text.Get())
 		}
 	}
 }
 
-// delete deletes the character at the cursor.
+// delete deletes the cluster at the cursor.
 func (inp *Input) delete(ke KeyEvent) {
 	runes := []rune(inp.text.Get())
 	pos := inp.clampCursorPos()
 	if pos < len(runes) {
-		newRunes := append(runes[:pos], runes[pos+1:]...)
+		next := inp.nextClusterBoundary(pos)
+		newRunes := append(runes[:pos], runes[next:]...)
 		inp.text.Set(string(newRunes))
-		visible := inp.visibleWidth()
-		if len(newRunes) >= visible && pos >= visible {
-			inp.scrollPos.Set(pos - visible + 1)
-		} else {
-			inp.scrollPos.Set(0)
-		}
+		inp.ensureCursorVisible()
 		if inp.onChange != nil {
 			inp.onChange(inp.text.Get())
 		}
 	}
 }
 
-// moveLeft moves cursor left.
+// moveLeft moves cursor to the previous cluster boundary.
 func (inp *Input) moveLeft(ke KeyEvent) {
-	pos := inp.cursorPos.Get()
+	pos := inp.clampCursorPos()
 	if pos > 0 {
-		inp.cursorPos.Set(pos - 1)
+		inp.cursorPos.Set(inp.prevClusterBoundary(pos))
 		inp.blink.Set(true)
 		inp.ensureCursorVisible()
 	}
 }
 
-// moveRight moves cursor right.
+// moveRight moves cursor to the next cluster boundary.
 func (inp *Input) moveRight(ke KeyEvent) {
-	pos := inp.cursorPos.Get()
+	pos := inp.clampCursorPos()
 	if pos < utf8.RuneCountInString(inp.text.Get()) {
-		inp.cursorPos.Set(pos + 1)
+		inp.cursorPos.Set(inp.nextClusterBoundary(pos))
 		inp.blink.Set(true)
 		inp.ensureCursorVisible()
 	}
+}
+
+// prevClusterBoundary returns the rune index of the cluster boundary immediately
+// before the given (cluster-aligned) rune position.
+func (inp *Input) prevClusterBoundary(pos int) int {
+	starts := clusterRuneStarts(inp.text.Get())
+	prev := 0
+	for _, st := range starts {
+		if st >= pos {
+			break
+		}
+		prev = st
+	}
+	return prev
+}
+
+// nextClusterBoundary returns the rune index of the cluster boundary immediately
+// after the given (cluster-aligned) rune position.
+func (inp *Input) nextClusterBoundary(pos int) int {
+	starts := clusterRuneStarts(inp.text.Get())
+	for _, st := range starts {
+		if st > pos {
+			return st
+		}
+	}
+	return starts[len(starts)-1]
 }
 
 // moveHome moves cursor to start.
@@ -364,63 +418,102 @@ func (inp *Input) submit(ke KeyEvent) {
 
 // --- Display ---
 
-// displayText returns a viewport-clamped slice of the text with cursor overlay.
+// displayText returns a viewport-clamped slice of the text (by display column)
+// with the cursor glyph overlaid at the cursor's display column. It walks
+// clusters, emits those inside the column window, and pads a single space for a
+// wide cluster whose left half is scrolled off so columns stay aligned.
 func (inp *Input) displayText() string {
 	text := inp.text.Get()
-	runes := []rune(text)
 	pos := inp.clampCursorPos()
 	visible := inp.visibleWidth()
+	focused := inp.focused.Get()
 
 	inp.ensureCursorVisible()
-	scroll := min(
-		// Clamp scroll to valid range
-		max(
+	scroll := max(inp.scrollPos.Get(), 0)
 
-			inp.scrollPos.Get(), 0), len(runes))
-
-	if !inp.focused.Get() {
-		if len(runes) == 0 {
-			return " "
-		}
-		// Show viewport slice
-		end := min(scroll+visible, len(runes))
-		return string(runes[scroll:end])
-	}
-
-	// Build the visible slice with cursor inserted
+	cursorCol := runeIndexToDisplayCol(text, pos)
 	cursor := inp.cursorRune
 	if !inp.blink.Get() {
 		cursor = ' '
 	}
 
-	// Insert cursor into the full rune slice at pos
-	withCursor := make([]rune, 0, len(runes)+1)
-	withCursor = append(withCursor, runes[:pos]...)
-	withCursor = append(withCursor, cursor)
-	withCursor = append(withCursor, runes[pos:]...)
-
-	// The cursor insertion shifts indices after pos by 1.
-	// Adjust scroll start: characters before cursor are unshifted,
-	// characters at/after cursor position are shifted by 1.
-	viewStart := scroll
-	if scroll > pos {
-		viewStart = scroll + 1
+	// Build the column-space stream of glyph units. When focused, a one-column
+	// cursor unit is inserted at the cursor's column, which shifts later glyphs one
+	// column to the right (with-cursor space).
+	type unit struct {
+		s string
+		w int
 	}
+	var units []unit
+	inserted := false
+	col := 0 // running text column
+	insertCursor := func() {
+		if focused && !inserted && col == cursorCol {
+			units = append(units, unit{string(cursor), 1})
+			inserted = true
+		}
+	}
+	rest := text
+	for len(rest) > 0 {
+		insertCursor()
+		cluster, w, size := nextCluster(rest)
+		if size == 0 {
+			break
+		}
+		rest = rest[size:]
+		units = append(units, unit{cluster, w})
+		col += w
+	}
+	insertCursor() // cursor at end of text
 
-	// visible+1 because the cursor character takes a column
-	viewEnd := min(viewStart+visible+1, len(withCursor))
+	// The window is `visible` text columns wide, plus one column for the inserted
+	// cursor when focused. scroll is a text column; shift it into with-cursor space
+	// when it sits past the cursor (the cursor added a column before the window).
+	windowWidth := visible
+	wcScroll := scroll
+	if focused {
+		windowWidth = visible + 1
+		if scroll > cursorCol {
+			wcScroll = scroll + 1
+		}
+	}
+	windowEnd := wcScroll + windowWidth
 
-	return string(withCursor[viewStart:viewEnd])
+	var b strings.Builder
+	wc := 0 // running with-cursor column
+	for _, u := range units {
+		start, end := wc, wc+u.w
+		wc = end
+		if end <= wcScroll {
+			continue
+		}
+		if start >= windowEnd {
+			break
+		}
+		if start < wcScroll {
+			// Wide glyph straddling the left edge: pad its hidden half so columns
+			// stay aligned.
+			b.WriteRune(' ')
+			continue
+		}
+		b.WriteString(u.s)
+	}
+	if b.Len() == 0 {
+		return " "
+	}
+	return b.String()
 }
 
 func (inp *Input) clampCursorPos() int {
 	pos := inp.cursorPos.Get()
+	text := inp.text.Get()
 	if pos < 0 {
 		return 0
 	}
-	max := utf8.RuneCountInString(inp.text.Get())
+	max := utf8.RuneCountInString(text)
 	if pos > max {
 		return max
 	}
-	return pos
+	// Snap to a cluster boundary so the cursor never sits inside a cluster.
+	return snapRuneToClusterStart(text, pos)
 }

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -126,8 +126,8 @@ func TestMarkdown_RenderBlockquote(t *testing.T) {
 	if !strings.Contains(out, "quoted line one") {
 		t.Fatalf("blockquote text missing:\n%s", out)
 	}
-	if buf.Cell(0, 0).Rune != '│' {
-		t.Errorf("expected │ bar at (0,0), got %q", buf.Cell(0, 0).Rune)
+	if buf.Cell(0, 0).Text != "│" {
+		t.Errorf("expected │ bar at (0,0), got %q", buf.Cell(0, 0).Text)
 	}
 }
 
@@ -234,14 +234,14 @@ func TestMarkdown_HeadingHasTrailingSpace(t *testing.T) {
 	buf := NewBuffer(20, 5)
 	m.Render(nil).Render(buf, 20, 5)
 	// Heading on row 0, a blank line on row 1, body on row 2.
-	if buf.Cell(0, 0).Rune != 'T' {
-		t.Fatalf("heading should be on row 0, got %q", buf.Cell(0, 0).Rune)
+	if buf.Cell(0, 0).Text != "T" {
+		t.Fatalf("heading should be on row 0, got %q", buf.Cell(0, 0).Text)
 	}
-	if r := buf.Cell(0, 1).Rune; r != 0 && r != ' ' {
+	if r := buf.Cell(0, 1).Text; r != "" && r != " " {
 		t.Errorf("expected a blank line after the heading, got %q at (0,1)", r)
 	}
-	if buf.Cell(0, 2).Rune != 'b' {
-		t.Errorf("body should be on row 2 after heading + blank line, got %q", buf.Cell(0, 2).Rune)
+	if buf.Cell(0, 2).Text != "b" {
+		t.Errorf("body should be on row 2 after heading + blank line, got %q", buf.Cell(0, 2).Text)
 	}
 }
 
@@ -254,7 +254,7 @@ func TestMarkdown_TableRuleBetweenEveryRow(t *testing.T) {
 	// each starting with the left-tee junction.
 	tees := 0
 	for y := range 10 {
-		if buf.Cell(0, y).Rune == '├' {
+		if buf.Cell(0, y).Text == "├" {
 			tees++
 		}
 	}
@@ -281,20 +281,20 @@ func TestMarkdown_HeadingSpacingBeforeAndAfterDeduped(t *testing.T) {
 	m := NewMarkdown(WithMarkdownSource("# A\n\n## B\n\nbody"), WithMarkdownWidth(20))
 	buf := NewBuffer(20, 8)
 	m.Render(nil).Render(buf, 20, 8)
-	rune0 := func(y int) rune { return buf.Cell(0, y).Rune }
-	if rune0(0) != 'A' {
+	rune0 := func(y int) string { return buf.Cell(0, y).Text }
+	if rune0(0) != "A" {
 		t.Fatalf("row 0 should be 'A', got %q", rune0(0))
 	}
-	if r := rune0(1); r != 0 && r != ' ' {
+	if r := rune0(1); r != "" && r != " " {
 		t.Errorf("row 1 should be blank between the two headings, got %q", r)
 	}
-	if rune0(2) != 'B' {
+	if rune0(2) != "B" {
 		t.Errorf("row 2 should be 'B' (one blank between headings), got %q", rune0(2))
 	}
-	if r := rune0(3); r != 0 && r != ' ' {
+	if r := rune0(3); r != "" && r != " " {
 		t.Errorf("row 3 should be blank after the heading, got %q", r)
 	}
-	if rune0(4) != 'b' {
+	if rune0(4) != "b" {
 		t.Errorf("row 4 should be 'body', got %q", rune0(4))
 	}
 }
@@ -321,8 +321,8 @@ func TestMarkdown_TableFullGrid(t *testing.T) {
 
 	// DefaultMarkdownTheme draws a full rounded grid: outer corners, a top
 	// column junction, a header-rule cross, and column separators.
-	if buf.Cell(0, 0).Rune != '╭' {
-		t.Errorf("top-left corner should be ╭, got %q", buf.Cell(0, 0).Rune)
+	if buf.Cell(0, 0).Text != "╭" {
+		t.Errorf("top-left corner should be ╭, got %q", buf.Cell(0, 0).Text)
 	}
 	for _, want := range []rune{'┬', '┼', '┴', '│'} {
 		if !strings.ContainsRune(out, want) {
@@ -358,9 +358,9 @@ func TestMarkdown_BlockquoteWrapsLongContent(t *testing.T) {
 		t.Fatalf("blockquote content should wrap, not clip; got:\n%s", out)
 	}
 	// Content occupies more than one row, and the bar spans each content row.
-	if buf.Cell(0, 0).Rune != '│' || buf.Cell(0, 1).Rune != '│' {
+	if buf.Cell(0, 0).Text != "│" || buf.Cell(0, 1).Text != "│" {
 		t.Errorf("bar should span wrapped content rows; row0=%q row1=%q",
-			buf.Cell(0, 0).Rune, buf.Cell(0, 1).Rune)
+			buf.Cell(0, 0).Text, buf.Cell(0, 1).Text)
 	}
 }
 
@@ -380,10 +380,11 @@ func TestMarkdown_ListWrapsLongContent(t *testing.T) {
 
 // findCell returns the row,col of the first occurrence of r in the buffer.
 func findCell(buf *Buffer, r rune) (int, int) {
+	want := string(r)
 	w, h := buf.Size()
 	for y := range h {
 		for x := range w {
-			if buf.Cell(x, y).Rune == r {
+			if buf.Cell(x, y).Text == want {
 				return y, x
 			}
 		}

--- a/mock_terminal.go
+++ b/mock_terminal.go
@@ -216,10 +216,10 @@ func (m *MockTerminal) String() string {
 			if cell.IsContinuation() {
 				continue // Skip continuation cells
 			}
-			if cell.Rune == 0 {
+			if cell.Text == "" {
 				sb.WriteRune(' ')
 			} else {
-				sb.WriteRune(cell.Rune)
+				sb.WriteString(cell.Text)
 			}
 		}
 		if y < m.height-1 {
@@ -239,10 +239,10 @@ func (m *MockTerminal) StringTrimmed() string {
 			if cell.IsContinuation() {
 				continue
 			}
-			if cell.Rune == 0 {
+			if cell.Text == "" {
 				line.WriteRune(' ')
 			} else {
-				line.WriteRune(cell.Rune)
+				line.WriteString(cell.Text)
 			}
 		}
 		sb.WriteString(strings.TrimRight(line.String(), " "))

--- a/mount_layout_test.go
+++ b/mount_layout_test.go
@@ -211,7 +211,7 @@ func TestMount_FullAppRenderPipeline(t *testing.T) {
 	for y := range 24 {
 		for x := range 80 {
 			c := app.buffer.Cell(x, y)
-			if c.Rune == '╭' {
+			if c.Text == "╭" {
 				found = true
 				break
 			}
@@ -269,7 +269,7 @@ func extractBufferText(buf *Buffer, width, height int) string {
 	for y := range height {
 		for x := range width {
 			c := buf.Cell(x, y)
-			sb.WriteRune(c.Rune)
+			sb.WriteString(c.Text)
 		}
 		sb.WriteRune('\n')
 	}

--- a/render_element.go
+++ b/render_element.go
@@ -52,12 +52,12 @@ func bufferRowToANSI(buf *Buffer, row int, esc *escBuilder, caps Capabilities) s
 			styleSet = true
 		}
 
-		// Emit the rune (zero rune = empty cell, render as space).
-		r := c.Rune
-		if r == 0 {
-			r = ' '
+		// Emit the cluster text (empty cell renders as a space).
+		if c.Text != "" {
+			esc.WriteString(c.Text)
+		} else {
+			esc.WriteRune(' ')
 		}
-		esc.WriteRune(r)
 	}
 
 	// Close any open hyperlink before resetting style.

--- a/stream_writer.go
+++ b/stream_writer.go
@@ -40,15 +40,22 @@ func (sw *StreamWriter) WriteStyled(text string, style Style) (int, error) {
 	sw.esc.WriteString(text)
 	sw.esc.ResetStyle()
 
-	// Track column position.
-	for _, r := range text {
-		if r == '\n' {
+	// Track column position by cluster width.
+	rest := text
+	for len(rest) > 0 {
+		if rest[0] == '\n' {
+			rest = rest[1:]
 			sw.col = 0
-		} else {
-			sw.col += RuneWidth(r)
-			if sw.width > 0 && sw.col >= sw.width {
-				sw.col = 0
-			}
+			continue
+		}
+		_, cw, size := nextCluster(rest)
+		if size == 0 {
+			break
+		}
+		rest = rest[size:]
+		sw.col += cw
+		if sw.width > 0 && sw.col >= sw.width {
+			sw.col = 0
 		}
 	}
 
@@ -75,15 +82,24 @@ func (sw *StreamWriter) WriteGradient(text string, g Gradient, base ...Style) (i
 
 	sw.esc.Reset()
 
-	for _, r := range text {
-		if r == '\n' {
+	rest := text
+	for len(rest) > 0 {
+		if rest[0] == '\n' {
+			rest = rest[1:]
 			sw.esc.ResetStyle()
 			sw.esc.WriteRune('\n')
 			sw.col = 0
 			continue
 		}
 
-		// Compute gradient position.
+		// Emit one cluster with a single gradient color for the whole cluster.
+		cluster, cw, size := nextCluster(rest)
+		if size == 0 {
+			break
+		}
+		rest = rest[size:]
+
+		// Compute gradient position from the cluster's starting column.
 		w := sw.width
 		if w < 1 {
 			w = 80
@@ -96,9 +112,9 @@ func (sw *StreamWriter) WriteGradient(text string, g Gradient, base ...Style) (i
 		charStyle := baseStyle
 		charStyle.Fg = g.At(t)
 		sw.esc.SetStyle(charStyle, sw.caps)
-		sw.esc.WriteRune(r)
+		sw.esc.WriteString(cluster)
 
-		sw.col += RuneWidth(r)
+		sw.col += cw
 		if sw.width > 0 && sw.col >= sw.width {
 			sw.col = 0
 		}

--- a/table_render_test.go
+++ b/table_render_test.go
@@ -64,9 +64,9 @@ func TestTableRender(t *testing.T) {
 
 			for pos, expectedRune := range tt.expectCells {
 				cell := buf.Cell(pos[0], pos[1])
-				if cell.Rune != expectedRune {
+				if cell.Text != string(expectedRune) {
 					t.Errorf("at (%d,%d): expected rune %q, got %q",
-						pos[0], pos[1], string(expectedRune), string(cell.Rune))
+						pos[0], pos[1], string(expectedRune), cell.Text)
 				}
 			}
 

--- a/terminal_ansi.go
+++ b/terminal_ansi.go
@@ -139,9 +139,9 @@ func (t *ANSITerminal) Flush(changes []CellChange) {
 			t.lastStyle = ch.Cell.Style
 		}
 
-		// Write the character
-		if ch.Cell.Rune != 0 {
-			t.esc.WriteRune(ch.Cell.Rune)
+		// Write the cluster text (empty cell renders as a space).
+		if ch.Cell.Text != "" {
+			t.esc.WriteString(ch.Cell.Text)
 		} else {
 			t.esc.WriteRune(' ')
 		}

--- a/terminal_emulator_test.go
+++ b/terminal_emulator_test.go
@@ -109,9 +109,9 @@ func (e *EmulatorTerminal) Flush(changes []CellChange) {
 			continue
 		}
 		if ch.X >= 0 && ch.X < e.width {
-			r := ch.Cell.Rune
-			if r == 0 {
-				r = ' '
+			r := ' '
+			if ch.Cell.Text != "" {
+				r = []rune(ch.Cell.Text)[0]
 			}
 			e.screen[ch.Y][ch.X] = r
 		}

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -82,8 +82,8 @@ func TestMockTerminal_FlushUpdatesCorrectCells(t *testing.T) {
 			m.Flush(tt.changes)
 
 			cell := m.CellAt(tt.checkX, tt.checkY)
-			if cell.Rune != tt.expected {
-				t.Errorf("CellAt(%d, %d).Rune = %q, want %q", tt.checkX, tt.checkY, cell.Rune, tt.expected)
+			if cell.Text != string(tt.expected) {
+				t.Errorf("CellAt(%d, %d).Text = %q, want %q", tt.checkX, tt.checkY, cell.Text, string(tt.expected))
 			}
 		})
 	}
@@ -103,13 +103,13 @@ func TestMockTerminal_FlushIgnoresOutOfBounds(t *testing.T) {
 	m.Flush(changes)
 
 	// Border cells should still be spaces
-	if m.CellAt(0, 0).Rune != ' ' {
+	if m.CellAt(0, 0).Text != " " {
 		t.Error("Out-of-bounds flush affected (0,0)")
 	}
-	if m.CellAt(9, 0).Rune != ' ' {
+	if m.CellAt(9, 0).Text != " " {
 		t.Error("Out-of-bounds flush affected (9,0)")
 	}
-	if m.CellAt(0, 9).Rune != ' ' {
+	if m.CellAt(0, 9).Text != " " {
 		t.Error("Out-of-bounds flush affected (0,9)")
 	}
 }
@@ -160,10 +160,10 @@ func TestMockTerminal_Clear(t *testing.T) {
 	m.Clear()
 
 	// Check that cells are cleared
-	if m.CellAt(0, 0).Rune != ' ' {
+	if m.CellAt(0, 0).Text != " " {
 		t.Errorf("Clear() did not reset cell (0,0)")
 	}
-	if m.CellAt(5, 5).Rune != ' ' {
+	if m.CellAt(5, 5).Text != " " {
 		t.Errorf("Clear() did not reset cell (5,5)")
 	}
 
@@ -311,8 +311,8 @@ func TestMockTerminal_CellAt(t *testing.T) {
 	})
 
 	cell := m.CellAt(3, 4)
-	if cell.Rune != 'Z' {
-		t.Errorf("CellAt(3,4).Rune = %q, want 'Z'", cell.Rune)
+	if cell.Text != "Z" {
+		t.Errorf("CellAt(3,4).Text = %q, want \"Z\"", cell.Text)
 	}
 	if !cell.Style.HasAttr(AttrBold) {
 		t.Error("Cell should be bold")
@@ -327,13 +327,13 @@ func TestMockTerminal_CellAtOutOfBounds(t *testing.T) {
 
 	// Out of bounds should return empty cell
 	cell := m.CellAt(-1, 0)
-	if cell.Rune != 0 {
-		t.Errorf("CellAt(-1,0).Rune = %q, want 0", cell.Rune)
+	if cell.Text != "" {
+		t.Errorf("CellAt(-1,0).Text = %q, want \"\"", cell.Text)
 	}
 
 	cell = m.CellAt(10, 0)
-	if cell.Rune != 0 {
-		t.Errorf("CellAt(10,0).Rune = %q, want 0", cell.Rune)
+	if cell.Text != "" {
+		t.Errorf("CellAt(10,0).Text = %q, want \"\"", cell.Text)
 	}
 }
 
@@ -351,7 +351,7 @@ func TestMockTerminal_Reset(t *testing.T) {
 	m.Reset()
 
 	// Verify all states are reset
-	if m.CellAt(0, 0).Rune != ' ' {
+	if m.CellAt(0, 0).Text != " " {
 		t.Error("Reset() should clear cells")
 	}
 	x, y := m.Cursor()
@@ -435,13 +435,13 @@ func TestMockTerminal_Resize(t *testing.T) {
 			// Check content preservation
 			cell := m.CellAt(tt.checkAfter.x, tt.checkAfter.y)
 			if tt.checkAfter.shouldPreserve {
-				if cell.Rune != tt.checkAfter.expectedRune {
-					t.Errorf("CellAt(%d,%d).Rune = %q, want %q", tt.checkAfter.x, tt.checkAfter.y, cell.Rune, tt.checkAfter.expectedRune)
+				if cell.Text != string(tt.checkAfter.expectedRune) {
+					t.Errorf("CellAt(%d,%d).Text = %q, want %q", tt.checkAfter.x, tt.checkAfter.y, cell.Text, string(tt.checkAfter.expectedRune))
 				}
 			} else {
 				// Out of bounds should return empty cell
-				if cell.Rune != 0 && cell.Rune != ' ' {
-					t.Errorf("CellAt(%d,%d) should be empty after shrink, got %q", tt.checkAfter.x, tt.checkAfter.y, cell.Rune)
+				if cell.Text != "" && cell.Text != " " {
+					t.Errorf("CellAt(%d,%d) should be empty after shrink, got %q", tt.checkAfter.x, tt.checkAfter.y, cell.Text)
 				}
 			}
 		})
@@ -460,8 +460,8 @@ func TestMockTerminal_FlushWithWideCharacters(t *testing.T) {
 
 	// Check primary cell
 	cell := m.CellAt(0, 0)
-	if cell.Rune != '中' {
-		t.Errorf("CellAt(0,0).Rune = %q, want '中'", cell.Rune)
+	if cell.Text != "中" {
+		t.Errorf("CellAt(0,0).Text = %q, want \"中\"", cell.Text)
 	}
 	if cell.Width != 2 {
 		t.Errorf("CellAt(0,0).Width = %d, want 2", cell.Width)

--- a/text_wrap.go
+++ b/text_wrap.go
@@ -39,21 +39,27 @@ func wrapParagraph(text string, maxWidth int) []string {
 		ww := stringWidth(word)
 
 		if ww > maxWidth {
-			// Word is longer than line — flush then break character by character
+			// Word is longer than line — flush then break on cluster boundaries
+			// so a grapheme cluster is never split mid-line.
 			if lineWidth > 0 {
 				lines = append(lines, buf.String())
 				buf.Reset()
 				lineWidth = 0
 			}
-			for _, r := range word {
-				rw := RuneWidth(r)
-				if lineWidth+rw > maxWidth && lineWidth > 0 {
+			rest := word
+			for len(rest) > 0 {
+				cluster, cw, size := nextCluster(rest)
+				if size == 0 {
+					break
+				}
+				rest = rest[size:]
+				if lineWidth+cw > maxWidth && lineWidth > 0 {
 					lines = append(lines, buf.String())
 					buf.Reset()
 					lineWidth = 0
 				}
-				buf.WriteRune(r)
-				lineWidth += rw
+				buf.WriteString(cluster)
+				lineWidth += cw
 			}
 			continue
 		}
@@ -87,12 +93,80 @@ type styledRune struct {
 	link string
 }
 
+// styledCluster is one grapheme cluster carrying the style and link of its base
+// rune's source span, with the cluster's display width.
+type styledCluster struct {
+	text  string
+	width int
+	st    Style
+	link  string
+}
+
+// segmentStyledRunes segments a styled-rune stream into grapheme clusters. A
+// cluster takes its base (first) rune's style and link, so a cluster whose base
+// and combining mark fall in adjacent spans stays one styled unit.
+func segmentStyledRunes(rs []styledRune) []styledCluster {
+	if len(rs) == 0 {
+		return nil
+	}
+	// Build the concatenated text and a parallel byte->index map to recover the
+	// base rune's style/link for each cluster.
+	var b strings.Builder
+	starts := make([]int, 0, len(rs)) // byte offset where each styledRune begins
+	for _, sr := range rs {
+		starts = append(starts, b.Len())
+		b.WriteRune(sr.r)
+	}
+	s := b.String()
+
+	var out []styledCluster
+	pos := 0
+	ri := 0
+	for pos < len(s) {
+		cluster, w, size := nextCluster(s[pos:])
+		if size == 0 {
+			break
+		}
+		// Advance ri to the styledRune whose byte offset matches pos (the base).
+		for ri < len(starts) && starts[ri] < pos {
+			ri++
+		}
+		base := rs[0]
+		if ri < len(rs) {
+			base = rs[ri]
+		}
+		out = append(out, styledCluster{
+			text:  cluster,
+			width: w,
+			st:    base.st,
+			link:  base.link,
+		})
+		pos += size
+	}
+	return out
+}
+
+// segmentLineClusters flattens a wrapped rich-text line into a styled-cluster
+// stream. Each cluster's style is the element base merged with its span style.
+func segmentLineClusters(line []TextSpan, base Style) []styledCluster {
+	var rs []styledRune
+	for _, span := range line {
+		st := mergeSpanStyle(base, span.Style)
+		for _, r := range span.Text {
+			rs = append(rs, styledRune{r: r, st: st, link: span.Link})
+		}
+	}
+	return segmentStyledRunes(rs)
+}
+
 // wrapSpans wraps styled spans to maxWidth using word boundaries, mirroring
 // wrapParagraph. Words are delimited by actual whitespace in the concatenated
 // text (a span boundary is NOT a word boundary), so a single word may mix styles
-// (e.g. "a**b**c" is one word "abc"). Each rune keeps its source span's style, so
-// a styled run stays styled across a line break. Adjacent same-style runes on a
-// line are merged into one segment. Newlines start new lines.
+// (e.g. "a**b**c" is one word "abc"). The flattened styled-rune stream is
+// segmented into grapheme clusters, so a cluster is never split at a line break
+// or at a span boundary; each cluster keeps its base rune's style/link. Adjacent
+// same-style clusters on a line are merged into one segment. Newlines start new
+// lines.
 func wrapSpans(spans []TextSpan, maxWidth int) [][]TextSpan {
 	if maxWidth < 1 {
 		return [][]TextSpan{{}}
@@ -107,13 +181,13 @@ func wrapSpans(spans []TextSpan, maxWidth int) [][]TextSpan {
 		cur = nil
 		lineWidth = 0
 	}
-	// emit appends styled runes to cur, merging same-style into the last segment.
-	emit := func(rs []styledRune) {
-		for _, sr := range rs {
-			if n := len(cur); n > 0 && cur[n-1].Style == sr.st && cur[n-1].Link == sr.link {
-				cur[n-1].Text += string(sr.r)
+	// emit appends styled clusters to cur, merging same-style into the last segment.
+	emit := func(cs []styledCluster) {
+		for _, sc := range cs {
+			if n := len(cur); n > 0 && cur[n-1].Style == sc.st && cur[n-1].Link == sc.link {
+				cur[n-1].Text += sc.text
 			} else {
-				cur = append(cur, TextSpan{Text: string(sr.r), Style: sr.st, Link: sr.link})
+				cur = append(cur, TextSpan{Text: sc.text, Style: sc.st, Link: sc.link})
 			}
 		}
 	}
@@ -132,53 +206,54 @@ func wrapSpans(spans []TextSpan, maxWidth int) [][]TextSpan {
 	}
 
 	var word []styledRune
-	wordWidth := 0
 	placeWord := func() {
 		if len(word) == 0 {
 			return
 		}
+		clusters := segmentStyledRunes(word)
+		wordWidth := 0
+		for _, c := range clusters {
+			wordWidth += c.width
+		}
 		if wordWidth > maxWidth {
-			// Word longer than the line: flush current, then hard-break by rune.
+			// Word longer than the line: flush current, then hard-break by cluster.
 			if lineWidth > 0 {
 				flush()
 			}
-			for _, sr := range word {
-				rw := RuneWidth(sr.r)
-				if lineWidth+rw > maxWidth && lineWidth > 0 {
+			for _, c := range clusters {
+				if lineWidth+c.width > maxWidth && lineWidth > 0 {
 					flush()
 				}
-				emit([]styledRune{sr})
-				lineWidth += rw
+				emit([]styledCluster{c})
+				lineWidth += c.width
 			}
 			word = word[:0]
-			wordWidth = 0
 			return
 		}
 		switch {
 		case lineWidth == 0:
-			emit(word)
+			emit(clusters)
 			lineWidth = wordWidth
 		case lineWidth+1+wordWidth <= maxWidth:
 			// If the separator sits between two words of the same link, give it
 			// that link's style+target so the link renders as one continuous run.
 			var sepSt Style
 			var sepLink string
-			if len(word) > 0 && word[0].link != "" {
-				if n := len(cur); n > 0 && cur[n-1].Link == word[0].link {
-					sepSt = word[0].st
-					sepLink = word[0].link
+			if len(clusters) > 0 && clusters[0].link != "" {
+				if n := len(cur); n > 0 && cur[n-1].Link == clusters[0].link {
+					sepSt = clusters[0].st
+					sepLink = clusters[0].link
 				}
 			}
 			emitSpace(sepSt, sepLink)
-			emit(word)
+			emit(clusters)
 			lineWidth += 1 + wordWidth
 		default:
 			flush()
-			emit(word)
+			emit(clusters)
 			lineWidth = wordWidth
 		}
 		word = word[:0]
-		wordWidth = 0
 	}
 
 	for _, sp := range spans {
@@ -193,7 +268,6 @@ func wrapSpans(spans []TextSpan, maxWidth int) [][]TextSpan {
 				placeWord()
 			default:
 				word = append(word, styledRune{r: r, st: sp.Style, link: sp.Link})
-				wordWidth += RuneWidth(r)
 			}
 		}
 	}

--- a/textarea.go
+++ b/textarea.go
@@ -279,13 +279,16 @@ func (t *TextArea) Watchers() []Watcher {
 
 // --- Key Handlers ---
 
-// insertChar inserts a character at the cursor position.
+// insertChar inserts a character at the cursor position. The cursor then lands
+// on the cluster boundary after the resulting cluster (a combining mark merges
+// into the preceding cluster; see Input.insertChar).
 func (t *TextArea) insertChar(ke KeyEvent) {
 	runes := []rune(t.text.Get())
 	pos := t.clampCursorPos()
 	newRunes := append(runes[:pos], append([]rune{ke.Rune}, runes[pos:]...)...)
-	t.text.Set(string(newRunes))
-	t.cursorPos.Set(pos + 1)
+	newText := string(newRunes)
+	t.text.Set(newText)
+	t.cursorPos.Set(clusterEndAfterInsert(newText, pos))
 	t.blink.Set(true)
 }
 
@@ -299,52 +302,79 @@ func (t *TextArea) insertNewline(ke KeyEvent) {
 	t.blink.Set(true)
 }
 
-// backspace deletes the character before the cursor.
+// backspace deletes the cluster before the cursor.
 func (t *TextArea) backspace(ke KeyEvent) {
 	runes := []rune(t.text.Get())
 	pos := t.clampCursorPos()
 	if pos > 0 {
-		newRunes := append(runes[:pos-1], runes[pos:]...)
+		prev := t.prevClusterBoundary(pos)
+		newRunes := append(runes[:prev], runes[pos:]...)
 		t.text.Set(string(newRunes))
-		t.cursorPos.Set(pos - 1)
+		t.cursorPos.Set(prev)
 	}
 }
 
-// delete deletes the character at the cursor.
+// delete deletes the cluster at the cursor.
 func (t *TextArea) delete(ke KeyEvent) {
 	runes := []rune(t.text.Get())
 	pos := t.clampCursorPos()
 	if pos < len(runes) {
-		newRunes := append(runes[:pos], runes[pos+1:]...)
+		next := t.nextClusterBoundary(pos)
+		newRunes := append(runes[:pos], runes[next:]...)
 		t.text.Set(string(newRunes))
 	}
 }
 
-// moveLeft moves cursor left.
+// moveLeft moves cursor to the previous cluster boundary.
 func (t *TextArea) moveLeft(ke KeyEvent) {
-	pos := t.cursorPos.Get()
+	pos := t.clampCursorPos()
 	if pos > 0 {
-		t.cursorPos.Set(pos - 1)
+		t.cursorPos.Set(t.prevClusterBoundary(pos))
 		t.blink.Set(true)
 	}
 }
 
-// moveRight moves cursor right.
+// moveRight moves cursor to the next cluster boundary.
 func (t *TextArea) moveRight(ke KeyEvent) {
-	pos := t.cursorPos.Get()
+	pos := t.clampCursorPos()
 	if pos < utf8.RuneCountInString(t.text.Get()) {
-		t.cursorPos.Set(pos + 1)
+		t.cursorPos.Set(t.nextClusterBoundary(pos))
 		t.blink.Set(true)
 	}
 }
 
-// moveUp moves cursor up one line.
+// prevClusterBoundary returns the rune index of the cluster boundary immediately
+// before the given (cluster-aligned) rune position.
+func (t *TextArea) prevClusterBoundary(pos int) int {
+	starts := clusterRuneStarts(t.text.Get())
+	prev := 0
+	for _, st := range starts {
+		if st >= pos {
+			break
+		}
+		prev = st
+	}
+	return prev
+}
+
+// nextClusterBoundary returns the rune index of the cluster boundary immediately
+// after the given (cluster-aligned) rune position.
+func (t *TextArea) nextClusterBoundary(pos int) int {
+	starts := clusterRuneStarts(t.text.Get())
+	for _, st := range starts {
+		if st > pos {
+			return st
+		}
+	}
+	return starts[len(starts)-1]
+}
+
+// moveUp moves cursor up one line, preserving the cursor's rune column.
 func (t *TextArea) moveUp(ke KeyEvent) {
 	lines := t.wrapText()
 	row, col := t.cursorRowCol(lines)
 	if row > 0 {
-		prevLine := lines[row-1]
-		prevLen := utf8.RuneCountInString(prevLine)
+		prevLen := utf8.RuneCountInString(lines[row-1])
 		if col > prevLen {
 			col = prevLen
 		}
@@ -353,13 +383,12 @@ func (t *TextArea) moveUp(ke KeyEvent) {
 	}
 }
 
-// moveDown moves cursor down one line.
+// moveDown moves cursor down one line, preserving the cursor's rune column.
 func (t *TextArea) moveDown(ke KeyEvent) {
 	lines := t.wrapText()
 	row, col := t.cursorRowCol(lines)
 	if row < len(lines)-1 {
-		nextLine := lines[row+1]
-		nextLen := utf8.RuneCountInString(nextLine)
+		nextLen := utf8.RuneCountInString(lines[row+1])
 		if col > nextLen {
 			col = nextLen
 		}
@@ -409,11 +438,12 @@ func (t *TextArea) wrapWidth() int {
 	return w
 }
 
-// wrapText wraps the text to fit within the content width, respecting
-// embedded newlines. Lines break at display-column boundaries (CJK and emoji
-// runes occupy two columns), never mid-rune: a wide rune that does not fit
-// moves to the next line. Cursor math stays in rune indices, which remain
-// consistent because wrapping only changes where lines split, not their runes.
+// wrapText wraps the text to fit within the content width, respecting embedded
+// newlines. Lines break at display-column boundaries on grapheme-cluster
+// boundaries (CJK, emoji, flags, and ZWJ families occupy whole columns), never
+// mid-cluster: a cluster that does not fit moves to the next line. Cursor math
+// stays in rune indices, which remain consistent because wrapping only changes
+// where lines split, not their runes.
 func (t *TextArea) wrapText() []string {
 	text := t.text.Get()
 	if text == "" {
@@ -432,28 +462,36 @@ func (t *TextArea) wrapText() []string {
 			continue
 		}
 
-		// Wrap this paragraph to width
-		currentLine := make([]rune, 0)
+		// Wrap this paragraph to width on cluster boundaries.
+		var currentLine strings.Builder
 		currentWidth := 0
-		for _, r := range para {
-			rw := RuneWidth(r)
-			// The len guard keeps a rune wider than the wrap width on a line
-			// of its own instead of emitting empty lines before it.
-			if width > 0 && len(currentLine) > 0 && currentWidth+rw > width {
-				lines = append(lines, string(currentLine))
-				currentLine = currentLine[:0]
+		rest := para
+		for len(rest) > 0 {
+			cluster, cw, size := nextCluster(rest)
+			if size == 0 {
+				break
+			}
+			rest = rest[size:]
+			// The non-empty guard keeps a cluster wider than the wrap width on a
+			// line of its own instead of emitting empty lines before it.
+			if width > 0 && currentLine.Len() > 0 && currentWidth+cw > width {
+				lines = append(lines, currentLine.String())
+				currentLine.Reset()
 				currentWidth = 0
 			}
-			currentLine = append(currentLine, r)
-			currentWidth += rw
+			currentLine.WriteString(cluster)
+			currentWidth += cw
 		}
-		lines = append(lines, string(currentLine))
+		lines = append(lines, currentLine.String())
 	}
 
 	return lines
 }
 
-// cursorRowCol returns the row and column of the cursor.
+// cursorRowCol returns the row and column (a rune index within the wrapped line)
+// of the cursor. Because navigation and editing keep cursorPos on a cluster
+// boundary, the reported column always lands between clusters, so a wide or
+// multi-rune cluster is never split by the cursor.
 //
 // A cursor at the end of a display-full line has no column left to render in,
 // so it moves to the start of the next visual line (downstream affinity). This
@@ -497,7 +535,8 @@ func (t *TextArea) cursorRowCol(lines []string) (row, col int) {
 	return currentRow, currentCol
 }
 
-// posFromRowCol converts row/col back to absolute position.
+// posFromRowCol converts row/col (a rune index within the line) back to an
+// absolute rune position.
 func (t *TextArea) posFromRowCol(lines []string, targetRow, targetCol int) int {
 	text := t.text.Get()
 	textRunes := []rune(text)
@@ -580,6 +619,7 @@ func (t *TextArea) lineWithCursor(lineIdx int) string {
 		if !t.blink.Get() {
 			cursor = " "
 		}
+		// col is a rune index within the line (always on a cluster boundary).
 		runes := []rune(line)
 		if col >= len(runes) {
 			// A display-full line ended by a hard newline keeps the cursor at
@@ -609,12 +649,14 @@ func (t *TextArea) lineWithCursor(lineIdx int) string {
 
 func (t *TextArea) clampCursorPos() int {
 	pos := t.cursorPos.Get()
+	text := t.text.Get()
 	if pos < 0 {
 		return 0
 	}
-	max := utf8.RuneCountInString(t.text.Get())
+	max := utf8.RuneCountInString(text)
 	if pos > max {
 		return max
 	}
-	return pos
+	// Snap to a cluster boundary so the cursor never sits inside a cluster.
+	return snapRuneToClusterStart(text, pos)
 }

--- a/textarea.go
+++ b/textarea.go
@@ -630,7 +630,11 @@ func (t *TextArea) lineWithCursor(lineIdx int) string {
 				if !t.blink.Get() {
 					return line
 				}
-				return string(runes[:len(runes)-1]) + string(t.cursorRune)
+				// Overlay the whole final grapheme cluster, not just its last
+				// rune, so a flag or ZWJ family at the line end is not split.
+				starts := clusterRuneStarts(line)
+				lastStart := starts[len(starts)-2]
+				return string(runes[:lastStart]) + string(t.cursorRune)
 			}
 			return line + cursor
 		}

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -183,10 +183,10 @@ func renderedRows(t *testing.T, c Component, width int) []string {
 			if cell.IsContinuation() {
 				continue
 			}
-			if cell.Rune == 0 {
+			if cell.Text == "" {
 				sb.WriteRune(' ')
 			} else {
-				sb.WriteRune(cell.Rune)
+				sb.WriteString(cell.Text)
 			}
 		}
 		rows = append(rows, sb.String())


### PR DESCRIPTION
## Summary

go-tui measured text one Unicode code point at a time and counted genuinely zero-width runes (combining marks, ZWJ, variation selectors) as width 1. So a grapheme cluster the terminal draws as a single glyph got over-counted: a flag (two regional indicators) scored 4, a 👨‍👩‍👧‍👦 ZWJ family scored 11, a skin-tone 👍🏽 scored 4, and "café" written with a combining accent scored 5. That one width number drives wrapping, alignment, layout sizing, cell placement, and cursor math, so @ST33LDI9ITAL's report (#95) of offset box frames, cursor drift, and broken word wrap all trace back to it. Single-codepoint emoji and bare CJK already worked, which is why it looked fine in casual use; the breakage is specific to multi-codepoint clusters.

The fix adds one grapheme primitive and routes every width-dependent path through it:

- **`grapheme.go`** adds `nextCluster` (with a `[]byte` twin for the inline scanner) that segments a string into grapheme clusters and reports each cluster's display width. It is an in-house pragmatic profile rather than a dependency: combining marks, ZWJ emoji sequences, regional-indicator pairs, emoji modifiers, and variation selectors. `stringWidth` becomes a sum of cluster widths, so wrapping, alignment, truncation, layout sizing, rich text, and markdown all read correctly for free.
- **Rendering** stores a whole cluster in one cell and draws it as one glyph. The buffer write path, the gradient and background loop, rich-text spans, the border title, and ANSI emission all iterate clusters.
- **Editable widgets** navigate and edit by whole cluster: left/right, backspace/delete, and typing snap to cluster boundaries, and wrapping never splits one. The textarea cursor column stays a rune index that always lands on a cluster boundary, so wide content renders correctly without changing the existing cursor model.
- **Inline streaming** (`PrintAbove` / `StreamAbove`) tracks columns by cluster.

I went in-house instead of taking the suggested `runeseg`/`uniseg` dependency, to keep the golang.org/x-only footprint. Credit to @ST33LDI9ITAL for the diagnosis and the grapheme-rendering direction.

Review turned up two real cluster-splitting bugs that went in with their own tests: the textarea block cursor at a display-full line end dropped only the final rune, orphaning half a flag, and `Buffer.SetStringGradient` was the last per-rune writer left. Both now operate on whole clusters.

## Breaking change

`Cell.Rune rune` is replaced by `Cell.Text string`, the cell's cluster text ("" for continuation and blank cells). Code that read or built a `Cell` through its `Rune` field moves to `Text`. A cell now holds the text it draws, which simplifies emission, the buffer, and tests.

## Known limitations

The profile targets emoji and combining-mark correctness, not full UAX #29. Hangul jamo composition, Prepend, Indic conjuncts, and emoji tag sequences (subdivision flags) are out of scope, and a cluster split across two streaming `Write()` calls renders as separate glyphs (partial UTF-8 already does not survive a write boundary today).

Fixes #95.
