### PR TITLE
feat: TextArea/Input editing API, element resize setters, and real-cursor protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -820,6 +820,8 @@ func (c *myComponent) KeyMap() tui.KeyMap {
 
 The `OnPreemptStop` variant fires in a preemptive pass before all normal handlers. Used by the Modal component to block parent key handlers when the modal is open.
 
+When a hand-written component hosts more than one focusable widget (say a `TextArea` next to an `Input`), mount each with `app.Mount` instead of merging their `KeyMap()`s onto the host. `OnFocused` only gates on focus when the binding's owning component implements `IsFocused()` and is mounted, so merging keymaps onto a host without `IsFocused()` drops the gate and the first widget swallows every key; the dispatch builder now errors when it detects this.
+
 ### Mouse Click Handling
 
 Implement `MouseListener` with ref-based hit testing:

--- a/app.go
+++ b/app.go
@@ -52,7 +52,6 @@ type App struct {
 	eventQueueSize   int           // Capacity of event queue (default 256, used during construction)
 	mouseEnabled     bool          // Whether mouse events are enabled
 	mouseExplicit    bool          // Whether mouse setting was explicitly configured
-	cursorVisible    bool          // Currently always false (WithCursor is a no-op); the cursor is driven per-frame by placeCursor. Field and its `if !a.cursorVisible` guards are retained for the resume/suspend paths and a possible future opt-in.
 	manualCursor     bool          // Disable framework-driven cursor placement (WithManualCursor)
 	legacyKeyboard   bool          // Force legacy keyboard mode (skip Kitty protocol negotiation)
 	onSuspend        func()        // Called before suspending (Ctrl+Z / SIGTSTP)
@@ -138,7 +137,6 @@ func NewApp(opts ...AppOption) (*App, error) {
 		inputLatency:   InputLatencyBlocking,  // Default: block until input arrives
 		frameDuration:  16 * time.Millisecond, // Default ~60fps
 		eventQueueSize: 256,                   // Default queue size
-		cursorVisible:  false,                 // Cursor hidden by default
 		mounts:         newMountState(),
 		batch:          newBatchContext(),
 	}
@@ -184,9 +182,7 @@ func NewApp(opts ...AppOption) (*App, error) {
 
 	// Apply terminal settings based on options
 	app.enableInputReporting()
-	if !app.cursorVisible {
-		terminal.HideCursor()
-	}
+	terminal.HideCursor()
 
 	// Enable interrupt capability on the reader for SIGWINCH and shutdown wakeup
 	if interruptible, ok := reader.(InterruptibleReader); ok {
@@ -194,9 +190,7 @@ func NewApp(opts ...AppOption) (*App, error) {
 			app.Stop() // Stop background goroutines (startWatcherBridge, startEventMerge)
 			reader.Close()
 			app.disableInputReporting()
-			if !app.cursorVisible {
-				terminal.ShowCursor()
-			}
+			terminal.ShowCursor()
 			if app.inlineHeight == 0 {
 				terminal.ExitAltScreen()
 			}
@@ -244,7 +238,6 @@ func NewAppWithReader(reader EventReader, opts ...AppOption) (*App, error) {
 		inputLatency:   InputLatencyBlocking,  // Default: block until input arrives
 		frameDuration:  16 * time.Millisecond, // Default ~60fps
 		eventQueueSize: 256,                   // Default queue size
-		cursorVisible:  false,                 // Cursor hidden by default
 		mounts:         newMountState(),
 		batch:          newBatchContext(),
 	}
@@ -290,9 +283,7 @@ func NewAppWithReader(reader EventReader, opts ...AppOption) (*App, error) {
 
 	// Apply terminal settings based on options
 	app.enableInputReporting()
-	if !app.cursorVisible {
-		terminal.HideCursor()
-	}
+	terminal.HideCursor()
 
 	// Enable interrupt capability on the reader for SIGWINCH and shutdown wakeup
 	if interruptible, ok := reader.(InterruptibleReader); ok {
@@ -300,9 +291,7 @@ func NewAppWithReader(reader EventReader, opts ...AppOption) (*App, error) {
 			app.Stop() // Stop background goroutines (startWatcherBridge, startEventMerge)
 			reader.Close()
 			app.disableInputReporting()
-			if !app.cursorVisible {
-				terminal.ShowCursor()
-			}
+			terminal.ShowCursor()
 			if app.inlineHeight == 0 {
 				terminal.ExitAltScreen()
 			}

--- a/app.go
+++ b/app.go
@@ -53,6 +53,7 @@ type App struct {
 	mouseEnabled     bool          // Whether mouse events are enabled
 	mouseExplicit    bool          // Whether mouse setting was explicitly configured
 	cursorVisible    bool          // Whether cursor is visible (default false)
+	manualCursor     bool          // Disable framework-driven cursor placement (WithManualCursor)
 	legacyKeyboard   bool          // Force legacy keyboard mode (skip Kitty protocol negotiation)
 	onSuspend        func()        // Called before suspending (Ctrl+Z / SIGTSTP)
 	onResume         func()        // Called after resuming (SIGCONT)

--- a/app.go
+++ b/app.go
@@ -52,7 +52,7 @@ type App struct {
 	eventQueueSize   int           // Capacity of event queue (default 256, used during construction)
 	mouseEnabled     bool          // Whether mouse events are enabled
 	mouseExplicit    bool          // Whether mouse setting was explicitly configured
-	cursorVisible    bool          // Whether cursor is visible (default false)
+	cursorVisible    bool          // Currently always false (WithCursor is a no-op); the cursor is driven per-frame by placeCursor. Field and its `if !a.cursorVisible` guards are retained for the resume/suspend paths and a possible future opt-in.
 	manualCursor     bool          // Disable framework-driven cursor placement (WithManualCursor)
 	legacyKeyboard   bool          // Force legacy keyboard mode (skip Kitty protocol negotiation)
 	onSuspend        func()        // Called before suspending (Ctrl+Z / SIGTSTP)

--- a/app_lifecycle.go
+++ b/app_lifecycle.go
@@ -31,10 +31,8 @@ func (a *App) Close() error {
 		// Disable mouse event reporting, or alternate-scroll if that was used.
 		a.disableInputReporting()
 
-		// Show cursor (only if it was hidden)
-		if !a.cursorVisible {
-			a.terminal.ShowCursor()
-		}
+		// Show cursor (it is hidden for the lifetime of the app)
+		a.terminal.ShowCursor()
 
 		// Handle screen cleanup based on mode
 		if a.inAlternateScreen {

--- a/app_options.go
+++ b/app_options.go
@@ -140,11 +140,26 @@ func WithoutMouse() AppOption {
 	}
 }
 
-// WithCursor keeps the cursor visible during app execution.
-// By default, the cursor is hidden.
+// WithManualCursor disables framework-driven terminal cursor management. By
+// default the App places the real terminal cursor at the focused widget's
+// reported position at the end of every frame (see CursorReporter). Use this
+// when the application drives the cursor itself, or wants no cursor at all.
+func WithManualCursor() AppOption {
+	return func(a *App) error {
+		a.manualCursor = true
+		return nil
+	}
+}
+
+// WithCursor is deprecated and now a no-op. The framework drives the real
+// terminal cursor automatically at the focused text widget; use the default
+// behavior, or WithManualCursor to opt out. Retained as an alias so existing
+// call sites keep compiling.
+//
+// Deprecated: cursor visibility is managed by the framework; this option does
+// nothing. Use WithManualCursor to disable framework cursor management.
 func WithCursor() AppOption {
 	return func(a *App) error {
-		a.cursorVisible = true
 		return nil
 	}
 }

--- a/app_options_test.go
+++ b/app_options_test.go
@@ -325,11 +325,22 @@ func TestAppFlagAndCallbackOptions(t *testing.T) {
 	}
 
 	tests := map[string]tc{
-		"WithCursor keeps cursor visible": {
+		"WithCursor is a no-op": {
 			opt: WithCursor(),
 			assert: func(t *testing.T, app *App) {
-				if !app.cursorVisible {
-					t.Fatal("expected cursorVisible to be true")
+				if app.cursorVisible {
+					t.Fatal("WithCursor should be a no-op and not set cursorVisible")
+				}
+				if app.manualCursor {
+					t.Fatal("WithCursor should not enable manual cursor")
+				}
+			},
+		},
+		"WithManualCursor disables framework cursor management": {
+			opt: WithManualCursor(),
+			assert: func(t *testing.T, app *App) {
+				if !app.manualCursor {
+					t.Fatal("expected manualCursor to be true")
 				}
 			},
 		},

--- a/app_options_test.go
+++ b/app_options_test.go
@@ -328,9 +328,6 @@ func TestAppFlagAndCallbackOptions(t *testing.T) {
 		"WithCursor is a no-op": {
 			opt: WithCursor(),
 			assert: func(t *testing.T, app *App) {
-				if app.cursorVisible {
-					t.Fatal("WithCursor should be a no-op and not set cursorVisible")
-				}
 				if app.manualCursor {
 					t.Fatal("WithCursor should not enable manual cursor")
 				}

--- a/app_render.go
+++ b/app_render.go
@@ -97,6 +97,35 @@ func (a *App) renderFrame() {
 	if a.postRenderHook != nil {
 		a.postRenderHook()
 	}
+	// Place the real terminal cursor last so it survives all cell writes and the
+	// postRenderHook. This is the final terminal op of the frame.
+	a.placeCursor()
+}
+
+// placeCursor drives the real terminal cursor from the focused element's
+// CursorReporter at the end of a frame. It is the final terminal operation, run
+// after Flush and postRenderHook so cell writes cannot clobber the placement.
+// In inline mode the reported coordinates are offset by the inline start row,
+// mirroring the renderer. No-op when WithManualCursor disabled management.
+func (a *App) placeCursor() {
+	if a.manualCursor {
+		return
+	}
+	reporter, ok := a.focus.Focused().(CursorReporter)
+	if !ok {
+		a.terminal.HideCursor()
+		return
+	}
+	x, y, vis := reporter.ReportCursor()
+	if !vis {
+		a.terminal.HideCursor()
+		return
+	}
+	if !a.inAlternateScreen && a.inlineHeight > 0 {
+		y += a.inlineStartRow
+	}
+	a.terminal.SetCursor(x, y)
+	a.terminal.ShowCursor()
 }
 
 // renderInline handles rendering for inline mode by offsetting Y coordinates.
@@ -171,6 +200,7 @@ func (a *App) RenderFull() {
 	if a.postRenderHook != nil {
 		a.postRenderHook()
 	}
+	a.placeCursor()
 }
 
 // rerenderComponent re-renders the root component to produce a fresh element tree.

--- a/app_render.go
+++ b/app_render.go
@@ -61,6 +61,11 @@ func (a *App) renderFrame() {
 		renderHeight = a.inlineHeight
 	}
 
+	// Reset the focused element's cursor capture before rendering, so an element
+	// that no longer draws this frame (hidden, or scrolled fully out of view)
+	// reports no cursor instead of a stale position.
+	a.resetFocusedCursor()
+
 	// If root exists, render the element tree
 	if a.root != nil {
 		a.root.Render(a.buffer, width, renderHeight)
@@ -100,6 +105,15 @@ func (a *App) renderFrame() {
 	// Place the real terminal cursor last so it survives all cell writes and the
 	// postRenderHook. This is the final terminal op of the frame.
 	a.placeCursor()
+}
+
+// resetFocusedCursor clears the focused element's cursor capture before a render
+// so an element that stops drawing this frame reports no cursor rather than a
+// stale one. The render re-captures it if it draws.
+func (a *App) resetFocusedCursor() {
+	if f, ok := a.focus.Focused().(*Element); ok {
+		f.clearCursorReport()
+	}
 }
 
 // placeCursor drives the real terminal cursor from the focused element's
@@ -185,6 +199,9 @@ func (a *App) RenderFull() {
 
 	// Re-render the component tree so overlays and state are up to date.
 	a.rerenderComponent()
+
+	// Reset the focused element's cursor capture (mirrors renderFrame).
+	a.resetFocusedCursor()
 
 	// If root exists, render the element tree
 	if a.root != nil {

--- a/app_suspend_test.go
+++ b/app_suspend_test.go
@@ -260,27 +260,6 @@ func TestResumeSequence_InlineMode(t *testing.T) {
 	}
 }
 
-func TestResumeSequence_CursorVisible(t *testing.T) {
-	term := newRecordingTerminal(80, 24)
-
-	app := &App{
-		terminal:      term,
-		cursorVisible: true,
-		stopCh:        make(chan struct{}),
-		buffer:        NewBuffer(80, 24),
-		dirty:         atomic.Bool{},
-	}
-
-	app.resumeTerminal()
-
-	// Should NOT hide cursor when cursorVisible is true
-	for _, call := range term.calls {
-		if call == "HideCursor" {
-			t.Fatal("should not hide cursor when cursorVisible is true")
-		}
-	}
-}
-
 func TestSuspendSequence_MouseDisabled(t *testing.T) {
 	term := newRecordingTerminal(80, 24)
 	term.inRawMode = true
@@ -411,7 +390,7 @@ func TestResumeSequence_DynamicAltScreen(t *testing.T) {
 
 	app.resumeTerminal()
 
-	// Should re-enter alt screen overlay, then hide cursor (cursorVisible defaults to false)
+	// Should re-enter alt screen overlay, then hide cursor
 	expected := []string{"EnterRawMode", "EnableKittyKeyboard", "EnterAltScreen", "Clear", "HideCursor"}
 	if len(term.calls) != len(expected) {
 		t.Fatalf("expected %d calls, got %d: %v", len(expected), len(term.calls), term.calls)

--- a/app_suspend_unix.go
+++ b/app_suspend_unix.go
@@ -85,9 +85,7 @@ func (a *App) resumeTerminal() {
 		a.terminal.Clear()
 	}
 
-	if !a.cursorVisible {
-		a.terminal.HideCursor()
-	}
+	a.terminal.HideCursor()
 
 	a.enableInputReporting()
 

--- a/cell.go
+++ b/cell.go
@@ -103,8 +103,13 @@ func (c Cell) IsEmpty() bool {
 	return false
 }
 
-// RuneWidth returns the display width of a rune in terminal cells.
+// RuneWidth returns the display width of a single rune in terminal cells.
 // Returns 1 for most characters, 2 for wide characters (CJK/fullwidth, emoji).
+//
+// RuneWidth is low-level and per-rune: it is wrong for multi-rune grapheme
+// clusters (a combining mark, ZWJ joiner, or regional-indicator half counts as
+// 1 here). For string and cursor-column math use StringWidth, which measures
+// whole clusters.
 //
 // Note: this cell model reserves Width==0 for continuation cells only.
 // Runes that are logically zero-width (combining marks, variation selectors,

--- a/cursor.go
+++ b/cursor.go
@@ -43,33 +43,42 @@ func (e *Element) ReportCursor() (int, int, bool) {
 		return 0, 0, false
 	}
 
-	// Start at the cursor cell in the element's own layout base. An element under
-	// a scrollable ancestor is laid out in that ancestor's content space (the
-	// whole subtree is rebased toward 0,0), so the position must be translated up
-	// through each scrollable ancestor exactly as the renderer does:
-	//   screen = ancestorContentOrigin - ancestorScroll + posInAncestorContentSpace
-	// and clipped to each ancestor's viewport (out-of-view hides the cursor).
+	// Cursor cell in the element's own layout base. Under a scrollable ancestor the
+	// whole subtree is laid out in that ancestor's content space (rebased toward
+	// 0,0), so this is already content-local there.
 	cr := e.ContentRect()
 	x := cr.X + col
 	y := cr.Y + row
 
+	// Mirror the renderer: only the OUTERMOST scrollable ancestor's transform is
+	// applied to the entire clipped subtree (renderClippedElement recurses into
+	// descendants without re-basing at nested scrollables). Apply that one
+	// transform and clip against its viewport. No scrollable ancestor means the
+	// content-local position is already screen-absolute.
+	var outer *Element
 	for anc := e.parent; anc != nil; anc = anc.parent {
-		if !anc.IsScrollable() {
-			continue
-		}
-		// Map (x,y) from this scrollable's content space into the scrollable's own
-		// base (its parent's coordinate space), mirroring renderClippedElement.
-		clip := anc.ContentRect() // viewport, expressed in the scrollable's base
-		sx, sy := anc.ScrollOffset()
-		x += clip.X - sx
-		y += clip.Y - sy
-
-		// Clip against the viewport in the scrollable's base. A cursor scrolled
-		// out of view is hidden.
-		if x < clip.X || x >= clip.Right() || y < clip.Y || y >= clip.Bottom() {
-			return 0, 0, false
+		if anc.IsScrollable() {
+			outer = anc
 		}
 	}
+	if outer == nil {
+		return x, y, true
+	}
 
+	clip := outer.ContentRect()
+	sx, sy := outer.ScrollOffset()
+	x += clip.X - sx
+	y += clip.Y - sy
+
+	// The renderer reserves the last content column for a vertical scrollbar, so
+	// shrink the clip to match before the visibility test.
+	if outer.needsVerticalScrollbar() {
+		clip.Width = max(0, clip.Width-1)
+	}
+
+	// A cursor scrolled outside the viewport is hidden.
+	if x < clip.X || x >= clip.Right() || y < clip.Y || y >= clip.Bottom() {
+		return 0, 0, false
+	}
 	return x, y, true
 }

--- a/cursor.go
+++ b/cursor.go
@@ -1,0 +1,75 @@
+package tui
+
+// CursorReporter is implemented by things that can report where the real
+// terminal cursor should be drawn. The App queries the focused element through
+// this interface at the end of each frame and drives the hardware cursor.
+//
+// The returned coordinates are absolute terminal cells (0-indexed, full-screen
+// space; the App offsets them by the inline start row in inline mode). When
+// visible is false the cursor is hidden.
+type CursorReporter interface {
+	// ReportCursor returns the absolute terminal cell and whether to show it.
+	ReportCursor() (x, y int, visible bool)
+}
+
+// cursorSource computes the cursor position local to an element's content area:
+// (col, row) measured in display cells from the content origin, and whether the
+// cursor is currently visible (e.g. false when scrolled out of view). Widgets
+// like TextArea and Input install one via SetCursorSource so the framework can
+// place the real terminal cursor.
+type cursorSource func() (col, row int, visible bool)
+
+// Compile-time check that Element implements CursorReporter.
+var _ CursorReporter = (*Element)(nil)
+
+// SetCursorSource installs a content-local cursor source on the element. Pass
+// nil to clear it. The source reports (col, row) within the element's content
+// area; ReportCursor converts that to an absolute terminal cell, accounting for
+// the scroll offset and clip of any scrollable ancestor.
+func (e *Element) SetCursorSource(fn cursorSource) {
+	e.cursorSource = fn
+}
+
+// ReportCursor implements CursorReporter. It returns the absolute terminal cell
+// for the element's content-local cursor, or visible=false when no source is
+// set, the source reports invisible, or the cursor is scrolled out of view in a
+// scrollable ancestor.
+func (e *Element) ReportCursor() (int, int, bool) {
+	if e.cursorSource == nil {
+		return 0, 0, false
+	}
+	col, row, vis := e.cursorSource()
+	if !vis {
+		return 0, 0, false
+	}
+
+	// Start at the cursor cell in the element's own layout base. An element under
+	// a scrollable ancestor is laid out in that ancestor's content space (the
+	// whole subtree is rebased toward 0,0), so the position must be translated up
+	// through each scrollable ancestor exactly as the renderer does:
+	//   screen = ancestorContentOrigin - ancestorScroll + posInAncestorContentSpace
+	// and clipped to each ancestor's viewport (out-of-view hides the cursor).
+	cr := e.ContentRect()
+	x := cr.X + col
+	y := cr.Y + row
+
+	for anc := e.parent; anc != nil; anc = anc.parent {
+		if !anc.IsScrollable() {
+			continue
+		}
+		// Map (x,y) from this scrollable's content space into the scrollable's own
+		// base (its parent's coordinate space), mirroring renderClippedElement.
+		clip := anc.ContentRect() // viewport, expressed in the scrollable's base
+		sx, sy := anc.ScrollOffset()
+		x += clip.X - sx
+		y += clip.Y - sy
+
+		// Clip against the viewport in the scrollable's base. A cursor scrolled
+		// out of view is hidden.
+		if x < clip.X || x >= clip.Right() || y < clip.Y || y >= clip.Bottom() {
+			return 0, 0, false
+		}
+	}
+
+	return x, y, true
+}

--- a/cursor.go
+++ b/cursor.go
@@ -31,54 +31,41 @@ func (e *Element) SetCursorSource(fn cursorSource) {
 }
 
 // ReportCursor implements CursorReporter. It returns the absolute terminal cell
-// for the element's content-local cursor, or visible=false when no source is
-// set, the source reports invisible, or the cursor is scrolled out of view in a
-// scrollable ancestor.
+// captured for the element's cursor during the most recent render, or
+// visible=false when no source is set, the source reported invisible, or the
+// cursor was clipped out of view. The value is produced by captureCursor at the
+// element's draw site, so it always matches where the renderer placed the
+// content (nested scrollables, overflow-hidden clipping, and the scrollbar gutter
+// included) rather than re-deriving the transform here.
 func (e *Element) ReportCursor() (int, int, bool) {
+	return e.cursorReport.x, e.cursorReport.y, e.cursorReport.visible
+}
+
+// captureCursor records where the element's content-local cursor lands on screen
+// for ReportCursor to return. originX/originY is the element's content origin in
+// screen space and clip is the visible region (the active ancestor clip already
+// intersected with the element's own viewport when it is scrollable). It is
+// called by the renderer at the element's draw site so the cursor uses the exact
+// transform and clip the renderer applied to the element's content.
+func (e *Element) captureCursor(originX, originY int, clip Rect) {
+	e.cursorReport = cursorReport{}
 	if e.cursorSource == nil {
-		return 0, 0, false
+		return
 	}
 	col, row, vis := e.cursorSource()
 	if !vis {
-		return 0, 0, false
+		return
 	}
-
-	// Cursor cell in the element's own layout base. Under a scrollable ancestor the
-	// whole subtree is laid out in that ancestor's content space (rebased toward
-	// 0,0), so this is already content-local there.
-	cr := e.ContentRect()
-	x := cr.X + col
-	y := cr.Y + row
-
-	// Mirror the renderer: only the OUTERMOST scrollable ancestor's transform is
-	// applied to the entire clipped subtree (renderClippedElement recurses into
-	// descendants without re-basing at nested scrollables). Apply that one
-	// transform and clip against its viewport. No scrollable ancestor means the
-	// content-local position is already screen-absolute.
-	var outer *Element
-	for anc := e.parent; anc != nil; anc = anc.parent {
-		if anc.IsScrollable() {
-			outer = anc
-		}
-	}
-	if outer == nil {
-		return x, y, true
-	}
-
-	clip := outer.ContentRect()
-	sx, sy := outer.ScrollOffset()
-	x += clip.X - sx
-	y += clip.Y - sy
-
-	// The renderer reserves the last content column for a vertical scrollbar, so
-	// shrink the clip to match before the visibility test.
-	if outer.needsVerticalScrollbar() {
-		clip.Width = max(0, clip.Width-1)
-	}
-
-	// A cursor scrolled outside the viewport is hidden.
+	x, y := originX+col, originY+row
 	if x < clip.X || x >= clip.Right() || y < clip.Y || y >= clip.Bottom() {
-		return 0, 0, false
+		return
 	}
-	return x, y, true
+	e.cursorReport = cursorReport{x: x, y: y, visible: true}
+}
+
+// clearCursorReport marks the element's cursor hidden until the next capture. The
+// renderer clears the focused element each frame so an element that no longer
+// draws (hidden, or scrolled fully out of view) stops reporting a stale cursor.
+func (e *Element) clearCursorReport() {
+	e.cursorReport = cursorReport{}
 }

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -247,3 +247,80 @@ func TestElement_ReportCursor_ScrollableAncestorShiftsAndClips(t *testing.T) {
 		t.Fatalf("ReportCursor = (%d,%d), want (%d,%d)", x, y, clip.X+1, clip.Y+0)
 	}
 }
+
+// findGlyph scans the buffer for the first cell whose reconstructed glyph equals
+// want, returning its coordinates. Used to pin cursor reporting to the position
+// the renderer actually drew at, rather than to a re-derivation of the formula.
+func findGlyph(b *Buffer, want string) (x, y int, found bool) {
+	w, h := b.Size()
+	for yy := range h {
+		for xx := range w {
+			if cellGlyph(b.Cell(xx, yy)) == want {
+				return xx, yy, true
+			}
+		}
+	}
+	return 0, 0, false
+}
+
+func TestElement_ReportCursor_NestedScrollablesMirrorRenderer(t *testing.T) {
+	app := newTestApp(40, 10)
+
+	// Outer scrollable viewport.
+	outer := New(WithDirection(Column), WithWidth(20), WithHeight(6), WithScrollable(ScrollVertical))
+	// Inner scrollable with a border, so its content origin is offset within the
+	// outer scrollable's content space. The renderer applies only the outer
+	// scrollable's transform to the whole clipped subtree; the previous
+	// per-ancestor accumulation also added this inner offset and mis-placed the
+	// cursor by exactly the inner scrollable's content origin.
+	middle := New(WithDirection(Column), WithWidth(16), WithHeight(8), WithScrollable(ScrollVertical), WithBorder(BorderSingle))
+	cursorChild := New(WithWidth(10), WithHeight(2))
+	cursorChild.SetText("Z") // marker rendered at the cursor's content origin
+	cursorChild.SetCursorSource(func() (int, int, bool) { return 0, 0, true })
+
+	middle.AddChild(cursorChild)
+	outer.AddChild(middle)
+	root := New(WithDirection(Column))
+	root.AddChild(outer)
+	app.SetRoot(root)
+	app.MarkDirty()
+	app.Render()
+
+	zx, zy, found := findGlyph(app.buffer, "Z")
+	if !found {
+		t.Fatal("cursor marker 'Z' was not rendered inside the nested viewports")
+	}
+
+	x, y, vis := cursorChild.ReportCursor()
+	if !vis {
+		t.Fatal("expected cursor visible inside nested viewports")
+	}
+	if x != zx || y != zy {
+		t.Fatalf("ReportCursor = (%d,%d), but glyph rendered at (%d,%d)", x, y, zx, zy)
+	}
+}
+
+func TestElement_ReportCursor_HidesCursorUnderScrollbarGutter(t *testing.T) {
+	app := newTestApp(40, 10)
+
+	// A scrollable whose content overflows vertically, so the renderer reserves
+	// the last content column for the vertical scrollbar and shrinks the clip by
+	// one. A cursor in that last column sits under the gutter and must be hidden.
+	scroller := New(WithDirection(Column), WithWidth(10), WithHeight(3), WithScrollable(ScrollVertical))
+	tall := New(WithWidth(10), WithHeight(5)) // taller than the viewport => scrollbar shows
+	tall.SetCursorSource(func() (int, int, bool) { return 9, 0, true })
+	scroller.AddChild(tall)
+
+	root := New(WithDirection(Column))
+	root.AddChild(scroller)
+	app.SetRoot(root)
+	app.MarkDirty()
+	app.Render()
+
+	if !scroller.needsVerticalScrollbar() {
+		t.Fatal("test setup: expected scroller to need a vertical scrollbar")
+	}
+	if _, _, vis := tall.ReportCursor(); vis {
+		t.Fatal("cursor in the scrollbar gutter column should be reported hidden")
+	}
+}

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -324,3 +324,28 @@ func TestElement_ReportCursor_HidesCursorUnderScrollbarGutter(t *testing.T) {
 		t.Fatal("cursor in the scrollbar gutter column should be reported hidden")
 	}
 }
+
+func TestElement_ReportCursor_HiddenScrollbarReclaimsGutter(t *testing.T) {
+	app := newTestApp(40, 10)
+
+	// Same overflowing viewport, but with the scrollbar hidden the gutter column
+	// is reclaimed: needsVerticalScrollbar is false, so the last column stays
+	// inside the clip and a cursor there remains visible.
+	scroller := New(WithDirection(Column), WithWidth(10), WithHeight(3), WithScrollable(ScrollVertical), WithScrollbarHidden(true))
+	tall := New(WithWidth(10), WithHeight(5))
+	tall.SetCursorSource(func() (int, int, bool) { return 9, 0, true })
+	scroller.AddChild(tall)
+
+	root := New(WithDirection(Column))
+	root.AddChild(scroller)
+	app.SetRoot(root)
+	app.MarkDirty()
+	app.Render()
+
+	if scroller.needsVerticalScrollbar() {
+		t.Fatal("test setup: hidden scrollbar should not reserve a gutter")
+	}
+	if _, _, vis := tall.ReportCursor(); !vis {
+		t.Fatal("cursor in the last column should be visible when the gutter is reclaimed")
+	}
+}

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -349,3 +349,115 @@ func TestElement_ReportCursor_HiddenScrollbarReclaimsGutter(t *testing.T) {
 		t.Fatal("cursor in the last column should be visible when the gutter is reclaimed")
 	}
 }
+
+func TestElement_ReportCursor_OverflowHiddenAncestorHidesCursor(t *testing.T) {
+	app := newTestApp(40, 10)
+
+	// An overflow-hidden parent clips its children to its content box just like a
+	// scrollable does, but it is not scrollable. A cursor on a child positioned
+	// below the clip must be reported hidden, matching the renderer (which draws
+	// nothing for that child).
+	parent := New(WithDirection(Column), WithWidth(10), WithHeight(2), WithOverflow(OverflowHidden))
+	inClip := New(WithWidth(10), WithHeight(2))
+	inClip.SetText("A")
+	below := New(WithWidth(10), WithHeight(2))
+	below.SetText("Z")
+	below.SetCursorSource(func() (int, int, bool) { return 0, 0, true })
+	parent.AddChild(inClip)
+	parent.AddChild(below)
+
+	root := New(WithDirection(Column))
+	root.AddChild(parent)
+	app.SetRoot(root)
+	app.MarkDirty()
+	app.Render()
+
+	if _, _, found := findGlyph(app.buffer, "A"); !found {
+		t.Fatal("test setup: in-clip child should render")
+	}
+	if _, _, found := findGlyph(app.buffer, "Z"); found {
+		t.Fatal("test setup: below-clip child should be clipped out by overflow-hidden")
+	}
+	if _, _, vis := below.ReportCursor(); vis {
+		t.Fatal("cursor clipped out by an overflow-hidden ancestor should be reported hidden")
+	}
+}
+
+func TestElement_ReportCursor_OverflowHiddenInClipVisible(t *testing.T) {
+	app := newTestApp(40, 10)
+
+	// Counterpart to the hidden case: a cursor within the overflow-hidden clip is
+	// reported at the cell where its glyph actually rendered.
+	parent := New(WithDirection(Column), WithWidth(10), WithHeight(3), WithOverflow(OverflowHidden))
+	child := New(WithWidth(10), WithHeight(2))
+	child.SetText("Z")
+	child.SetCursorSource(func() (int, int, bool) { return 0, 0, true })
+	parent.AddChild(child)
+
+	root := New(WithDirection(Column))
+	root.AddChild(parent)
+	app.SetRoot(root)
+	app.MarkDirty()
+	app.Render()
+
+	zx, zy, found := findGlyph(app.buffer, "Z")
+	if !found {
+		t.Fatal("cursor marker 'Z' should render inside the overflow-hidden clip")
+	}
+	x, y, vis := child.ReportCursor()
+	if !vis {
+		t.Fatal("cursor inside the overflow-hidden clip should be visible")
+	}
+	if x != zx || y != zy {
+		t.Fatalf("ReportCursor = (%d,%d), but glyph rendered at (%d,%d)", x, y, zx, zy)
+	}
+}
+
+func TestElement_ReportCursor_SelfScrollableClipsOwnCursor(t *testing.T) {
+	app := newTestApp(40, 10)
+
+	// A cursor source installed directly on a scrollable element must be clipped to
+	// that element's own viewport. A row past the viewport height is out of view.
+	scroller := New(WithDirection(Column), WithWidth(10), WithHeight(2), WithScrollable(ScrollVertical))
+	scroller.SetCursorSource(func() (int, int, bool) { return 0, 5, true }) // row 5, viewport is 2 tall
+
+	root := New(WithDirection(Column))
+	root.AddChild(scroller)
+	app.SetRoot(root)
+	app.MarkDirty()
+	app.Render()
+
+	if _, _, vis := scroller.ReportCursor(); vis {
+		t.Fatal("cursor past the scrollable's own viewport should be reported hidden")
+	}
+}
+
+func TestApp_RenderFull_ResetsCursorForElementThatStopsDrawing(t *testing.T) {
+	app := newTestApp(40, 10)
+
+	// A persistent (SetRoot) focused element with a cursor source. After it stops
+	// drawing, a full redraw must not leave a stale cursor on screen.
+	cursorEl := New(WithWidth(10), WithHeight(2), WithFocusable(true))
+	cursorEl.SetText("X")
+	cursorEl.SetCursorSource(func() (int, int, bool) { return 0, 0, true })
+	root := New(WithDirection(Column))
+	root.AddChild(cursorEl)
+	app.SetRoot(root)
+	app.focus.Register(cursorEl)
+	app.focus.SetFocus(cursorEl)
+
+	app.MarkDirty()
+	app.Render()
+
+	mt := app.terminal.(*MockTerminal)
+	if mt.IsCursorHidden() {
+		t.Fatal("setup: cursor should be visible while the focused element draws")
+	}
+
+	cursorEl.SetHidden(true)
+	app.RenderFull()
+	if !mt.IsCursorHidden() {
+		x, y := mt.Cursor()
+		t.Fatalf("cursor should be hidden after the focused element stops drawing, shown at (%d,%d)", x, y)
+	}
+}

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -1,0 +1,249 @@
+package tui
+
+import "testing"
+
+// renderFocusedInput builds an app with the given input as an auto-focused root
+// component, renders one frame, and returns the app so the test can inspect the
+// MockTerminal cursor state set by placeCursor.
+func renderFocusedInputApp(t *testing.T, inp *Input, termW, termH int) *App {
+	t.Helper()
+	app := newTestApp(termW, termH)
+	inp.BindApp(app)
+	app.SetRootComponent(inp)
+	app.MarkDirty()
+	app.Render()
+	if app.Focused() == nil {
+		t.Fatal("input was not focused after render")
+	}
+	return app
+}
+
+func TestInput_RealCursor_PlacedAtCell(t *testing.T) {
+	type tc struct {
+		text  string
+		width int
+		// cursor placed at end of text via CursorPos round-trip; expected absolute
+		// column equals the text's display width.
+		wantCol int
+	}
+
+	tests := map[string]tc{
+		"ascii":      {text: "ab", width: 10, wantCol: 2},
+		"cjk wide":   {text: "一二", width: 10, wantCol: 4},
+		"flag":       {text: flagUS, width: 10, wantCol: 2},
+		"zwj family": {text: zwjFamily, width: 12, wantCol: 2},
+		"skin tone":  {text: skinWave, width: 10, wantCol: 2},
+		"mixed wide": {text: "a" + flagUS + "b", width: 12, wantCol: 4},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			inp := NewInput(WithInputWidth(tt.width), WithInputAutoFocus(true))
+			inp.SetText(tt.text) // moves cursor to end
+
+			app := renderFocusedInputApp(t, inp, 40, 5)
+			mt := app.terminal.(*MockTerminal)
+
+			if mt.IsCursorHidden() {
+				t.Fatal("cursor should be visible for focused input")
+			}
+			x, y := mt.Cursor()
+			if x != tt.wantCol || y != 0 {
+				t.Fatalf("cursor at (%d,%d), want (%d,0)", x, y, tt.wantCol)
+			}
+		})
+	}
+}
+
+// scrolledTextAreaRoot wraps a focused TextArea inside a short scrollable
+// viewport scrolled so the cursor row falls outside the visible window.
+type scrolledTextAreaRoot struct {
+	ta      *TextArea
+	scrollY int
+}
+
+func (r *scrolledTextAreaRoot) Render(app *App) *Element {
+	scroller := New(
+		WithDirection(Column),
+		WithHeight(2),
+		WithWidth(20),
+		WithScrollable(ScrollVertical),
+		WithScrollOffset(0, r.scrollY),
+	)
+	scroller.AddChild(r.ta.Render(app))
+	return scroller
+}
+
+func (r *scrolledTextAreaRoot) BindApp(app *App) { r.ta.BindApp(app) }
+
+func TestTextArea_RealCursor_HiddenWhenScrolledOutOfView(t *testing.T) {
+	// A multi-line textarea inside a 2-row scrollable viewport. The cursor sits on
+	// the last line; scrolling the viewport down by enough rows pushes the cursor
+	// out of view, so the real cursor must be hidden.
+	ta := NewTextArea(WithTextAreaWidth(20), WithTextAreaAutoFocus(true))
+	ta.SetText("l0\nl1\nl2\nl3\nl4") // cursor lands on l4 (row 4)
+
+	root := &scrolledTextAreaRoot{ta: ta, scrollY: 0}
+	app := newTestApp(40, 10)
+	root.BindApp(app)
+	app.SetRootComponent(root)
+	app.MarkDirty()
+	app.Render()
+
+	mt := app.terminal.(*MockTerminal)
+
+	// With no scroll, the viewport shows rows 0..1; the cursor on row 4 is below
+	// the viewport and must be hidden.
+	if !mt.IsCursorHidden() {
+		x, y := mt.Cursor()
+		t.Fatalf("cursor should be hidden when below viewport, but shown at (%d,%d)", x, y)
+	}
+
+	// Scroll down so the cursor's row enters the viewport: it must become visible.
+	root.scrollY = 3 // viewport now shows content rows 3..4
+	app.MarkDirty()
+	app.Render()
+	if mt.IsCursorHidden() {
+		t.Fatal("cursor should be visible once its row is scrolled into view")
+	}
+}
+
+func TestTextArea_RealCursor_PlacedAtCell(t *testing.T) {
+	type tc struct {
+		text    string
+		width   int
+		wantCol int
+		wantRow int
+	}
+
+	tests := map[string]tc{
+		"ascii end":    {text: "abc", width: 20, wantCol: 3, wantRow: 0},
+		"cjk wide":     {text: "一二", width: 20, wantCol: 4, wantRow: 0},
+		"flag":         {text: flagUS, width: 20, wantCol: 2, wantRow: 0},
+		"second line":  {text: "ab\ncd", width: 20, wantCol: 2, wantRow: 1},
+		"after family": {text: zwjFamily, width: 20, wantCol: 2, wantRow: 0},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ta := NewTextArea(WithTextAreaWidth(tt.width), WithTextAreaAutoFocus(true))
+			ta.SetText(tt.text) // cursor to end
+
+			app := newTestApp(40, 10)
+			ta.BindApp(app)
+			app.SetRootComponent(ta)
+			app.MarkDirty()
+			app.Render()
+
+			if app.Focused() == nil {
+				t.Fatal("textarea not focused")
+			}
+			mt := app.terminal.(*MockTerminal)
+			if mt.IsCursorHidden() {
+				t.Fatal("cursor should be visible for focused textarea")
+			}
+			x, y := mt.Cursor()
+			if x != tt.wantCol || y != tt.wantRow {
+				t.Fatalf("cursor at (%d,%d), want (%d,%d)", x, y, tt.wantCol, tt.wantRow)
+			}
+		})
+	}
+}
+
+func TestApp_PlaceCursor_HiddenWhenNoFocus(t *testing.T) {
+	app := newTestApp(20, 5)
+	root := New()
+	app.SetRoot(root)
+	app.MarkDirty()
+	app.Render()
+
+	mt := app.terminal.(*MockTerminal)
+	if !mt.IsCursorHidden() {
+		t.Fatal("cursor should be hidden when nothing focused reports a cursor")
+	}
+}
+
+func TestApp_ManualCursor_SkipsPlacement(t *testing.T) {
+	app := newTestApp(40, 5)
+	app.manualCursor = true
+
+	inp := NewInput(WithInputWidth(10), WithInputAutoFocus(true))
+	inp.SetText("ab")
+	inp.BindApp(app)
+	app.SetRootComponent(inp)
+
+	mt := app.terminal.(*MockTerminal)
+	mt.HideCursor() // baseline
+	mt.SetCursor(7, 7)
+	app.MarkDirty()
+	app.Render()
+
+	// With manual cursor, placeCursor is a no-op: it must not move or show the
+	// cursor.
+	x, y := mt.Cursor()
+	if x != 7 || y != 7 {
+		t.Fatalf("manual cursor moved to (%d,%d), want (7,7)", x, y)
+	}
+	if !mt.IsCursorHidden() {
+		t.Fatal("manual cursor should leave cursor hidden as set")
+	}
+}
+
+func TestElement_ReportCursor_NoSource(t *testing.T) {
+	e := New()
+	if _, _, vis := e.ReportCursor(); vis {
+		t.Fatal("element with no cursor source should report invisible")
+	}
+}
+
+func TestElement_ReportCursor_AddsContentOrigin(t *testing.T) {
+	app := newTestApp(40, 10)
+	// A bordered child so its content rect is offset from the root origin.
+	child := New(WithWidth(10), WithHeight(3), WithBorder(BorderSingle))
+	child.SetCursorSource(func() (int, int, bool) { return 2, 1, true })
+	root := New(WithDirection(Column))
+	root.AddChild(child)
+	app.SetRoot(root)
+	app.MarkDirty()
+	app.Render()
+
+	cr := child.ContentRect()
+	x, y, vis := child.ReportCursor()
+	if !vis {
+		t.Fatal("expected visible")
+	}
+	if x != cr.X+2 || y != cr.Y+1 {
+		t.Fatalf("ReportCursor = (%d,%d), want (%d,%d)", x, y, cr.X+2, cr.Y+1)
+	}
+}
+
+func TestElement_ReportCursor_ScrollableAncestorShiftsAndClips(t *testing.T) {
+	app := newTestApp(40, 10)
+
+	// A scrollable viewport of height 3, scrolled down by 2 rows.
+	scroller := New(WithDirection(Column), WithHeight(3), WithWidth(10), WithScrollable(ScrollVertical), WithScrollOffset(0, 2))
+	// Two stacked children; the cursor source lives on the second.
+	first := New(WithHeight(2), WithWidth(10))
+	cursorChild := New(WithHeight(4), WithWidth(10))
+	cursorChild.SetCursorSource(func() (int, int, bool) { return 1, 0, true })
+	scroller.AddChild(first)
+	scroller.AddChild(cursorChild)
+
+	root := New(WithDirection(Column))
+	root.AddChild(scroller)
+	app.SetRoot(root)
+	app.MarkDirty()
+	app.Render()
+
+	// cursorChild starts at content-row 2 (after first's 2 rows). With scrollY=2,
+	// it shifts to screen row 0 of the viewport. The viewport content origin is
+	// the scroller's content rect.
+	clip := scroller.ContentRect()
+	x, y, vis := cursorChild.ReportCursor()
+	if !vis {
+		t.Fatalf("expected cursor visible inside viewport, got hidden")
+	}
+	if x != clip.X+1 || y != clip.Y+0 {
+		t.Fatalf("ReportCursor = (%d,%d), want (%d,%d)", x, y, clip.X+1, clip.Y+0)
+	}
+}

--- a/dispatch.go
+++ b/dispatch.go
@@ -169,7 +169,8 @@ func (dt *dispatchTable) dispatch(ke KeyEvent) bool {
 func (dt *dispatchTable) validate() error {
 	// Track patterns that already have a Stop handler
 	type stopInfo struct {
-		position int
+		position    int
+		droppedGate bool
 	}
 	stopPatterns := make(map[KeyPattern]stopInfo)
 
@@ -177,8 +178,12 @@ func (dt *dispatchTable) validate() error {
 		if !entry.stop {
 			continue
 		}
-		// Focus-gated entries cannot conflict because only one can be focused at a time
-		if entry.pattern.FocusRequired {
+		// A focus-gated entry is exempt only when its focus check resolved: the
+		// owning component implements IsFocused (and was mounted), so at most one
+		// such binding is active at a time. When focusCheck is nil the gate was
+		// dropped — the binding fires unconditionally — so treat it as an ordinary
+		// stop handler that can conflict.
+		if entry.pattern.FocusRequired && entry.focusCheck != nil {
 			continue
 		}
 		// Preemptive entries (modal overlay) run in a separate dispatch pass
@@ -186,17 +191,29 @@ func (dt *dispatchTable) validate() error {
 		if entry.preempt {
 			continue
 		}
+		// Reaching here with FocusRequired means focusCheck was nil: the focus gate
+		// was dropped (owner has no IsFocused, or the widget was not mounted).
+		droppedGate := entry.pattern.FocusRequired
 		// Strip FocusRequired for comparison so focus-gated and broadcast entries
 		// with the same key don't conflict
 		comparePattern := entry.pattern
 		comparePattern.FocusRequired = false
 		if existing, conflict := stopPatterns[comparePattern]; conflict {
+			if droppedGate || existing.droppedGate {
+				return fmt.Errorf(
+					"focus-gated key binding for pattern %+v at tree positions %d and %d fires "+
+						"unconditionally because its owning component does not implement IsFocused() "+
+						"or was not mounted; mount each focusable widget as its own component "+
+						"(app.Mount) instead of aggregating their KeyMaps onto a host",
+					entry.pattern, existing.position, entry.position,
+				)
+			}
 			return fmt.Errorf(
 				"conflicting stop handlers for key pattern %+v at tree positions %d and %d",
 				entry.pattern, existing.position, entry.position,
 			)
 		}
-		stopPatterns[comparePattern] = stopInfo{position: entry.position}
+		stopPatterns[comparePattern] = stopInfo{position: entry.position, droppedGate: droppedGate}
 	}
 
 	return nil

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -1072,3 +1072,64 @@ func TestDispatch_KittyCtrlH_DistinctFromBackspace(t *testing.T) {
 		t.Errorf("0x08: calls = %v, want [ctrl-h]", calls)
 	}
 }
+
+// mockFocusableKeyComponent implements Component, KeyListener, and focusQuerier,
+// so its OnFocused bindings keep their focus gate at dispatch time.
+type mockFocusableKeyComponent struct {
+	keyMap  KeyMap
+	focused bool
+}
+
+func (m *mockFocusableKeyComponent) Render(app *App) *Element { return New() }
+func (m *mockFocusableKeyComponent) KeyMap() KeyMap           { return m.keyMap }
+func (m *mockFocusableKeyComponent) IsFocused() bool          { return m.focused }
+
+func TestBuildDispatchTable_DroppedFocusGateConflicts(t *testing.T) {
+	noop := func(KeyEvent) {}
+
+	type tc struct {
+		root      *Element
+		wantError bool
+	}
+
+	tests := map[string]tc{
+		"aggregated OnFocused on a host without IsFocused errors": {
+			// Mirrors hand-aggregating two widgets' KeyMaps onto one host: the host
+			// has no IsFocused, so both AnyRune focus gates drop and fire always.
+			root: buildTestTree(&mockKeyComponent{keyMap: KeyMap{
+				OnFocused(AnyRune, noop),
+				OnFocused(AnyRune, noop),
+			}}),
+			wantError: true,
+		},
+		"single OnFocused on a host without IsFocused is fine": {
+			// One aggregated focusable widget is the common generated pattern; with
+			// no second binding to conflict, it stays valid.
+			root: buildTestTree(&mockKeyComponent{keyMap: KeyMap{
+				OnFocused(AnyRune, noop),
+			}}),
+			wantError: false,
+		},
+		"per-widget OnFocused on mounted focusable components is fine": {
+			// The correct multi-widget shape: each widget is its own component with
+			// IsFocused, so gates resolve and only one fires at a time.
+			root: buildTestTree(
+				&mockFocusableKeyComponent{keyMap: KeyMap{OnFocused(AnyRune, noop)}},
+				&mockFocusableKeyComponent{keyMap: KeyMap{OnFocused(AnyRune, noop)}},
+			),
+			wantError: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := buildDispatchTable(nil, tt.root)
+			if tt.wantError && err == nil {
+				t.Fatal("expected a dispatch-table error, got nil")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/docs/plans/cursor-and-editing-api.md
+++ b/docs/plans/cursor-and-editing-api.md
@@ -1,0 +1,271 @@
+# Design: Cursor reporting, text editing API, and element resize
+
+Status: Draft / proposal (not yet implemented). Adapted to #103 on 2026-06-22.
+Base: build on `main` after PR #103 (`st33l-grapheme`) merges. PRs #96 and #97 are
+closed; #103 supersedes both.
+Scope: public API surface for `TextArea` / `Input` / `Element` cursor and editing.
+
+## Problem
+
+After the grapheme-cluster work, text rendering and the framework's own cursor
+are correct for emoji, flags, ZWJ sequences, and skin-tone modifiers. But
+building a real text-input UI still requires reaching inside the framework. The
+driving consumer app uses `reflect` and `unsafe` in four places:
+
+| Reach inside | What it does | Fix |
+|---|---|---|
+| insert `\n` at the cursor | reads/writes `cursorPos`, splices text by hand | Part A: editing API (`InsertText`) |
+| resize a persisted element each frame | writes `style.Height` | Part B: `Element.SetHeight` |
+| place the real terminal cursor | reads cursor state, scroll, absolute position | Part C: cursor reporting protocol |
+| read an element's screen position | reads `layout.AbsoluteX/AbsoluteY` | none needed; `Element.Rect().X/Y` is already public (discoverability only) |
+
+## Relationship to #103
+
+#103 already landed the parts of the original plan that overlap with the engine,
+and chose to expose the engine rather than encapsulate it:
+
+- Cells store `Rune` + `Combining` (the old #97 storage refactor is absorbed).
+- The grapheme engine is public: `StringWidth`, `NextCluster`, `NextClusterRunes`,
+  `ClusterCount`, `ClusterRuneCount`. `RuneWidth` remains public. `WithScrollOffset`
+  is an `Element` option.
+
+What #103 does NOT provide, and what this design adds:
+
+- No programmatic text editing (`InsertText`, public cursor position).
+- No element resize setters.
+- No cursor-reporting protocol; the framework still does not place the real
+  terminal cursor at a focused widget.
+
+Consequence: this design no longer internalizes `RuneWidth` or hides the engine
+(that fight is over, #103 exposed it). The cursor protocol becomes a clean default
+layered on top of an already-exposed engine, not a replacement for it.
+
+## Goals
+
+- Build a real text-input UI using public API only (remove the consumer's
+  `reflect`/`unsafe`).
+- Coexist with #103's exposed engine; reuse its primitives.
+- Keep new surface minimal and on the declarative grain where it does not fight a
+  real need.
+
+## Non-goals
+
+- Changing `grapheme.go` segmentation.
+- Reversing #103's public engine (no `RuneWidth` internalization).
+- Terminal cursor shape/blink control (`DECSCUSR`); possible later follow-up.
+
+## Priority
+
+1. Part A (editing API) and Part B (element setters): highest value, they remove
+   `reflect`/`unsafe` that #103 leaves untouched.
+2. Part C (cursor protocol): clean default and removes the last reflection plus a
+   timing bug, but `StringWidth` already lets a consumer compute a correct cursor
+   column today, so it is polish rather than a fix.
+
+---
+
+## Part A: Editing API (mutation)
+
+`TextArea` can be typed into but offers no programmatic editing entry point, so
+custom edits (for example Shift+Enter inserts a newline) force reflection into
+`cursorPos` plus hand-splicing the bound text.
+
+Positions are grapheme-cluster indices (Decision 3): the count of whole glyphs
+before the cursor. Translate to and from the internal rune index using #103's
+primitives (`ClusterCount` / `ClusterRuneCount` and the internal
+`clusterRuneStarts` / `runeIndexToDisplayCol`).
+
+```go
+func (t *TextArea) CursorPos() int        // read cursor as a cluster index
+func (t *TextArea) SetCursorPos(pos int)  // move cursor to a cluster index (clamped)
+func (t *TextArea) InsertText(s string)   // insert at cursor, advance cursor (cluster-correct)
+```
+
+`InsertText` routes through the same internal insert path that typing uses (#103:
+`cursorPos.Set(clusterEnd(newText, pos))`), keeping the bound `State[string]` and
+the cursor consistent by construction. The consumer's newline handler collapses
+to:
+
+```go
+tui.OnStop(tui.KeyEnter.Shift(), func(ke tui.KeyEvent) { textArea.InsertText("\n") })
+```
+
+Document that string mutation goes through `InsertText`, not slicing the text
+with a cluster index (a cluster index is not a byte or rune offset).
+`DeleteBackward`/`DeleteForward` are already covered by the built-in keymap;
+expose them only for symmetry. Ship all three methods on both `TextArea` and
+`Input` (Decision 4).
+
+---
+
+## Part B: Element resize after creation (Decision 5)
+
+A consumer holds a persisted element and changes its height each frame (a
+fuzzy-match list that grows from 1 to 8 rows), and writes `style.Height` through
+`unsafe` because there is no public setter.
+
+```go
+func (e *Element) SetHeight(v Value)  // sets style.Height, then e.MarkDirty()
+func (e *Element) SetWidth(v Value)   // sets style.Width,  then e.MarkDirty()
+```
+
+Each setter marks the element (and ancestors) dirty so layout recomputes next
+frame. Constraints:
+
+- Target retained elements (a consumer holding the reference across renders). A
+  setter on an element recreated each render has no lasting effect; document this.
+- Ship `SetHeight`/`SetWidth` only for now. Hold min/max and the rest of the
+  layout surface until a concrete need appears.
+
+The consumer then replaces its `unsafe` write with
+`matches.SetHeight(tui.Fixed(rows))`.
+
+Independent of Parts A and C; can land on its own.
+
+---
+
+## Part C: Cursor reporting protocol (output)
+
+Three layers, each contributing only what it owns: the widget computes the
+cursor's position within its own content (cluster-aware, after internal scroll);
+the element converts content-local to absolute via its laid-out `ContentRect()`;
+the app drives the real terminal cursor at end of frame. The position is computed
+once and consumed by both presentations (real cursor or drawn glyph) so they
+cannot diverge.
+
+### Protocol (element-level)
+
+Focus and absolute layout both live on the element.
+
+```go
+type CursorReporter interface {
+    // ReportCursor returns the absolute terminal cell and whether to show it.
+    ReportCursor() (x, y int, visible bool)
+}
+```
+
+`*Element` always implements it (returns `visible=false` when no source is set).
+
+### Element side
+
+```go
+type cursorSource func() (col, row int, visible bool) // content-local
+// field e.cursorSource on Element; option WithCursorSource(fn) / setter SetCursorSource(fn)
+
+func (e *Element) ReportCursor() (int, int, bool) {
+    if e.cursorSource == nil { return 0, 0, false }
+    col, row, vis := e.cursorSource()
+    if !vis { return 0, 0, false }
+
+    cr := e.ContentRect()
+    x, y := cr.X+col, cr.Y+row
+
+    // The renderer applies only the OUTERMOST scrollable ancestor's transform to
+    // the whole clipped subtree (it never re-bases at nested scrollables). Mirror
+    // that: apply that one (ContentRect - scroll) transform and clip against its
+    // viewport, shrinking the clip by one when it reserves a vertical-scrollbar
+    // column. No scrollable ancestor => the content-local position is screen-absolute.
+    var outer *Element
+    for anc := e.parent; anc != nil; anc = anc.parent {
+        if anc.IsScrollable() { outer = anc }
+    }
+    if outer == nil { return x, y, true }
+
+    clip := outer.ContentRect()
+    sx, sy := outer.ScrollOffset()
+    x, y = x+clip.X-sx, y+clip.Y-sy
+    if outer.needsVerticalScrollbar() { clip.Width = max(0, clip.Width-1) }
+    if x < clip.X || x >= clip.Right() || y < clip.Y || y >= clip.Bottom() {
+        return 0, 0, false
+    }
+    return x, y, true
+}
+```
+
+### Widget side (names illustrative; map onto #103 internals)
+
+`Input` has a clear internal scroll model on #103: `scrollPos` (a display-column
+`State[int]`) with `ensureCursorVisible` and `snapColToNextClusterBoundary`. Its
+source is `(col = cursorDisplayCol - scrollPos, row = 0)`.
+
+`TextArea` on #103 has no internal scroll field; it relies on an enclosing
+scrollable element. So its source reports the cursor's content-local `(col,row)`
+within the textarea, and the enclosing scrollable element's offset is what shifts
+it; the implementer must account for that scroll offset when composing the
+absolute position (rather than the old `tempScrollOffset` the original plan
+assumed). Use the existing cluster-aware helpers (`runeIndexToDisplayCol`,
+`clusterEnd`, `snapRuneToClusterStart`) for the column math. If the cursor is
+scrolled out of view, report `visible=false` (Decision: out-of-view hides the
+cursor).
+
+### App side (end of frame, after Flush)
+
+```go
+func (a *App) placeCursor() {
+    if cr, ok := a.focusManager.Focused().(CursorReporter); ok {
+        if x, y, vis := cr.ReportCursor(); vis {
+            a.terminal.SetCursor(x, y); a.terminal.ShowCursor(); return
+        }
+    }
+    a.terminal.HideCursor()
+}
+```
+
+Timing: placement must be the last terminal op of the frame. `placeCursor()` runs
+after `Flush` and then after `postRenderHook`, so no cell writes (including any in
+the hook) can clobber the cursor position.
+
+Inline mode (Decision 2): offset the reported coordinates by the inline start row,
+mirroring the renderer, so the cursor lands in the inline block.
+
+### Presentation: real cursor is the default (Decision 1)
+
+The real terminal cursor is the default for focused text widgets; the framework
+positions it automatically. Overrides:
+
+1. `WithTextAreaVirtualCursor()` switches a widget to the drawn `▌` glyph
+   (customizable via `WithTextAreaCursorRune(r)`), which reports `visible=false`.
+2. `WithCursorSource(fn)` lets any element report its own cursor.
+3. `WithManualCursor()` disables framework cursor management entirely.
+
+Behavior-change note: making the real cursor the default means existing tests
+that assert on the drawn `▌` glyph must opt into virtual mode or assert position
+through the protocol, and full-screen snapshot tests lose the cursor glyph.
+
+### Docs
+
+Bless `StringWidth` as the width function for strings and cursor math; note
+`RuneWidth` is low-level per-rune and wrong for multi-rune clusters. (No code
+change; `RuneWidth` stays public per #103.)
+
+---
+
+## Decisions
+
+1. Real terminal cursor is the default; drawn glyph opt-in via
+   `WithTextAreaVirtualCursor()`. (Part C; behavior change.)
+2. Inline mode handled: placement offsets by the inline start row.
+3. `CursorPos()`/`SetCursorPos()` use grapheme-cluster indices.
+4. Cursor reporting and editing API ship on both `TextArea` and `Input`.
+5. Add mutable `Element.SetHeight`/`SetWidth` (narrow, retained-element scoped).
+6. (Adapted 2026-06-22) `RuneWidth` is NOT internalized; the engine stays exposed
+   per #103. The original "encapsulate + hide RuneWidth" stage is dropped.
+
+### Remaining micro-questions
+
+- Confirm the opt-into-glyph option name `WithTextAreaVirtualCursor()` (presence =
+  on) and that the drawn-glyph mode is retained at all.
+- Setter scope: `SetHeight`/`SetWidth` only, or include min/max now?
+
+## Net result
+
+| Reach inside (driving example) | Removed by |
+|---|---|
+| read/write `cursorPos` plus manual splice for newline | Part A `InsertText` |
+| write `style.Height` | Part B `Element.SetHeight` |
+| read cursor state, scroll, abs pos for the cursor | Part C protocol (or, interim, `StringWidth` in the consumer's own loop) |
+| read `layout.AbsoluteX/AbsoluteY` | already public `Element.Rect()`; docs only |
+
+Parts A and B are the high-value work and remove `reflect`/`unsafe` that #103 does
+not address. Part C is a clean default that can follow. All three build on `main`
+after #103 merges.

--- a/editing_api_test.go
+++ b/editing_api_test.go
@@ -1,0 +1,230 @@
+package tui
+
+import "testing"
+
+// Grapheme fixtures: each is a single user-perceived glyph made of multiple runes.
+// Built with explicit escapes so the ZWJ joiners and combining marks are visible.
+var (
+	flagUS    = "\U0001F1FA\U0001F1F8"             // US flag (2 runes, 1 cluster)
+	zwjFamily = "\U0001F468‍\U0001F469‍\U0001F467" // man+woman+girl ZWJ family (5 runes, 1 cluster)
+	skinWave  = "\U0001F44B\U0001F3FD"             // waving hand + medium skin tone (2 runes, 1 cluster)
+	comboE    = "é"                               // e + combining acute (2 runes, 1 cluster)
+)
+
+func TestTextArea_InsertText_KeepsClustersWhole(t *testing.T) {
+	type tc struct {
+		insert        string
+		wantClusters  int // ClusterCount of the inserted glyph (always 1)
+		wantCursorPos int // cluster index after insert
+	}
+
+	tests := map[string]tc{
+		"flag":       {insert: flagUS, wantClusters: 1, wantCursorPos: 1},
+		"zwj family": {insert: zwjFamily, wantClusters: 1, wantCursorPos: 1},
+		"skin tone":  {insert: skinWave, wantClusters: 1, wantCursorPos: 1},
+		"combining":  {insert: comboE, wantClusters: 1, wantCursorPos: 1},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ta := NewTextArea()
+			ta.BindApp(testApp)
+			ta.InsertText(tt.insert)
+
+			if got := ta.Text(); got != tt.insert {
+				t.Fatalf("text = %q, want %q", got, tt.insert)
+			}
+			if got := ClusterCount(ta.Text()); got != tt.wantClusters {
+				t.Fatalf("ClusterCount = %d, want %d", got, tt.wantClusters)
+			}
+			if got := ta.CursorPos(); got != tt.wantCursorPos {
+				t.Fatalf("CursorPos = %d, want %d", got, tt.wantCursorPos)
+			}
+		})
+	}
+}
+
+func TestTextArea_InsertText_RoutesThroughInsertPath(t *testing.T) {
+	ta := NewTextArea()
+	ta.BindApp(testApp)
+	// Place a combining accent after a base by inserting the base first, then
+	// the mark. InsertText must glue them and land the cursor after the cluster.
+	ta.InsertText("e")
+	ta.InsertText("́") // combining acute
+	if got := ta.Text(); got != comboE {
+		t.Fatalf("text = %q, want %q", got, comboE)
+	}
+	// One whole cluster, cursor after it.
+	if got := ClusterCount(ta.Text()); got != 1 {
+		t.Fatalf("ClusterCount = %d, want 1", got)
+	}
+	if got := ta.CursorPos(); got != 1 {
+		t.Fatalf("CursorPos = %d, want 1", got)
+	}
+	// The cursor rune index must sit at the end of the multi-rune cluster.
+	if got := ta.cursorPos.Get(); got != 2 {
+		t.Fatalf("internal cursorPos = %d, want 2", got)
+	}
+}
+
+func TestTextArea_CursorPos_RoundTripsThroughSetCursorPos(t *testing.T) {
+	type tc struct {
+		text string
+		want int // ClusterCount(text)
+	}
+
+	tests := map[string]tc{
+		"ascii":          {text: "hello", want: 5},
+		"flags":          {text: flagUS + flagUS, want: 2},
+		"mixed clusters": {text: "a" + flagUS + comboE + "z", want: 4},
+		"zwj family":     {text: zwjFamily, want: 1},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ta := NewTextArea()
+			ta.BindApp(testApp)
+			ta.SetText(tt.text)
+
+			if got := ClusterCount(tt.text); got != tt.want {
+				t.Fatalf("ClusterCount(%q) = %d, want %d", tt.text, got, tt.want)
+			}
+
+			// Every cluster index round-trips through SetCursorPos/CursorPos.
+			for pos := 0; pos <= tt.want; pos++ {
+				ta.SetCursorPos(pos)
+				if got := ta.CursorPos(); got != pos {
+					t.Fatalf("SetCursorPos(%d) -> CursorPos() = %d", pos, got)
+				}
+			}
+		})
+	}
+}
+
+func TestTextArea_SetCursorPos_ClampsAndSnaps(t *testing.T) {
+	ta := NewTextArea()
+	ta.BindApp(testApp)
+	ta.SetText("a" + flagUS) // 2 clusters, 3 runes
+
+	// Past the end clamps to the last cluster boundary.
+	ta.SetCursorPos(99)
+	if got := ta.CursorPos(); got != 2 {
+		t.Fatalf("CursorPos after over-clamp = %d, want 2", got)
+	}
+	if got := ta.cursorPos.Get(); got != 3 {
+		t.Fatalf("internal cursorPos after over-clamp = %d, want 3", got)
+	}
+
+	// Negative clamps to 0.
+	ta.SetCursorPos(-5)
+	if got := ta.CursorPos(); got != 0 {
+		t.Fatalf("CursorPos after negative = %d, want 0", got)
+	}
+}
+
+func TestTextArea_InsertText_AtCursor_ClusterIndexSemantics(t *testing.T) {
+	ta := NewTextArea()
+	ta.BindApp(testApp)
+	ta.SetText(flagUS + flagUS) // 2 clusters
+	ta.SetCursorPos(1)          // between the two flags
+
+	ta.InsertText("X")
+	if got := ta.Text(); got != flagUS+"X"+flagUS {
+		t.Fatalf("text = %q, want %q", got, flagUS+"X"+flagUS)
+	}
+	// Cursor now sits after the inserted X (cluster index 2).
+	if got := ta.CursorPos(); got != 2 {
+		t.Fatalf("CursorPos = %d, want 2", got)
+	}
+}
+
+func TestInput_InsertText_KeepsClustersWhole(t *testing.T) {
+	type tc struct {
+		insert       string
+		wantClusters int
+	}
+
+	tests := map[string]tc{
+		"flag":       {insert: flagUS, wantClusters: 1},
+		"zwj family": {insert: zwjFamily, wantClusters: 1},
+		"skin tone":  {insert: skinWave, wantClusters: 1},
+		"combining":  {insert: comboE, wantClusters: 1},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			inp := NewInput(WithInputWidth(20))
+			inp.BindApp(testApp)
+			inp.InsertText(tt.insert)
+
+			if got := inp.Text(); got != tt.insert {
+				t.Fatalf("text = %q, want %q", got, tt.insert)
+			}
+			if got := ClusterCount(inp.Text()); got != tt.wantClusters {
+				t.Fatalf("ClusterCount = %d, want %d", got, tt.wantClusters)
+			}
+			if got := inp.CursorPos(); got != tt.wantClusters {
+				t.Fatalf("CursorPos = %d, want %d", got, tt.wantClusters)
+			}
+		})
+	}
+}
+
+func TestInput_InsertText_FiresOnChangeAndAdvancesCursor(t *testing.T) {
+	var changes []string
+	inp := NewInput(WithInputWidth(20), WithInputOnChange(func(s string) {
+		changes = append(changes, s)
+	}))
+	inp.BindApp(testApp)
+
+	inp.InsertText("ab")
+	inp.InsertText(flagUS)
+
+	if got := inp.Text(); got != "ab"+flagUS {
+		t.Fatalf("text = %q, want %q", got, "ab"+flagUS)
+	}
+	// 3 clusters: a, b, flag.
+	if got := inp.CursorPos(); got != 3 {
+		t.Fatalf("CursorPos = %d, want 3", got)
+	}
+	if len(changes) != 2 {
+		t.Fatalf("onChange called %d times, want 2", len(changes))
+	}
+}
+
+func TestInput_CursorPos_RoundTripsThroughSetCursorPos(t *testing.T) {
+	inp := NewInput(WithInputWidth(20))
+	inp.BindApp(testApp)
+	text := "a" + flagUS + comboE + "z" // 4 clusters
+	inp.SetText(text)
+
+	want := ClusterCount(text)
+	if want != 4 {
+		t.Fatalf("ClusterCount = %d, want 4", want)
+	}
+	for pos := 0; pos <= want; pos++ {
+		inp.SetCursorPos(pos)
+		if got := inp.CursorPos(); got != pos {
+			t.Fatalf("SetCursorPos(%d) -> CursorPos() = %d", pos, got)
+		}
+	}
+}
+
+func TestInput_SetCursorPos_Clamps(t *testing.T) {
+	inp := NewInput(WithInputWidth(20))
+	inp.BindApp(testApp)
+	inp.SetText(flagUS) // 1 cluster, 2 runes
+
+	inp.SetCursorPos(99)
+	if got := inp.CursorPos(); got != 1 {
+		t.Fatalf("CursorPos after over-clamp = %d, want 1", got)
+	}
+	if got := inp.cursorPos.Get(); got != 2 {
+		t.Fatalf("internal cursorPos = %d, want 2", got)
+	}
+
+	inp.SetCursorPos(-3)
+	if got := inp.CursorPos(); got != 0 {
+		t.Fatalf("CursorPos after negative = %d, want 0", got)
+	}
+}

--- a/element.go
+++ b/element.go
@@ -130,6 +130,11 @@ type Element struct {
 
 	// Component that produced this element (set by Mount, read during tree walks)
 	component Component
+
+	// Content-local cursor source. When set, the element reports a terminal
+	// cursor position via ReportCursor. Returns (col, row) within the element's
+	// content area and whether the cursor is visible. nil = no cursor.
+	cursorSource cursorSource
 }
 
 // New creates a new Element with the given options.

--- a/element.go
+++ b/element.go
@@ -135,6 +135,18 @@ type Element struct {
 	// cursor position via ReportCursor. Returns (col, row) within the element's
 	// content area and whether the cursor is visible. nil = no cursor.
 	cursorSource cursorSource
+
+	// cursorReport caches where the cursor landed on screen, captured by the
+	// renderer at this element's draw site and returned by ReportCursor.
+	cursorReport cursorReport
+}
+
+// cursorReport is the screen-space result captured for an element's cursor during
+// render. visible is false when there is no source, the source reports invisible,
+// or the cursor is clipped out of view.
+type cursorReport struct {
+	x, y    int
+	visible bool
 }
 
 // New creates a new Element with the given options.

--- a/element_accessors.go
+++ b/element_accessors.go
@@ -12,6 +12,24 @@ func (e *Element) SetStyle(style LayoutStyle) {
 	e.MarkDirty()
 }
 
+// SetHeight updates the element's height after creation and marks it (and its
+// ancestors) dirty so layout recomputes on the next frame. Intended for retained
+// elements held across renders; a setter on an element recreated each render has
+// no lasting effect. Pass tui.Fixed(n), tui.Percent(p), or tui.Auto().
+func (e *Element) SetHeight(v Value) {
+	e.style.Height = v
+	e.MarkDirty()
+}
+
+// SetWidth updates the element's width after creation and marks it (and its
+// ancestors) dirty so layout recomputes on the next frame. Intended for retained
+// elements held across renders; a setter on an element recreated each render has
+// no lasting effect. Pass tui.Fixed(n), tui.Percent(p), or tui.Auto().
+func (e *Element) SetWidth(v Value) {
+	e.style.Width = v
+	e.MarkDirty()
+}
+
 // Style returns the current layout style.
 func (e *Element) Style() LayoutStyle {
 	return e.style

--- a/element_accessors.go
+++ b/element_accessors.go
@@ -191,6 +191,13 @@ func (e *Element) Component() Component {
 // sum of its code points.
 //
 // StringWidth is the exported wrapper.
+//
+// StringWidth is the correct width function for strings and for cursor-column
+// math: it measures whole grapheme clusters, so a multi-rune glyph advances the
+// column by the cell width the terminal actually paints. Use it (not RuneWidth)
+// when computing a cursor position or the width of a span of text. RuneWidth is
+// low-level: it reports a single rune's width and is wrong for multi-rune
+// clusters (a combining mark or ZWJ joiner counts as 1 there).
 func StringWidth(s string) int { return stringWidth(s) }
 
 func stringWidth(s string) int {

--- a/element_options.go
+++ b/element_options.go
@@ -324,6 +324,17 @@ func WithScrollOffset(x, y int) Option {
 	}
 }
 
+// WithCursorSource installs a content-local cursor source on the element so the
+// framework can place the real terminal cursor when this element is focused. The
+// function returns (col, row) in display cells from the element's content origin
+// and whether the cursor is visible. See SetCursorSource for the post-creation
+// setter.
+func WithCursorSource(fn func() (col, row int, visible bool)) Option {
+	return func(e *Element) {
+		e.cursorSource = fn
+	}
+}
+
 // WithScrollbarStyle sets the style for the scrollbar track.
 func WithScrollbarStyle(style Style) Option {
 	return func(e *Element) {

--- a/element_render.go
+++ b/element_render.go
@@ -163,6 +163,22 @@ func renderElement(buf *Buffer, e *Element, inherited inheritedStyle) {
 			renderElement(buf, child, rc.childInherited)
 		}
 	}
+
+	// Capture the cursor at its draw site (after children, so a scrollable's
+	// scrollbar state is settled). The content origin is absolute here; a
+	// scrollable also clips its own cursor to its viewport (gutter-aware).
+	if e.cursorSource != nil {
+		cr := e.ContentRect()
+		clip := buf.Rect()
+		if e.IsScrollable() {
+			viewport := cr
+			if e.needsVerticalScrollbar() {
+				viewport.Width = max(0, viewport.Width-1)
+			}
+			clip = clip.Intersect(viewport)
+		}
+		e.captureCursor(cr.X, cr.Y, clip)
+	}
 }
 
 // renderScrollableChildren renders children with scroll offset and clipping.
@@ -214,6 +230,19 @@ func renderClippedElement(buf *Buffer, e *Element, clipRect Rect, scrollX, scrol
 	visibleRect := screenRect.Intersect(clipRect)
 	if visibleRect.IsEmpty() {
 		return
+	}
+
+	// Capture the cursor at its draw site, using the same content origin and the
+	// active clip (already gutter-shrunk by the enclosing scrollable) the renderer
+	// uses for this element's text.
+	if e.cursorSource != nil {
+		ox := screenX + e.style.Padding.Left
+		oy := screenY + e.style.Padding.Top
+		if e.border != BorderNone {
+			ox++
+			oy++
+		}
+		e.captureCursor(ox, oy, clipRect)
 	}
 
 	// Resolve effective styles (inheritance + <th> bold)

--- a/element_resize_test.go
+++ b/element_resize_test.go
@@ -1,0 +1,71 @@
+package tui
+
+import "testing"
+
+// TestElement_SetHeight_TriggersRelayout verifies that SetHeight on a retained
+// element changes its laid-out height on the next frame.
+func TestElement_SetHeight_TriggersRelayout(t *testing.T) {
+	app := newTestApp(40, 24)
+
+	// A retained child with an explicit starting height inside a column root.
+	child := New(WithHeight(1), WithWidth(10))
+	root := New(WithDirection(Column))
+	root.AddChild(child)
+	app.SetRoot(root)
+
+	app.Render()
+	if got := child.Rect().Height; got != 1 {
+		t.Fatalf("initial child height = %d, want 1", got)
+	}
+
+	// Grow the retained child; the next frame must re-lay it out.
+	child.SetHeight(Fixed(8))
+	app.Render()
+	if got := child.Rect().Height; got != 8 {
+		t.Fatalf("child height after SetHeight = %d, want 8", got)
+	}
+}
+
+// TestElement_SetWidth_TriggersRelayout verifies that SetWidth on a retained
+// element changes its laid-out width on the next frame.
+func TestElement_SetWidth_TriggersRelayout(t *testing.T) {
+	app := newTestApp(40, 24)
+
+	child := New(WithHeight(1), WithWidth(5))
+	root := New(WithDirection(Column))
+	root.AddChild(child)
+	app.SetRoot(root)
+
+	app.Render()
+	if got := child.Rect().Width; got != 5 {
+		t.Fatalf("initial child width = %d, want 5", got)
+	}
+
+	child.SetWidth(Fixed(20))
+	app.Render()
+	if got := child.Rect().Width; got != 20 {
+		t.Fatalf("child width after SetWidth = %d, want 20", got)
+	}
+}
+
+// TestElement_SetHeight_MarksDirty verifies the element flag is set so the
+// app re-renders.
+func TestElement_SetHeight_MarksDirty(t *testing.T) {
+	app := newTestApp(40, 24)
+	child := New(WithHeight(1))
+	root := New()
+	root.AddChild(child)
+	app.SetRoot(root)
+	app.Render() // clears dirty
+
+	if app.checkAndClearDirty() {
+		t.Fatal("app should be clean after render")
+	}
+	child.SetHeight(Fixed(4))
+	if !child.IsDirty() {
+		t.Fatal("child should be dirty after SetHeight")
+	}
+	if !app.checkAndClearDirty() {
+		t.Fatal("app should be dirty after SetHeight")
+	}
+}

--- a/focus_integration_test.go
+++ b/focus_integration_test.go
@@ -182,3 +182,62 @@ func TestFocusIntegration_TabFocusesInput(t *testing.T) {
 		t.Error("app should NOT be stopped - 'q' should be captured by focused input")
 	}
 }
+
+// testTwoInputApp mounts two focusable inputs so dispatch must route a key to the
+// focused one and skip the other. Each is its own mounted component, so its
+// OnFocused bindings carry its own IsFocused gate.
+type testTwoInputApp struct{}
+
+func (c *testTwoInputApp) Render(app *App) *Element {
+	root := New(WithDirection(Column))
+	root.AddChild(app.MountPersistent(c, 0, func() Component { return newTestInputComponent() }))
+	root.AddChild(app.MountPersistent(c, 1, func() Component { return newTestInputComponent() }))
+	return root
+}
+
+func (c *testTwoInputApp) KeyMap() KeyMap {
+	return KeyMap{
+		On(KeyTab, func(ke KeyEvent) { ke.App().FocusNext() }),
+	}
+}
+
+func mountedInput(app *App, parent Component, key int) *testInputComponent {
+	if comp, ok := app.mounts.cache[mountKey{parent: parent, key: key}]; ok {
+		return comp.(*testInputComponent)
+	}
+	return nil
+}
+
+// TestFocusIntegration_RoutesKeysToFocusedWidget pins the behavior that broke when
+// widgets were hand-aggregated instead of mounted: with two focusable widgets, a
+// typed key reaches only the focused one. The single-input integration test above
+// cannot catch a regression here because it has nothing for the wrong widget to be.
+func TestFocusIntegration_RoutesKeysToFocusedWidget(t *testing.T) {
+	host := &testTwoInputApp{}
+	app := newTestApp(80, 24)
+	app.SetRootComponent(host)
+	app.MarkDirty()
+	app.Render()
+
+	in0 := mountedInput(app, host, 0)
+	in1 := mountedInput(app, host, 1)
+	if in0 == nil || in1 == nil {
+		t.Fatal("both inputs should be mounted")
+	}
+
+	// Tab focuses the first input: 'a' lands there only.
+	app.Dispatch(KeyEvent{Key: KeyTab})
+	app.Render()
+	app.Dispatch(KeyEvent{Key: KeyRune, Rune: 'a'})
+	if in0.text.Get() != "a" || in1.text.Get() != "" {
+		t.Fatalf("after Tab to input 0: in0=%q in1=%q, want in0=\"a\" in1=\"\"", in0.text.Get(), in1.text.Get())
+	}
+
+	// Tab moves focus to the second input: 'b' lands there, input 0 is untouched.
+	app.Dispatch(KeyEvent{Key: KeyTab})
+	app.Render()
+	app.Dispatch(KeyEvent{Key: KeyRune, Rune: 'b'})
+	if in1.text.Get() != "b" || in0.text.Get() != "a" {
+		t.Fatalf("after Tab to input 1: in0=%q in1=%q, want in0=\"a\" in1=\"b\"", in0.text.Get(), in1.text.Get())
+	}
+}

--- a/grapheme.go
+++ b/grapheme.go
@@ -324,3 +324,52 @@ func runeIndexToDisplayCol(s string, runeIdx int) int {
 	}
 	return col
 }
+
+// runeIndexToClusterIndex returns the grapheme-cluster index for a rune index in
+// s: the number of whole clusters that start strictly before runeIdx. A runeIdx
+// inside a multi-rune cluster reports that cluster (the marks join the base), so
+// the result counts clusters wholly preceding the position. Walks incrementally
+// and stops at the target, making it O(runeIdx).
+func runeIndexToClusterIndex(s string, runeIdx int) int {
+	if runeIdx <= 0 {
+		return 0
+	}
+	clusters := 0
+	runeAt := 0
+	for len(s) > 0 {
+		_, _, size := nextCluster(s)
+		if size == 0 {
+			break
+		}
+		clusterRunes := utf8.RuneCountInString(s[:size])
+		if runeAt+clusterRunes > runeIdx {
+			// runeIdx is at or inside this cluster: it does not advance past it.
+			break
+		}
+		clusters++
+		runeAt += clusterRunes
+		s = s[size:]
+	}
+	return clusters
+}
+
+// clusterIndexToRuneIndex returns the rune index at the start of the cluster at
+// the given cluster index. A cluster index past the end clamps to the total rune
+// count. Walks incrementally and stops at the target, making it O(clusterIdx).
+func clusterIndexToRuneIndex(s string, clusterIdx int) int {
+	runeAt := 0
+	clusters := 0
+	for len(s) > 0 {
+		if clusters == clusterIdx {
+			return runeAt
+		}
+		_, _, size := nextCluster(s)
+		if size == 0 {
+			break
+		}
+		runeAt += utf8.RuneCountInString(s[:size])
+		clusters++
+		s = s[size:]
+	}
+	return runeAt
+}

--- a/input.go
+++ b/input.go
@@ -94,6 +94,62 @@ func (inp *Input) Clear() {
 	inp.scrollPos.Set(0)
 }
 
+// CursorPos returns the cursor position as a grapheme-cluster index: the count
+// of whole glyphs before the cursor. This is the unit SetCursorPos accepts; it
+// is not a byte or rune offset, so do not use it to slice the text directly.
+func (inp *Input) CursorPos() int {
+	return runeIndexToClusterIndex(inp.text.Get(), inp.clampCursorPos())
+}
+
+// SetCursorPos moves the cursor to the given grapheme-cluster index. The index
+// is clamped to [0, ClusterCount(text)] and always lands on a cluster boundary.
+func (inp *Input) SetCursorPos(pos int) {
+	text := inp.text.Get()
+	if pos < 0 {
+		pos = 0
+	}
+	inp.cursorPos.Set(clusterIndexToRuneIndex(text, pos))
+	inp.blink.Set(true)
+	inp.ensureCursorVisible()
+}
+
+// InsertText inserts s at the cursor and advances the cursor past it. Insertion
+// routes through the same internal path that typing uses, so the bound text and
+// the cursor stay cluster-consistent (combining marks join the preceding base,
+// and the cursor lands after the final whole cluster).
+func (inp *Input) InsertText(s string) {
+	inp.insertString(s)
+}
+
+// insertString splices s into the text at the cursor's rune index and advances
+// the cursor to the end of the inserted content, snapped to a cluster boundary
+// via clusterEnd. This is the single insert path shared by insertChar and
+// InsertText; it keeps scroll and onChange consistent.
+func (inp *Input) insertString(s string) {
+	if s == "" {
+		return
+	}
+	text := inp.text.Get()
+	pos := inp.clampCursorPos()
+	runes := []rune(text)
+	insert := []rune(s)
+	newRunes := make([]rune, 0, len(runes)+len(insert))
+	newRunes = append(newRunes, runes[:pos]...)
+	newRunes = append(newRunes, insert...)
+	newRunes = append(newRunes, runes[pos:]...)
+	newText := string(newRunes)
+
+	inp.text.Set(newText)
+	// Advance to the end of the cluster that contains the last inserted rune so
+	// a trailing combining mark glues to its base and the cursor lands after it.
+	inp.cursorPos.Set(clusterEnd(newText, pos+len(insert)-1))
+	inp.blink.Set(true)
+	inp.ensureCursorVisible()
+	if inp.onChange != nil {
+		inp.onChange(inp.text.Get())
+	}
+}
+
 // --- Component Interface ---
 
 // visibleWidth returns the number of characters visible inside the input.
@@ -277,24 +333,7 @@ func (inp *Input) Watchers() []Watcher {
 // so combining marks join the previous base and the cursor lands after
 // the combined cluster.
 func (inp *Input) insertChar(ke KeyEvent) {
-	text := inp.text.Get()
-	pos := inp.clampCursorPos()
-
-	// Insert the rune into the string at the rune index.
-	runes := []rune(text)
-	newRunes := make([]rune, 0, len(runes)+1)
-	newRunes = append(newRunes, runes[:pos]...)
-	newRunes = append(newRunes, ke.Rune)
-	newRunes = append(newRunes, runes[pos:]...)
-	newText := string(newRunes)
-
-	inp.text.Set(newText)
-	inp.cursorPos.Set(clusterEnd(newText, pos))
-	inp.blink.Set(true)
-	inp.ensureCursorVisible()
-	if inp.onChange != nil {
-		inp.onChange(inp.text.Get())
-	}
+	inp.insertString(string(ke.Rune))
 }
 
 // backspace deletes the character before the cursor.

--- a/input.go
+++ b/input.go
@@ -10,18 +10,19 @@ import (
 // It implements Component, KeyListener, WatcherProvider, and Focusable interfaces.
 type Input struct {
 	// Configuration (set via options, immutable after construction)
-	width            int
-	border           BorderStyle
-	textStyle        Style
-	placeholder      string
-	placeholderStyle Style
-	cursorRune       rune
-	focusColor       *Color
-	borderGradient   *Gradient
-	focusGradient    *Gradient
-	autoFocus        bool
-	onSubmit         func(string)
-	onChange         func(string)
+	width             int
+	border            BorderStyle
+	textStyle         Style
+	placeholder       string
+	placeholderStyle  Style
+	cursorRune        rune
+	hideVirtualCursor bool
+	focusColor        *Color
+	borderGradient    *Gradient
+	focusGradient     *Gradient
+	autoFocus         bool
+	onSubmit          func(string)
+	onChange          func(string)
 
 	// Reactive state
 	text      *State[string]
@@ -59,6 +60,9 @@ func NewInput(opts ...InputOption) *Input {
 		placeholder:      "",
 		placeholderStyle: Style{}.Dim(),
 		cursorRune:       '▌',
+		// Real terminal cursor is the default; the drawn glyph is opt-in via
+		// WithInputVirtualCursor.
+		hideVirtualCursor: true,
 
 		// State
 		text:      NewState(""),
@@ -230,6 +234,11 @@ func (inp *Input) Render(app *App) *Element {
 	root.SetOnBlur(func(e *Element) {
 		inp.Blur()
 	})
+
+	// Drive the real terminal cursor unless the drawn glyph is opted in.
+	if inp.hideVirtualCursor {
+		root.SetCursorSource(inp.cursorColRow)
+	}
 
 	// Render placeholder or content
 	if inp.text.Get() == "" && inp.placeholder != "" && !inp.focused.Get() {
@@ -474,6 +483,27 @@ func textToClusters(s string) (clusters []displayCluster, totalWidth int) {
 	return
 }
 
+// cursorColRow returns the cursor's content-local position (display column, row)
+// within the input's content area and whether it is visible. It shares the
+// horizontal-scroll model with the drawn-glyph path: the column is the cursor's
+// display column minus scrollPos (ensureCursorVisible keeps it in the window).
+// A cursor scrolled outside the visible width reports visible=false. The row is
+// always 0 (single-line). Visibility also requires focus.
+func (inp *Input) cursorColRow() (col, row int, visible bool) {
+	if !inp.focused.Get() {
+		return 0, 0, false
+	}
+	inp.ensureCursorVisible()
+	text := inp.text.Get()
+	cursorCol := runeIndexToDisplayCol(text, inp.clampCursorPos())
+	col = cursorCol - max(inp.scrollPos.Get(), 0)
+	vw := inp.visibleWidth()
+	if col < 0 || (vw > 0 && col >= vw) {
+		return 0, 0, false
+	}
+	return col, 0, true
+}
+
 // displayText returns a viewport-clamped slice of the text with cursor overlay.
 func (inp *Input) displayText() string {
 	text := inp.text.Get()
@@ -490,6 +520,13 @@ func (inp *Input) displayText() string {
 		// In the unfocused path, scroll adjustment preserves the previously-set
 		// scroll position. ensureCursorVisible is only called in the focused path
 		// so that manually-scrolled text doesn't jump when the user blurs.
+		return inp.viewportText(allClusters, visible)
+	}
+
+	// Real-cursor mode: keep the cursor in view but draw no glyph. The framework
+	// places the hardware cursor via the content-local cursor source.
+	if inp.hideVirtualCursor {
+		inp.ensureCursorVisible()
 		return inp.viewportText(allClusters, visible)
 	}
 

--- a/input.go
+++ b/input.go
@@ -484,16 +484,16 @@ func textToClusters(s string) (clusters []displayCluster, totalWidth int) {
 }
 
 // cursorColRow returns the cursor's content-local position (display column, row)
-// within the input's content area and whether it is visible. It shares the
-// horizontal-scroll model with the drawn-glyph path: the column is the cursor's
-// display column minus scrollPos (ensureCursorVisible keeps it in the window).
-// A cursor scrolled outside the visible width reports visible=false. The row is
-// always 0 (single-line). Visibility also requires focus.
+// within the input's content area and whether it is visible. It is a pure read:
+// the column is the cursor's display column minus scrollPos, which is already
+// kept synced by every mutating key handler and by displayText on the render
+// path (which runs before placeCursor calls this source). A cursor scrolled
+// outside the visible width reports visible=false. The row is always 0
+// (single-line). Visibility also requires focus.
 func (inp *Input) cursorColRow() (col, row int, visible bool) {
 	if !inp.focused.Get() {
 		return 0, 0, false
 	}
-	inp.ensureCursorVisible()
 	text := inp.text.Get()
 	cursorCol := runeIndexToDisplayCol(text, inp.clampCursorPos())
 	col = cursorCol - max(inp.scrollPos.Get(), 0)

--- a/input_options.go
+++ b/input_options.go
@@ -38,10 +38,30 @@ func WithInputPlaceholderStyle(s Style) InputOption {
 	}
 }
 
-// WithInputCursor sets the cursor character (defaults to '▌').
-func WithInputCursor(r rune) InputOption {
+// WithInputCursorRune sets the drawn cursor glyph used in virtual-cursor mode
+// (defaults to '▌'). Only takes effect together with WithInputVirtualCursor; the
+// default real-cursor mode draws no glyph.
+func WithInputCursorRune(r rune) InputOption {
 	return func(inp *Input) {
 		inp.cursorRune = r
+	}
+}
+
+// WithInputCursor sets the drawn cursor glyph.
+//
+// Deprecated: use WithInputCursorRune. Retained as an alias so existing call
+// sites keep compiling.
+func WithInputCursor(r rune) InputOption {
+	return WithInputCursorRune(r)
+}
+
+// WithInputVirtualCursor switches the input to the drawn '▌' cursor glyph
+// instead of the framework-driven real terminal cursor. Presence enables it; the
+// glyph is customizable via WithInputCursorRune. By default (option absent) the
+// real terminal cursor is used and no glyph is drawn.
+func WithInputVirtualCursor() InputOption {
+	return func(inp *Input) {
+		inp.hideVirtualCursor = false
 	}
 }
 

--- a/input_options_test.go
+++ b/input_options_test.go
@@ -56,11 +56,27 @@ func TestInputOptions_ConfigureFields(t *testing.T) {
 				}
 			},
 		},
-		"WithInputCursor sets cursor rune": {
-			opt: WithInputCursor('_'),
+		"WithInputCursorRune sets cursor rune": {
+			opt: WithInputCursorRune('_'),
 			check: func(t *testing.T, inp *Input) {
 				if inp.cursorRune != '_' {
 					t.Errorf("cursorRune = %q, want '_'", inp.cursorRune)
+				}
+			},
+		},
+		"WithInputCursor alias sets cursor rune": {
+			opt: WithInputCursor('#'),
+			check: func(t *testing.T, inp *Input) {
+				if inp.cursorRune != '#' {
+					t.Errorf("cursorRune = %q, want '#'", inp.cursorRune)
+				}
+			},
+		},
+		"WithInputVirtualCursor enables drawn glyph": {
+			opt: WithInputVirtualCursor(),
+			check: func(t *testing.T, inp *Input) {
+				if inp.hideVirtualCursor {
+					t.Error("expected hideVirtualCursor to be false after WithInputVirtualCursor()")
 				}
 			},
 		},

--- a/input_test.go
+++ b/input_test.go
@@ -674,7 +674,9 @@ func TestInput_DisplayText(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			inp := newTestInput(WithInputWidth(tt.width))
+			// displayText draws the cursor glyph only in virtual-cursor mode; the
+			// real-cursor default draws no glyph in the text.
+			inp := newTestInput(WithInputWidth(tt.width), WithInputVirtualCursor())
 			inp.text.Set(tt.text)
 			inp.cursorPos.Set(tt.cursorPos)
 			inp.scrollPos.Set(tt.scrollPos)
@@ -704,9 +706,11 @@ func TestInput_Render_ContentAndPlaceholder(t *testing.T) {
 			wantStyle: Style{}.Dim(),
 		},
 		"placeholder hidden when focused": {
+			// Real-cursor default draws no glyph: focused empty input renders a
+			// bare space, and the placeholder is hidden.
 			opts:      []InputOption{WithInputPlaceholder("type here")},
 			focused:   true,
-			wantChild: "▌",
+			wantChild: " ",
 		},
 		"text shown instead of placeholder": {
 			opts:      []InputOption{WithInputPlaceholder("type here")},
@@ -885,7 +889,9 @@ func TestInput_Render_Output(t *testing.T) {
 			wantSubstr: "hi",
 		},
 		"focused input renders cursor": {
-			opts:       []InputOption{WithInputWidth(10)},
+			// Assert the drawn glyph: opt into virtual-cursor mode since the real
+			// terminal cursor is the default and draws no glyph.
+			opts:       []InputOption{WithInputWidth(10), WithInputVirtualCursor()},
 			text:       "ab",
 			focus:      true,
 			width:      10,

--- a/textarea.go
+++ b/textarea.go
@@ -93,6 +93,56 @@ func (t *TextArea) Clear() {
 	t.cursorPos.Set(0)
 }
 
+// CursorPos returns the cursor position as a grapheme-cluster index: the count
+// of whole glyphs before the cursor. This is the unit SetCursorPos accepts; it
+// is not a byte or rune offset, so do not use it to slice the text directly.
+func (t *TextArea) CursorPos() int {
+	return runeIndexToClusterIndex(t.text.Get(), t.clampCursorPos())
+}
+
+// SetCursorPos moves the cursor to the given grapheme-cluster index. The index
+// is clamped to [0, ClusterCount(text)] and always lands on a cluster boundary.
+func (t *TextArea) SetCursorPos(pos int) {
+	text := t.text.Get()
+	if pos < 0 {
+		pos = 0
+	}
+	t.cursorPos.Set(clusterIndexToRuneIndex(text, pos))
+	t.blink.Set(true)
+}
+
+// InsertText inserts s at the cursor and advances the cursor past it. Insertion
+// routes through the same internal path that typing uses, so the bound text and
+// the cursor stay cluster-consistent (combining marks join the preceding base,
+// and the cursor lands after the final whole cluster).
+func (t *TextArea) InsertText(s string) {
+	t.insertString(s)
+}
+
+// insertString splices s into the text at the cursor's rune index and advances
+// the cursor to the end of the inserted content, snapped to a cluster boundary
+// via clusterEnd. This is the single insert path shared by insertChar,
+// insertNewline, and InsertText.
+func (t *TextArea) insertString(s string) {
+	if s == "" {
+		return
+	}
+	text := t.text.Get()
+	pos := t.clampCursorPos()
+	runes := []rune(text)
+	insert := []rune(s)
+	newRunes := make([]rune, 0, len(runes)+len(insert))
+	newRunes = append(newRunes, runes[:pos]...)
+	newRunes = append(newRunes, insert...)
+	newRunes = append(newRunes, runes[pos:]...)
+	newText := string(newRunes)
+	t.text.Set(newText)
+	// Advance to the end of the cluster that contains the last inserted rune so
+	// a trailing combining mark glues to its base and the cursor lands after it.
+	t.cursorPos.Set(clusterEnd(newText, pos+len(insert)-1))
+	t.blink.Set(true)
+}
+
 // contentRows returns the number of content rows to render: the wrapped
 // lines plus the phantom cursor row, clamped to maxHeight. Note that when
 // content exceeds maxHeight the rows below the clamp (including the cursor's
@@ -287,24 +337,12 @@ func (t *TextArea) Watchers() []Watcher {
 // so combining marks join the previous base and the cursor lands after
 // the combined cluster.
 func (t *TextArea) insertChar(ke KeyEvent) {
-	text := t.text.Get()
-	pos := t.clampCursorPos()
-	runes := []rune(text)
-	newRunes := append(runes[:pos], append([]rune{ke.Rune}, runes[pos:]...)...)
-	newText := string(newRunes)
-	t.text.Set(newText)
-	t.cursorPos.Set(clusterEnd(newText, pos))
-	t.blink.Set(true)
+	t.insertString(string(ke.Rune))
 }
 
 // insertNewline inserts a newline character at the cursor position.
 func (t *TextArea) insertNewline(ke KeyEvent) {
-	runes := []rune(t.text.Get())
-	pos := t.clampCursorPos()
-	newRunes := append(runes[:pos], append([]rune{'\n'}, runes[pos:]...)...)
-	t.text.Set(string(newRunes))
-	t.cursorPos.Set(pos + 1)
-	t.blink.Set(true)
+	t.insertString("\n")
 }
 
 // backspace deletes the cluster before the cursor.

--- a/textarea.go
+++ b/textarea.go
@@ -60,7 +60,10 @@ func NewTextArea(opts ...TextAreaOption) *TextArea {
 		placeholder:      "",
 		placeholderStyle: Style{}.Dim(),
 		cursorRune:       '▌',
-		submitKey:        KeyEnter,
+		// Real terminal cursor is the default; the drawn glyph is opt-in via
+		// WithTextAreaVirtualCursor.
+		hideVirtualCursor: true,
+		submitKey:         KeyEnter,
 
 		// State
 		text:      NewState(""),
@@ -211,6 +214,11 @@ func (t *TextArea) Render(app *App) *Element {
 	root.SetOnBlur(func(e *Element) {
 		t.Blur()
 	})
+
+	// Drive the real terminal cursor unless the drawn glyph is opted in.
+	if t.hideVirtualCursor {
+		root.SetCursorSource(t.cursorColRow)
+	}
 
 	// Render placeholder or content
 	if t.text.Get() == "" && t.placeholder != "" && !t.focused.Get() {
@@ -639,11 +647,40 @@ func (t *TextArea) posFromRowCol(lines []string, targetRow, targetCol int) int {
 // wrapped line (end of text on a display-full line), which needs an extra
 // rendered row to host the cursor.
 func (t *TextArea) phantomCursorRow(lines []string) bool {
-	if !t.focused.Get() || t.hideVirtualCursor {
+	if !t.focused.Get() {
 		return false
 	}
 	row, _ := t.cursorRowCol(lines)
 	return row >= len(lines)
+}
+
+// cursorColRow returns the cursor's content-local position (display column, row)
+// within the textarea's content area and whether it is visible. It shares the
+// row/column computation (cursorRowCol) with the drawn-glyph path in
+// lineWithCursor; the display column is the width of the line prefix up to the
+// cursor's rune column, so wide clusters before the cursor advance it correctly.
+// The textarea has no internal horizontal scroll; vertical scroll, if any, is
+// owned by an enclosing scrollable element and applied by Element.ReportCursor.
+func (t *TextArea) cursorColRow() (col, row int, visible bool) {
+	if !t.focused.Get() {
+		return 0, 0, false
+	}
+	lines := t.wrapText()
+	r, runeCol := t.cursorRowCol(lines)
+
+	// On the phantom row past the last wrapped line the cursor sits at column 0.
+	if r >= len(lines) {
+		return 0, r, true
+	}
+
+	// Convert the rune column within the line to a display column.
+	line := lines[r]
+	runes := []rune(line)
+	if runeCol > len(runes) {
+		runeCol = len(runes)
+	}
+	col = stringWidth(string(runes[:runeCol]))
+	return col, r, true
 }
 
 // lineWithCursor returns a line with the cursor character inserted.

--- a/textarea_options.go
+++ b/textarea_options.go
@@ -49,19 +49,30 @@ func WithTextAreaPlaceholderStyle(s Style) TextAreaOption {
 	}
 }
 
-// WithTextAreaCursor sets the cursor character (defaults to '▌').
-func WithTextAreaCursor(r rune) TextAreaOption {
+// WithTextAreaCursorRune sets the drawn cursor glyph used in virtual-cursor
+// mode (defaults to '▌'). Only takes effect together with
+// WithTextAreaVirtualCursor; the default real-cursor mode draws no glyph.
+func WithTextAreaCursorRune(r rune) TextAreaOption {
 	return func(t *TextArea) {
 		t.cursorRune = r
 	}
 }
 
-// WithTextAreaVirtualCursor controls whether the virtual cursor character
-// is drawn in the text. When false, lineWithCursor returns the line unchanged
-// and applications can position the terminal's hardware cursor instead.
-func WithTextAreaVirtualCursor(visible bool) TextAreaOption {
+// WithTextAreaCursor sets the drawn cursor glyph.
+//
+// Deprecated: use WithTextAreaCursorRune. Retained as an alias so existing call
+// sites keep compiling.
+func WithTextAreaCursor(r rune) TextAreaOption {
+	return WithTextAreaCursorRune(r)
+}
+
+// WithTextAreaVirtualCursor switches the text area to the drawn '▌' cursor glyph
+// instead of the framework-driven real terminal cursor. Presence enables it; the
+// glyph is customizable via WithTextAreaCursorRune. By default (option absent)
+// the real terminal cursor is used and no glyph is drawn.
+func WithTextAreaVirtualCursor() TextAreaOption {
 	return func(t *TextArea) {
-		t.hideVirtualCursor = !visible
+		t.hideVirtualCursor = false
 	}
 }
 

--- a/textarea_options_test.go
+++ b/textarea_options_test.go
@@ -43,8 +43,8 @@ func TestTextAreaOptions(t *testing.T) {
 				if ta.submitKey != KeyEnter {
 					t.Fatalf("submitKey = %v, want KeyEnter", ta.submitKey)
 				}
-				if ta.hideVirtualCursor {
-					t.Fatal("hideVirtualCursor should default to false")
+				if !ta.hideVirtualCursor {
+					t.Fatal("hideVirtualCursor should default to true (real cursor is the default)")
 				}
 				if ta.autoFocus {
 					t.Fatal("autoFocus should default to false")
@@ -111,27 +111,27 @@ func TestTextAreaOptions(t *testing.T) {
 				}
 			},
 		},
-		"WithTextAreaCursor sets cursor rune": {
-			opts: []TextAreaOption{WithTextAreaCursor('_')},
+		"WithTextAreaCursorRune sets cursor rune": {
+			opts: []TextAreaOption{WithTextAreaCursorRune('_')},
 			assert: func(t *testing.T, ta *TextArea) {
 				if ta.cursorRune != '_' {
 					t.Fatalf("cursorRune = %q, want '_'", ta.cursorRune)
 				}
 			},
 		},
-		"WithTextAreaVirtualCursor false hides virtual cursor": {
-			opts: []TextAreaOption{WithTextAreaVirtualCursor(false)},
+		"WithTextAreaCursor alias sets cursor rune": {
+			opts: []TextAreaOption{WithTextAreaCursor('#')},
 			assert: func(t *testing.T, ta *TextArea) {
-				if !ta.hideVirtualCursor {
-					t.Fatal("expected hideVirtualCursor to be true")
+				if ta.cursorRune != '#' {
+					t.Fatalf("cursorRune = %q, want '#'", ta.cursorRune)
 				}
 			},
 		},
-		"WithTextAreaVirtualCursor true keeps virtual cursor": {
-			opts: []TextAreaOption{WithTextAreaVirtualCursor(true)},
+		"WithTextAreaVirtualCursor enables drawn glyph": {
+			opts: []TextAreaOption{WithTextAreaVirtualCursor()},
 			assert: func(t *testing.T, ta *TextArea) {
 				if ta.hideVirtualCursor {
-					t.Fatal("expected hideVirtualCursor to be false")
+					t.Fatal("expected hideVirtualCursor to be false after WithTextAreaVirtualCursor()")
 				}
 			},
 		},

--- a/textarea_test.go
+++ b/textarea_test.go
@@ -352,7 +352,9 @@ func TestTextArea_CursorVisibleAtWrapBoundary(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ta := NewTextArea(WithTextAreaWidth(tt.width))
+			// Assert on the drawn glyph: opt into virtual-cursor mode since the
+			// real terminal cursor is the default and draws no glyph.
+			ta := NewTextArea(WithTextAreaWidth(tt.width), WithTextAreaVirtualCursor())
 			ta.BindApp(testApp)
 			ta.SetText(tt.text)
 			ta.Focus()
@@ -399,9 +401,9 @@ func TestTextArea_HideVirtualCursor(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ta := NewTextArea(
-				WithTextAreaVirtualCursor(false),
-			)
+			// The default real-cursor mode draws no glyph, so lineWithCursor
+			// returns the line unchanged (this is what the option used to force).
+			ta := NewTextArea()
 			ta.BindApp(testApp)
 			ta.SetText(tt.text)
 			ta.Focus()
@@ -419,7 +421,8 @@ func TestTextArea_HideVirtualCursor(t *testing.T) {
 }
 
 func TestTextArea_BlockCursor_AtHardNewline_DoesNotSplitCluster(t *testing.T) {
-	ta := NewTextArea(WithTextAreaWidth(4))
+	// Block-cursor overlay only exists in virtual-cursor mode.
+	ta := NewTextArea(WithTextAreaWidth(4), WithTextAreaVirtualCursor())
 	ta.BindApp(testApp)
 	ta.Focus()
 	ta.SetText("ab\U0001F1FA\U0001F1F8\n")


### PR DESCRIPTION
## Summary

Adds the public API needed to build a real text-input UI without reaching into framework internals. The motivating consumer app had to use `reflect`/`unsafe` to insert text at the cursor, place the real terminal cursor, and resize a panel. Three independent additions, built on `main` after #103.

## What's included

**Editing API (`TextArea` + `Input`)**
- `CursorPos() int`, `SetCursorPos(int)`, `InsertText(string)`, all in grapheme-cluster indices (the count of whole glyphs before the cursor), translated to and from the internal rune index. `InsertText` routes through the same path as typing, so the bound `State[string]` and the cursor stay consistent.

**Element resize setters**
- `Element.SetHeight(Value)` / `Element.SetWidth(Value)`, each calling `MarkDirty()` so layout recomputes. Intended for elements retained across renders.

**Framework-driven real terminal cursor**
- New `CursorReporter` element capability; the App positions the hardware cursor at the focused widget at the end of the frame (after Flush), with an inline-mode row offset. The real cursor is now the default presentation for text widgets; the drawn glyph is opt-in.

## API and behavior changes (heads-up)

- The real terminal cursor is the default for `TextArea`/`Input`; the drawn `▌` glyph is opt-in via `WithTextAreaVirtualCursor()` / `WithInputVirtualCursor()` (presence-based).
- `WithTextAreaVirtualCursor` changed from a `bool` parameter to presence-based. The cursor-rune setter is now `WithTextAreaCursorRune(r)` / `WithInputCursorRune(r)`; the old `WithTextAreaCursor(r)` is kept as a deprecated alias.
- `WithCursor()` is a deprecated no-op; `WithManualCursor()` disables framework cursor management for callers who drive the cursor themselves.
- Docs now point to `StringWidth` for string and cursor width math; `RuneWidth` remains public but is low-level per-rune.

Typed `feat:` (not `feat!:`) to stay on the pre-1.0 minor track, consistent with #103. The items above are the breaking surface to call out in release notes.

## Known limitations (tracked as follow-ups)

- Cursor placement mirrors the renderer for zero or one scrollable ancestor. A text widget nested inside two or more scrollables can be mis-placed, because the renderer applies only the outermost scrollable's transform while `ReportCursor` currently applies each. Rare in practice.
- When a vertical scrollbar is visible, the cursor's right-edge clip is off by the one-column scrollbar gutter (cosmetic).
