### PR TITLE
feat: add WithPreRenderHook app option

### DIFF
--- a/app.go
+++ b/app.go
@@ -79,6 +79,7 @@ type App struct {
 	mounts         *mountState
 	dispatchTable  *dispatchTable // Key broadcast dispatch table, rebuilt on dirty frames
 	rootComponent  Component      // Root struct component (set via SetRoot with Component)
+	preRenderHook  func()
 	postRenderHook func()
 	rootUnbinder   AppUnbinder // Tracks the current root's AppUnbinder for swap-time teardown. Covers SetRootView where rootComponent is nil.
 

--- a/app_options.go
+++ b/app_options.go
@@ -122,6 +122,16 @@ func WithMouse() AppOption {
 	}
 }
 
+// WithPreRenderHook sets a callback that runs at the start of every render cycle,
+// after the buffer is cleared but before the component tree is re-rendered.
+// This is useful for state updates that must happen before the render.
+func WithPreRenderHook(fn func()) AppOption {
+	return func(a *App) error {
+		a.preRenderHook = fn
+		return nil
+	}
+}
+
 // WithPostRenderHook sets a callback that runs after every render cycle.
 func WithPostRenderHook(fn func()) AppOption {
 	return func(a *App) error {

--- a/app_options_test.go
+++ b/app_options_test.go
@@ -317,6 +317,7 @@ func TestMouseOptions(t *testing.T) {
 
 func TestAppFlagAndCallbackOptions(t *testing.T) {
 	globalKeyCalls := 0
+	preRenderCalls := 0
 	postRenderCalls := 0
 
 	type tc struct {
@@ -372,6 +373,20 @@ func TestAppFlagAndCallbackOptions(t *testing.T) {
 				app.postRenderHook()
 				if postRenderCalls != 1 {
 					t.Fatalf("hook called %d times, want 1", postRenderCalls)
+				}
+			},
+		},
+		"WithPreRenderHook stores a working hook": {
+			opt: WithPreRenderHook(func() {
+				preRenderCalls++
+			}),
+			assert: func(t *testing.T, app *App) {
+				if app.preRenderHook == nil {
+					t.Fatal("expected preRenderHook to be set")
+				}
+				app.preRenderHook()
+				if preRenderCalls != 1 {
+					t.Fatalf("hook called %d times, want 1", preRenderCalls)
 				}
 			},
 		},

--- a/app_render.go
+++ b/app_render.go
@@ -51,6 +51,11 @@ func (a *App) renderFrame() {
 	// Clear overlay registrations from previous frame
 	a.clearOverlays()
 
+	// Pre-render hook runs before component re-render (buffer is clear, state is fresh)
+	if a.preRenderHook != nil {
+		a.preRenderHook()
+	}
+
 	// If a root component is set, re-render it to get a fresh element tree.
 	// This is the core of the reactivity cycle: state changes → dirty → re-render
 	// component → new element tree with updated state reads.
@@ -153,6 +158,11 @@ func (a *App) RenderFull() {
 
 	// Clear overlay registrations from previous frame
 	a.clearOverlays()
+
+	// Pre-render hook runs before component re-render (buffer is clear, state is fresh)
+	if a.preRenderHook != nil {
+		a.preRenderHook()
+	}
 
 	// Re-render the component tree so overlays and state are up to date.
 	a.rerenderComponent()

--- a/app_render_test.go
+++ b/app_render_test.go
@@ -368,3 +368,41 @@ func TestPostRenderHook(t *testing.T) {
 		})
 	}
 }
+
+func TestApp_PreRenderHook_FiresDuringRender(t *testing.T) {
+	type tc struct {
+		render func(a *App)
+	}
+
+	tests := map[string]tc{
+		"fires during Render()":     {render: func(a *App) { a.Render() }},
+		"fires during RenderFull()": {render: func(a *App) { a.RenderFull() }},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var hookFired bool
+			app := &App{
+				terminal:      NewMockTerminal(80, 24),
+				focus:         newFocusManager(),
+				buffer:        NewBuffer(80, 24),
+				preRenderHook: func() { hookFired = true },
+				updates:       make(chan Event, 256),
+				merged:        make(chan Event, 256),
+				watcherQueue:  make(chan func(), 256),
+				stopCh:        make(chan struct{}),
+				stopped:       false,
+				mounts:        newMountState(),
+				batch:         newBatchContext(),
+			}
+
+			// Render() checks dirty flag, so set it for that path
+			app.dirty.Store(true)
+			tt.render(app)
+
+			if !hookFired {
+				t.Errorf("preRenderHook was not called during %s", name)
+			}
+		})
+	}
+}

--- a/element_render_test.go
+++ b/element_render_test.go
@@ -867,7 +867,8 @@ func TestRenderTree_AutoContrast(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			var parentOpts []Option
-			parentOpts = append(parentOpts,
+			parentOpts = append(
+				parentOpts,
 				WithSize(20, 10),
 				WithBackground(NewStyle().Background(tt.bgColor)),
 			)

--- a/internal/lsp/gopls/proxy_coverage_test.go
+++ b/internal/lsp/gopls/proxy_coverage_test.go
@@ -114,11 +114,13 @@ func fakeGoplsServe(in io.Reader, out io.Writer) {
 			reply(string(data))
 		case "test/error":
 			writeFramed(out, fmt.Sprintf(
-				`{"jsonrpc":"2.0","id":%d,"error":{"code":-32601,"message":"method not found"}}`, req.ID))
+				`{"jsonrpc":"2.0","id":%d,"error":{"code":-32601,"message":"method not found"}}`, req.ID,
+			))
 		case "test/publishDiagnostics":
 			// Echo the params back as a server-initiated diagnostics notification.
 			writeFramed(out, fmt.Sprintf(
-				`{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":%s}`, string(req.Params)))
+				`{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":%s}`, string(req.Params),
+			))
 		case "test/sendBare":
 			// Response with no id and no method: readResponses must skip it.
 			writeFramed(out, `{"jsonrpc":"2.0","result":{}}`)

--- a/markdown.go
+++ b/markdown.go
@@ -254,7 +254,8 @@ func (m *Markdown) renderBlockquote(b markdown.Block, contentWidth int) *Element
 	if contentWidth > 0 {
 		childWidth = max(
 			// bar (1) + gap (1)
-			contentWidth-2, 1)
+			contentWidth-2, 1,
+		)
 	}
 
 	// Constrain the content width (when known) so paragraphs wrap to it; this

--- a/modal.go
+++ b/modal.go
@@ -121,7 +121,8 @@ func (m *Modal) KeyMap() KeyMap {
 		}))
 	}
 	if m.trapFocus && m.app != nil {
-		km = append(km,
+		km = append(
+			km,
 			OnPreemptStop(KeyTab, func(ke KeyEvent) {
 				m.app.FocusNext()
 			}),


### PR DESCRIPTION
Mirrors the existing WithPostRenderHook pattern. Runs at the start of every render cycle, after buffer clear but before component re-render.

- app.go: preRenderHook field (mirrors postRenderHook)
- app_options.go: WithPreRenderHook AppOption
- app_render.go: fires hook before rerenderComponent()
- app_options_test.go: option storage and invocation test
- app_render_test.go: render cycle integration test