### PR TITLE
feat: add border title alignment support (left/center/right)

### DIFF
--- a/border.go
+++ b/border.go
@@ -365,9 +365,9 @@ func DrawBoxGradientClipped(buf *Buffer, rect Rect, border BorderStyle, g Gradie
 }
 
 // DrawBoxWithTitle draws a box border with a title in the top border.
-// The title is centered in the top border and truncated if too long.
+// The title is aligned (default: center) and truncated if too long.
 // If the rectangle is smaller than 2x2, the function does nothing.
-func DrawBoxWithTitle(buf *Buffer, rect Rect, border BorderStyle, title string, style Style) {
+func DrawBoxWithTitle(buf *Buffer, rect Rect, border BorderStyle, title string, style Style, align ...TextAlign) {
 	if rect.Width < 2 || rect.Height < 2 {
 		return
 	}
@@ -379,7 +379,7 @@ func DrawBoxWithTitle(buf *Buffer, rect Rect, border BorderStyle, title string, 
 	DrawBox(buf, rect, border, style)
 
 	// Draw the title
-	drawBoxTitle(buf, rect, title, style)
+	drawBoxTitle(buf, rect, title, style, align...)
 }
 
 // titleCluster is one grapheme cluster of a border title with its display width.
@@ -388,10 +388,14 @@ type titleCluster struct {
 	width int
 }
 
-// drawBoxTitle draws a centered title string on the top border line of the box.
+// drawBoxTitle draws an aligned title string on the top border line of the box.
 // drawBoxTitle does not draw the box itself — use DrawBoxWithTitle for that.
-func drawBoxTitle(buf *Buffer, rect Rect, title string, style Style) {
-	clusters, startX, ok := prepareTitle(title, rect)
+func drawBoxTitle(buf *Buffer, rect Rect, title string, style Style, align ...TextAlign) {
+	titleAlign := TextAlignCenter
+	if len(align) > 0 {
+		titleAlign = align[0]
+	}
+	clusters, startX, ok := prepareTitle(title, rect, titleAlign)
 	if !ok {
 		return
 	}
@@ -402,14 +406,18 @@ func drawBoxTitle(buf *Buffer, rect Rect, title string, style Style) {
 	}
 }
 
-// drawBoxTitleClipped draws a centered title string on the top border line,
+// drawBoxTitleClipped draws an aligned title string on the top border line,
 // skipping any cluster outside the given clip rectangle.
-func drawBoxTitleClipped(buf *Buffer, rect Rect, title string, style Style, clipRect Rect) {
+func drawBoxTitleClipped(buf *Buffer, rect Rect, title string, style Style, clipRect Rect, align ...TextAlign) {
 	// Reject if the title row is outside the clip rect's Y range.
 	if rect.Y < clipRect.Y || rect.Y >= clipRect.Y+clipRect.Height {
 		return
 	}
-	clusters, startX, ok := prepareTitle(title, rect)
+	titleAlign := TextAlignCenter
+	if len(align) > 0 {
+		titleAlign = align[0]
+	}
+	clusters, startX, ok := prepareTitle(title, rect, titleAlign)
 	if !ok {
 		return
 	}
@@ -422,9 +430,9 @@ func drawBoxTitleClipped(buf *Buffer, rect Rect, title string, style Style, clip
 	}
 }
 
-// prepareTitle truncates and centers a title for the given rectangle, breaking
+// prepareTitle truncates and aligns a title for the given rectangle, breaking
 // on grapheme-cluster boundaries so a cluster is never split at the clip edge.
-func prepareTitle(title string, rect Rect) (clusters []titleCluster, startX int, ok bool) {
+func prepareTitle(title string, rect Rect, align TextAlign) (clusters []titleCluster, startX int, ok bool) {
 	availableWidth := rect.Width - 2
 	if availableWidth <= 0 {
 		return nil, 0, false
@@ -446,7 +454,14 @@ func prepareTitle(title string, rect Rect) (clusters []titleCluster, startX int,
 	if len(clusters) == 0 {
 		return nil, 0, false
 	}
-	startX = rect.X + 1 + (availableWidth-titleWidth)/2
+	switch align {
+	case TextAlignLeft:
+		startX = rect.X + 1
+	case TextAlignRight:
+		startX = rect.X + rect.Width - 1 - titleWidth
+	default:
+		startX = rect.X + 1 + (availableWidth-titleWidth)/2
+	}
 	return clusters, startX, true
 }
 

--- a/border_test.go
+++ b/border_test.go
@@ -387,6 +387,46 @@ func TestDrawBoxWithTitle_WideCharTitle(t *testing.T) {
 	}
 }
 
+type alignTC struct {
+	align []TextAlign
+	want  int // expected startX of the title
+}
+
+func TestDrawBoxWithTitle_Alignment(t *testing.T) {
+	tests := map[string]alignTC{
+		"LeftAligned":           {align: []TextAlign{TextAlignLeft}, want: 1},
+		"RightAligned":          {align: []TextAlign{TextAlignRight}, want: 10},
+		"DefaultBackwardCompat": {align: nil, want: 5},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			buf := NewBuffer(20, 5)
+			rectWidth := 15
+			style := NewStyle()
+			DrawBoxWithTitle(buf, NewRect(0, 0, 15, 3), BorderSingle, "Test", style, tt.align...)
+			if buf.Cell(0, 0).Rune != '┌' {
+				t.Errorf("TopLeft = %q, want '┌'", buf.Cell(0, 0).Rune)
+			}
+			if buf.Cell(14, 0).Rune != '┐' {
+				t.Errorf("TopRight = %q, want '┐'", buf.Cell(14, 0).Rune)
+			}
+			for i, r := range "Test" {
+				cell := buf.Cell(tt.want+i, 0)
+				if cell.Rune != r {
+					t.Errorf("Title at %d = %q, want %q", tt.want+i, cell.Rune, r)
+				}
+			}
+			// Horizontal line should appear adjacent to the title
+			adjX := tt.want + len("Test")
+			if adjX < rectWidth-1 {
+				if buf.Cell(adjX, 0).Rune != '─' {
+					t.Errorf("Horizontal line at %d = %q, want '─'", adjX, buf.Cell(adjX, 0).Rune)
+				}
+			}
+		})
+	}
+}
+
 func TestDrawBoxClipped(t *testing.T) {
 	type tc struct {
 		boxRect  Rect

--- a/element.go
+++ b/element.go
@@ -57,10 +57,11 @@ type Element struct {
 	dirty  bool
 
 	// Visual properties
-	border      BorderStyle
-	borderStyle Style
-	background  *Style // nil = transparent
-	borderTitle string // title text drawn in the top border (DrawBoxWithTitle)
+	border           BorderStyle
+	borderStyle      Style
+	background       *Style    // nil = transparent
+	borderTitle      string    // title text drawn in the top border (DrawBoxWithTitle)
+	borderTitleAlign TextAlign // alignment of the border title (default TextAlignCenter)
 
 	// Text properties
 	text         string
@@ -136,8 +137,9 @@ type Element struct {
 // By default, an Element has Auto width/height (flexes to fill available space).
 func New(opts ...Option) *Element {
 	e := &Element{
-		style: DefaultLayoutStyle(),
-		dirty: true,
+		style:            DefaultLayoutStyle(),
+		borderTitleAlign: TextAlignCenter,
+		dirty:            true,
 	}
 	for _, opt := range opts {
 		opt(e)

--- a/element_accessors.go
+++ b/element_accessors.go
@@ -47,6 +47,16 @@ func (e *Element) SetBorderTitle(title string) {
 	e.borderTitle = title
 }
 
+// BorderTitleAlign returns the alignment of the border title.
+func (e *Element) BorderTitleAlign() TextAlign {
+	return e.borderTitleAlign
+}
+
+// SetBorderTitleAlign sets the alignment of the border title.
+func (e *Element) SetBorderTitleAlign(align TextAlign) {
+	e.borderTitleAlign = align
+}
+
 // Background returns the background style, or nil if transparent.
 func (e *Element) Background() *Style {
 	return e.background

--- a/element_options.go
+++ b/element_options.go
@@ -194,6 +194,14 @@ func WithBorderTitle(title string) Option {
 	}
 }
 
+// WithBorderTitleAlign sets the alignment of the border title (left, center, or right).
+// Default is TextAlignCenter (original behavior).
+func WithBorderTitleAlign(align TextAlign) Option {
+	return func(e *Element) {
+		e.borderTitleAlign = align
+	}
+}
+
 // WithBorderStyle sets the color/attributes for the border.
 func WithBorderStyle(style Style) Option {
 	return func(e *Element) {

--- a/element_render.go
+++ b/element_render.go
@@ -135,7 +135,7 @@ func renderElement(buf *Buffer, e *Element, inherited inheritedStyle) {
 			DrawBox(buf, rect, e.border, e.borderStyle)
 		}
 		if e.borderTitle != "" {
-			drawBoxTitle(buf, rect, e.borderTitle, e.borderStyle)
+			drawBoxTitle(buf, rect, e.borderTitle, e.borderStyle, e.borderTitleAlign)
 		}
 	}
 
@@ -247,7 +247,7 @@ func renderClippedElement(buf *Buffer, e *Element, clipRect Rect, scrollX, scrol
 			DrawBoxClipped(buf, screenRect, e.border, e.borderStyle, clipRect)
 		}
 		if e.borderTitle != "" {
-			drawBoxTitleClipped(buf, screenRect, e.borderTitle, e.borderStyle, clipRect)
+			drawBoxTitleClipped(buf, screenRect, e.borderTitle, e.borderStyle, clipRect, e.borderTitleAlign)
 		}
 	}
 


### PR DESCRIPTION
Adds `WithBorderTitleAlign(align TextAlign)` option with `BorderTitleAlign()`/`SetBorderTitleAlign()` accessors, following the same pattern as `WithTextAlign`.

- element.go: borderTitleAlign field (default TextAlignCenter)
- element_options.go: WithBorderTitleAlign Option
- element_accessors.go: BorderTitleAlign/SetBorderTitleAlign
- border.go: variadic align parameter on title drawing functions
- element_render.go: passes borderTitleAlign through
- border_test.go: 3 new tests