### PR TITLE
feat: add WithFocusBorderStyle for focus-indicated border styling

### DIFF
--- a/element.go
+++ b/element.go
@@ -62,6 +62,7 @@ type Element struct {
 	background       *Style    // nil = transparent
 	borderTitle      string    // title text drawn in the top border (DrawBoxWithTitle)
 	borderTitleAlign TextAlign // alignment of the border title (default TextAlignCenter)
+	focusBorderStyle *Style    // border style when focused (nil = no change)
 
 	// Text properties
 	text         string

--- a/element_accessors.go
+++ b/element_accessors.go
@@ -50,6 +50,26 @@ func (e *Element) BorderStyle() Style {
 	return e.borderStyle
 }
 
+// FocusBorderStyle returns the border style used when focused, or nil.
+func (e *Element) FocusBorderStyle() *Style {
+	return e.focusBorderStyle
+}
+
+// SetFocusBorderStyle sets the border style used when focused (nil = no change on focus).
+func (e *Element) SetFocusBorderStyle(s *Style) {
+	e.focusBorderStyle = s
+}
+
+// activeBorderStyle returns the border style to use for rendering.
+// If the element is focused and a focus border style is set, that is used;
+// otherwise the normal border style is the fallback.
+func (e *Element) activeBorderStyle() Style {
+	if e.focused && e.focusBorderStyle != nil {
+		return *e.focusBorderStyle
+	}
+	return e.borderStyle
+}
+
 // SetBorderStyle sets the style used to render the border.
 func (e *Element) SetBorderStyle(style Style) {
 	e.borderStyle = style

--- a/element_focus.go
+++ b/element_focus.go
@@ -31,8 +31,9 @@ func (e *Element) IsFocused() bool {
 // Idempotent: no-op if already focused.
 // Does not cascade to children — only the FocusManager target receives focus.
 //
-// For elements with a border and no explicit onFocus handler, a default
-// cyan border highlight is applied automatically.
+// For elements with a border, no explicit onFocus handler, and no
+// focusBorderStyle configured, a default cyan border highlight is applied
+// automatically.
 func (e *Element) Focus() {
 	if e.focused {
 		return
@@ -40,6 +41,11 @@ func (e *Element) Focus() {
 	e.focused = true
 	if e.onFocus != nil {
 		e.onFocus(e)
+		if e.focusBorderStyle != nil {
+			e.MarkDirty()
+		}
+	} else if e.focusBorderStyle != nil {
+		e.MarkDirty()
 	} else if e.border != BorderNone {
 		e.savedBorderStyle = e.borderStyle
 		e.hasSavedBorder = true
@@ -60,6 +66,15 @@ func (e *Element) Blur() {
 	e.focused = false
 	if e.onBlur != nil {
 		e.onBlur(e)
+		if e.focusBorderStyle != nil {
+			e.MarkDirty()
+		}
+	} else if e.focusBorderStyle != nil {
+		if e.hasSavedBorder {
+			e.borderStyle = e.savedBorderStyle
+			e.hasSavedBorder = false
+		}
+		e.MarkDirty()
 	} else if e.hasSavedBorder {
 		e.borderStyle = e.savedBorderStyle
 		e.hasSavedBorder = false

--- a/element_options.go
+++ b/element_options.go
@@ -202,6 +202,14 @@ func WithBorderTitleAlign(align TextAlign) Option {
 	}
 }
 
+// WithFocusBorderStyle sets the border style used when the element is focused.
+// If not set, the border style (WithBorderStyle) is used regardless of focus state.
+func WithFocusBorderStyle(s Style) Option {
+	return func(e *Element) {
+		e.focusBorderStyle = &s
+	}
+}
+
 // WithBorderStyle sets the color/attributes for the border.
 func WithBorderStyle(style Style) Option {
 	return func(e *Element) {

--- a/element_options_test.go
+++ b/element_options_test.go
@@ -324,3 +324,73 @@ func TestWithFocusable_False(t *testing.T) {
 		t.Error("WithFocusable(false) should override focusable to false")
 	}
 }
+
+type focusStyleTC struct {
+	focused bool
+	focusBC *Style // focusBorderStyle
+	borderS Style  // borderStyle
+	want    *Style // expected return of activeBorderStyle, nil = expect borderStyle
+}
+
+func TestWithFocusBorderStyle(t *testing.T) {
+	e := New()
+	if e.FocusBorderStyle() != nil {
+		t.Error("expected nil default FocusBorderStyle")
+	}
+
+	s := NewStyle().Foreground(Red)
+	WithFocusBorderStyle(s)(e)
+
+	if e.FocusBorderStyle() == nil {
+		t.Fatal("expected FocusBorderStyle to be set")
+	}
+	if *e.FocusBorderStyle() != s {
+		t.Errorf("FocusBorderStyle = %+v, want %+v", *e.FocusBorderStyle(), s)
+	}
+}
+
+func TestActiveBorderStyle(t *testing.T) {
+	red := NewStyle().Foreground(Red)
+	green := NewStyle().Foreground(Green)
+
+	tests := map[string]focusStyleTC{
+		"not_focused_returns_borderStyle": {
+			focused: false,
+			borderS: red,
+			want:    &red,
+		},
+		"not_focused_with_focusStyle_returns_borderStyle": {
+			focused: false,
+			focusBC: &green,
+			borderS: red,
+			want:    &red,
+		},
+		"focused_with_focusStyle_returns_focusStyle": {
+			focused: true,
+			focusBC: &green,
+			borderS: red,
+			want:    &green,
+		},
+		"focused_without_focusStyle_returns_borderStyle": {
+			focused: true,
+			focusBC: nil,
+			borderS: red,
+			want:    &red,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := New(WithBorderStyle(tt.borderS))
+			e.focusBorderStyle = tt.focusBC
+			e.focused = tt.focused
+			got := e.activeBorderStyle()
+			if tt.want == nil {
+				if got != tt.borderS {
+					t.Errorf("activeBorderStyle() = %+v, want borderStyle %+v", got, tt.borderS)
+				}
+			} else if got != *tt.want {
+				t.Errorf("activeBorderStyle() = %+v, want %+v", got, *tt.want)
+			}
+		})
+	}
+}

--- a/element_render.go
+++ b/element_render.go
@@ -130,12 +130,12 @@ func renderElement(buf *Buffer, e *Element, inherited inheritedStyle) {
 
 	if e.border != BorderNone {
 		if e.borderGradient != nil {
-			DrawBoxGradient(buf, rect, e.border, *e.borderGradient, e.borderStyle)
+			DrawBoxGradient(buf, rect, e.border, *e.borderGradient, e.activeBorderStyle())
 		} else {
-			DrawBox(buf, rect, e.border, e.borderStyle)
+			DrawBox(buf, rect, e.border, e.activeBorderStyle())
 		}
 		if e.borderTitle != "" {
-			drawBoxTitle(buf, rect, e.borderTitle, e.borderStyle, e.borderTitleAlign)
+			drawBoxTitle(buf, rect, e.borderTitle, e.activeBorderStyle(), e.borderTitleAlign)
 		}
 	}
 
@@ -271,12 +271,12 @@ func renderClippedElement(buf *Buffer, e *Element, clipRect Rect, scrollX, scrol
 	// Render border clipped to viewport (border style does NOT inherit)
 	if e.border != BorderNone {
 		if e.borderGradient != nil {
-			DrawBoxGradientClipped(buf, screenRect, e.border, *e.borderGradient, e.borderStyle, clipRect)
+			DrawBoxGradientClipped(buf, screenRect, e.border, *e.borderGradient, e.activeBorderStyle(), clipRect)
 		} else {
-			DrawBoxClipped(buf, screenRect, e.border, e.borderStyle, clipRect)
+			DrawBoxClipped(buf, screenRect, e.border, e.activeBorderStyle(), clipRect)
 		}
 		if e.borderTitle != "" {
-			drawBoxTitleClipped(buf, screenRect, e.borderTitle, e.borderStyle, clipRect, e.borderTitleAlign)
+			drawBoxTitleClipped(buf, screenRect, e.borderTitle, e.activeBorderStyle(), clipRect, e.borderTitleAlign)
 		}
 	}
 


### PR DESCRIPTION
Elements with a focus border style automatically switch to that style when focused (via the existing Focus()/Blur() cycle), providing a visual focus indicator without manual callback wiring.