### PR TITLE
feat(editor): nest generated _gsx.go files under .gsx sources in VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ vendor/
 
 # IDE/Editor
 .idea/
-.vscode/
+.vscode/*
+# Track shared project settings (file nesting for generated *_gsx.go), ignore personal cruft
+!.vscode/settings.json
 *.swp
 *.swo
 *~

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  // Nest generated `_gsx.go` files under their `.gsx` source in the Explorer.
+  // The go-tui VS Code extension contributes the pattern; this flips on the
+  // (workspace-wide) master switch and repeats the pattern so nesting works
+  // even when the extension isn't installed.
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.gsx": "${capture}_gsx.go"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,12 +112,12 @@ Use this section to quickly find the right files for a given change.
 ### Changing the public API (Element options, App config, types)
 
 - `element.go` — Element struct definition, TextAlign/ScrollMode/OverflowMode enums
-- `element_options.go` — Option funcs: WithWidth, WithHeight, WithFlexGrow, WithDirection, WithBorder, WithScrollable, WithTruncate, WithHidden, WithOverflow, WithTextGradient, WithBackgroundGradient, WithBorderGradient, etc.
+- `element_options.go` — Option funcs: WithWidth, WithHeight, WithFlexGrow, WithDirection, WithBorder, WithScrollable, WithTruncate, WithHidden, WithOverflow, WithTextGradient, WithBackgroundGradient, WithBorderGradient, WithBorderTitleAlign, WithBorderTitleStyle, WithFocusBorderStyle, WithCursorSource, etc.
 - `element_options_auto.go` — WithWidthAuto(), WithHeightAuto()
-- `element_accessors.go` — Getters/setters: SetText, SetBorder, SetStyle, Background, etc.
+- `element_accessors.go` — Getters/setters: SetText, SetBorder, SetStyle, Background, SetWidth, SetHeight, SetBorderTitleAlign, SetBorderTitleStyle, SetFocusBorderStyle, etc.
 - `element_tree.go` — Tree manipulation: AddChild, RemoveChild, RemoveAllChildren
 - `element_scroll.go` — Scroll methods: ScrollTo, ScrollOffset, MaxScroll, ViewportSize
-- `app_options.go` — AppOption funcs: WithFrameRate, WithMouseEnabled, WithInlineHeight, WithGlobalKeyHandler, WithInputLatency, WithEventQueueSize, etc.
+- `app_options.go` — AppOption funcs: WithFrameRate, WithMouseEnabled, WithInlineHeight, WithGlobalKeyHandler, WithInputLatency, WithEventQueueSize, WithPreRenderHook, WithPostRenderHook, WithManualCursor, etc.
 - `layout.go` — Re-exports from internal/layout (Direction, Justify, Align, Value, etc.)
 - `color.go` — Color type, ANSIColor(), RGBColor(), HexColor(), Gradient, GradientDirection
 - `style.go` — Style type with chainable methods (Bold, Dim, Italic, Foreground, etc.)

--- a/docs/content/llm.md
+++ b/docs/content/llm.md
@@ -573,6 +573,9 @@ tui.WithInlineHeight(rows int)           // Inline mode (not fullscreen)
 tui.WithGlobalKeyHandler(func(KeyEvent) bool)  // Global key intercept
 tui.WithInputLatency(d time.Duration)    // Coalesce rapid input
 tui.WithEventQueueSize(n int)            // Event queue buffer size
+tui.WithPreRenderHook(func())            // Runs at the start of each render cycle
+tui.WithPostRenderHook(func())           // Runs after each render cycle
+tui.WithManualCursor()                   // Disable framework-driven cursor placement
 ```
 
 ## App Methods
@@ -806,7 +809,38 @@ el := tui.New(
     tui.WithTextGradient(tui.NewGradient(tui.Cyan, tui.Magenta)),
     tui.WithBackgroundGradient(tui.NewGradient(tui.Blue, tui.Cyan)),
     tui.WithBorderGradient(tui.NewGradient(tui.Cyan, tui.Magenta)),
+    tui.WithBorderTitle(" Title "),
+    tui.WithBorderTitleAlign(tui.TextAlignLeft),
+    tui.WithBorderTitleStyle(tui.NewStyle().Bold()),
+    tui.WithFocusBorderStyle(tui.NewStyle().Foreground(tui.Magenta)),
+    tui.WithCursorSource(func() (col, row int, visible bool) { return 0, 0, true }),
 )
+```
+
+## Input / TextArea Runtime API
+
+Both `Input` and `TextArea` expose the same programmatic editing methods. Positions are grapheme-cluster indices (whole glyphs before the cursor), not byte or rune offsets.
+
+```go
+w.CursorPos() int          // cluster index of the cursor
+w.SetCursorPos(pos int)    // clamped to [0, ClusterCount(text)]
+w.InsertText(s string)     // insert at cursor, advance past it
+w.Text() string            // current text
+w.SetText(s string)        // replace text, cursor to end
+```
+
+Text widgets drive the real terminal cursor by default and draw no glyph. Opt into the painted `▌` with `WithInputVirtualCursor()` or `WithTextAreaVirtualCursor()`, or disable framework cursor placement app-wide with `tui.WithManualCursor()`.
+
+```go
+tui.WithInputOnChange(func(string))      // Input: fires on every text change
+tui.WithTextAreaOnChange(func(string))   // TextArea: fires on every text change
+```
+
+Resize a retained element between frames:
+
+```go
+el.SetWidth(tui.Fixed(40))   // or tui.Percent(50), tui.Auto()
+el.SetHeight(tui.Fixed(10))
 ```
 
 ## Cross-Component Communication

--- a/docs/content/reference/app.md
+++ b/docs/content/reference/app.md
@@ -178,6 +178,37 @@ func WithCursor() AppOption
 
 Keeps the cursor visible during app execution. By default, the cursor is hidden.
 
+### WithPreRenderHook
+
+```go
+func WithPreRenderHook(fn func()) AppOption
+```
+
+Sets a callback that runs at the start of every render cycle, after the buffer is cleared and before the component tree re-renders. Use it for state that must settle before the frame is drawn, such as syncing a layout value to the current terminal size.
+
+```go
+tui.WithPreRenderHook(func() {
+    w, _ := app.Size()
+    sidebar.SetWidth(tui.Fixed(w / 4))
+})
+```
+
+### WithPostRenderHook
+
+```go
+func WithPostRenderHook(fn func()) AppOption
+```
+
+Sets a callback that runs after every render cycle completes. Use it for work that should follow the frame, such as measurement or frame logging.
+
+### WithManualCursor
+
+```go
+func WithManualCursor() AppOption
+```
+
+Disables framework-driven cursor placement. By default the App moves the real terminal cursor to the focused widget's reported position at the end of each frame (see [Cursor Reporting](element.md#cursor-reporting)). Use this when your app positions the cursor itself or wants no cursor shown. This differs from `WithCursor`, which keeps the cursor visible but leaves placement to the framework.
+
 ### WithInlineHeight
 
 ```go

--- a/docs/content/reference/built-in-components.md
+++ b/docs/content/reference/built-in-components.md
@@ -38,7 +38,7 @@ Creates a new `Input` with the given options. Default values:
 | TextStyle   | `Style{}`    | Default terminal style                   |
 | Placeholder | `""`         | No placeholder text                      |
 | PlaceholderStyle | `Style{}.Dim()` | Dim text for placeholder          |
-| Cursor      | `'▌'`        | Block cursor character                   |
+| Cursor      | real cursor  | Framework places the terminal cursor; `WithInputVirtualCursor` draws `'▌'` instead |
 | FocusColor  | `Cyan`       | Border color when focused                |
 
 ### Reactive Value Binding
@@ -133,6 +133,23 @@ In `.gsx`:
 |-------------|-----------------------------------|
 | Enter       | Trigger `onSubmit` callback       |
 
+### Programmatic Editing
+
+Move the cursor and insert text from code, for example to seed a value or build an autocomplete.
+
+```go
+func (inp *Input) CursorPos() int
+func (inp *Input) SetCursorPos(pos int)
+func (inp *Input) InsertText(s string)
+```
+
+`CursorPos` returns the cursor position as a grapheme-cluster index, the count of whole glyphs before the cursor. That is the unit `SetCursorPos` accepts, so it is not a byte or rune offset and will not slice the text correctly if used that way. `SetCursorPos` clamps to `[0, ClusterCount(text)]` and lands on a cluster boundary. `InsertText` inserts at the cursor and advances past the inserted text, routing through the same path as typing so combining marks join the preceding glyph.
+
+```go
+inp.SetCursorPos(0)
+inp.InsertText("> ") // prefix the line, cursor ends after the prefix
+```
+
 ### InputOption Functions
 
 | Function | Description |
@@ -149,6 +166,10 @@ In `.gsx`:
 | `WithInputFocusGradient(Gradient)` | Border gradient when focused |
 | `WithInputOnSubmit(func(string))` | Enter key callback |
 | `WithInputOnChange(func(string))` | Text change callback |
+| `WithInputVirtualCursor()` | Draw the `▌` glyph instead of using the real terminal cursor |
+| `WithInputCursorRune(rune)` | Glyph used in virtual-cursor mode (default `▌`) |
+
+By default the Input drives the real terminal cursor and draws no glyph. Pass `WithInputVirtualCursor()` to paint the block glyph instead, and `WithInputCursorRune` to change it. `WithInputCursor` still works as a deprecated alias for `WithInputCursorRune`.
 
 ## TextArea
 
@@ -183,7 +204,7 @@ Creates a new `TextArea` with the given options. Default values:
 | TextStyle   | `Style{}`    | Default terminal style                   |
 | Placeholder | `""`         | No placeholder text                      |
 | PlaceholderStyle | `Style{}.Dim()` | Dim text for placeholder          |
-| Cursor      | `'▌'`        | Block cursor character                   |
+| Cursor      | real cursor  | Framework places the terminal cursor; `WithTextAreaVirtualCursor` draws `'▌'` instead |
 | FocusColor  | `Cyan`       | Border color when focused                |
 | SubmitKey   | `KeyEnter`   | Enter submits, Ctrl+J inserts newline    |
 
@@ -246,6 +267,20 @@ func (t *TextArea) Height() int
 ```
 
 Returns the total rendered height in rows, including border rows if a border is set. The height depends on the current text content and word wrapping. If `maxHeight` is set, the returned value is capped to that limit (plus border rows).
+
+#### Programmatic Editing
+
+```go
+func (t *TextArea) CursorPos() int
+func (t *TextArea) SetCursorPos(pos int)
+func (t *TextArea) InsertText(s string)
+```
+
+`CursorPos` returns the cursor position as a grapheme-cluster index (whole glyphs before the cursor), which is the unit `SetCursorPos` accepts. It is not a byte or rune offset. `SetCursorPos` clamps to `[0, ClusterCount(text)]` and lands on a cluster boundary. `InsertText` inserts at the cursor and advances past it, using the same path as typing so the bound text and cursor stay cluster-consistent.
+
+```go
+ta.InsertText("\n- ") // start a new bullet at the cursor
+```
 
 ### Focus Methods
 
@@ -323,9 +358,11 @@ Binds the TextArea's internal reactive states to the given `App`, so that state 
 
 When `submitKey` is set to something other than `KeyEnter`, the behavior flips: Enter inserts a newline and the configured key triggers submit.
 
-### Cursor Blink
+### Cursor
 
-`TextArea` implements `WatcherProvider` and returns a timer watcher that toggles the cursor visibility every 500ms while focused. The cursor resets to visible on every keystroke so the user always sees where they're typing.
+By default the TextArea drives the real terminal cursor and draws no glyph, so the terminal handles the blink. Pass `WithTextAreaVirtualCursor()` to paint the `▌` glyph in the buffer instead, and `WithTextAreaCursorRune` to change it.
+
+In virtual-cursor mode, `TextArea` implements `WatcherProvider` and returns a timer watcher that toggles the glyph every 500ms while focused. The glyph resets to visible on every keystroke so the user always sees where they are typing.
 
 ### TextAreaOption Functions
 
@@ -407,16 +444,19 @@ ta := tui.NewTextArea(
 )
 ```
 
-#### WithTextAreaCursor
+#### WithTextAreaCursorRune
 
 ```go
-func WithTextAreaCursor(r rune) TextAreaOption
+func WithTextAreaCursorRune(r rune) TextAreaOption
 ```
 
-Sets the cursor character. Default: `'▌'` (left half block).
+Sets the glyph drawn in virtual-cursor mode. Default: `'▌'` (left half block). It takes effect only with `WithTextAreaVirtualCursor`, since the default real-cursor mode draws no glyph. `WithTextAreaCursor` remains as a deprecated alias.
 
 ```go
-ta := tui.NewTextArea(tui.WithTextAreaCursor('█'))
+ta := tui.NewTextArea(
+    tui.WithTextAreaVirtualCursor(),
+    tui.WithTextAreaCursorRune('█'),
+)
 ```
 
 #### WithTextAreaSubmitKey
@@ -449,6 +489,24 @@ ta := tui.NewTextArea(
     }),
 )
 ```
+
+#### WithTextAreaOnChange
+
+```go
+func WithTextAreaOnChange(fn func(string)) TextAreaOption
+```
+
+Sets a callback invoked whenever the text content changes. The callback receives the full text after each change. It fires on user edits (typing, backspace, delete) and on programmatic changes through `SetText`, `Clear`, and `InsertText`. Use it to mirror the text elsewhere or to validate as the user types.
+
+```go
+ta := tui.NewTextArea(
+    tui.WithTextAreaOnChange(func(text string) {
+        charCount.Set(len(text))
+    }),
+)
+```
+
+This is a Go option. Unlike `<input onChange>`, the `<textarea>` tag does not yet expose `onChange` as an attribute, so set it through `WithTextAreaOnChange` when constructing the component.
 
 #### WithTextAreaValue
 
@@ -515,6 +573,14 @@ ta := tui.NewTextArea(
     tui.WithTextAreaFocusGradient(tui.NewGradient(tui.Cyan, tui.Magenta)),
 )
 ```
+
+#### WithTextAreaVirtualCursor
+
+```go
+func WithTextAreaVirtualCursor() TextAreaOption
+```
+
+Switches to the drawn `▌` glyph instead of the real terminal cursor. The glyph is customizable with `WithTextAreaCursorRune`.
 
 ### Example
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -142,6 +142,16 @@ Install the official go-tui extension, which bundles the LSP client, syntax high
 
 The extension automatically runs `tui lsp` for `.gsx` files. No manual configuration needed.
 
+The extension also registers a file nesting pattern so each generated `*_gsx.go` file collapses under its `.gsx` source in the Explorer. VS Code's file nesting is off by default, so enable it once to use it:
+
+```json
+{
+  "explorer.fileNesting.enabled": true
+}
+```
+
+Put that in a project's `.vscode/settings.json` to scope nesting to that project rather than every repository you open.
+
 ### Neovim
 
 With [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig), add a custom server configuration:

--- a/docs/content/reference/element.md
+++ b/docs/content/reference/element.md
@@ -151,6 +151,9 @@ tui.New(
 | `WithText(content string)` | Text content for this element |
 | `WithTextStyle(style Style)` | Text color and attributes. Setting this prevents style inheritance from the parent |
 | `WithTextAlign(align TextAlign)` | Text alignment: `TextAlignLeft` (default), `TextAlignCenter`, `TextAlignRight` |
+| `WithBorderTitleAlign(align TextAlign)` | Border title position: `TextAlignLeft`, `TextAlignCenter` (default), or `TextAlignRight` |
+| `WithBorderTitleStyle(style Style)` | Color and attributes for the border title text. Falls back to the active border style when unset |
+| `WithFocusBorderStyle(style Style)` | Border style applied while the element is focused. Falls back to `WithBorderStyle` when unset |
 
 ```go
 // Cyan-bordered box with bold white text on a blue background
@@ -162,6 +165,8 @@ tui.New(
     tui.WithTextStyle(tui.NewStyle().Bold().Foreground(tui.ANSIColor(tui.White))),
 )
 ```
+
+When `WithFocusBorderStyle` is set, the border switches to it while the element holds focus and returns to `WithBorderStyle` on blur. A title set with `WithBorderTitleStyle` follows the same focus-aware color unless you give the title its own style.
 
 ### Gradient
 
@@ -252,6 +257,22 @@ func (e *Element) SetStyle(style LayoutStyle)
 
 Read or replace the full layout style. `SetStyle` marks the element dirty.
 
+### Dimensions
+
+```go
+func (e *Element) SetWidth(v Value)
+func (e *Element) SetHeight(v Value)
+```
+
+Change an element's width or height after creation. Both mark the element and its ancestors dirty so layout recomputes on the next frame. Pass `tui.Fixed(n)`, `tui.Percent(p)`, or `tui.Auto()`.
+
+These apply to retained elements you hold across renders, such as a cached component's root. A setter on an element that the render rebuilds each frame has no lasting effect, since the next render recreates it from its options.
+
+```go
+// Grow a results dropdown to fit its matches, capped at 8 rows
+dropdown.SetHeight(tui.Fixed(min(len(matches), 8)))
+```
+
 ### Border
 
 ```go
@@ -261,9 +282,17 @@ func (e *Element) BorderStyle() Style
 func (e *Element) SetBorderStyle(style Style)
 func (e *Element) BorderTitle() string
 func (e *Element) SetBorderTitle(title string)
+func (e *Element) BorderTitleAlign() TextAlign
+func (e *Element) SetBorderTitleAlign(align TextAlign)
+func (e *Element) BorderTitleStyle() *Style
+func (e *Element) SetBorderTitleStyle(style *Style)
+func (e *Element) FocusBorderStyle() *Style
+func (e *Element) SetFocusBorderStyle(style *Style)
 ```
 
 `Border()` returns the border shape (`BorderSingle`, `BorderRounded`, etc.). `BorderStyle()` returns the color/attribute style used to draw the border lines. `BorderTitle()` returns the title text drawn in the top border, or `""` when no title is set.
+
+`BorderTitleAlign()` reports where the title sits on the top border, `TextAlignCenter` by default. `BorderTitleStyle()` and `FocusBorderStyle()` return `nil` when no override is set, so the title uses the active border style and the border keeps its base style while focused. Pass `nil` to either setter to clear the override.
 
 ### Background
 
@@ -591,6 +620,28 @@ func (e *Element) ElementAtPoint(x, y int) Focusable
 `ElementAt` finds the deepest element containing the given point. Children are checked in reverse order (last child renders on top, so it gets priority). Returns `nil` if no element contains the point.
 
 `ElementAtPoint` does the same thing but returns a `Focusable` interface to satisfy the internal mouse hit-testing contract.
+
+## Cursor Reporting
+
+The App drives the real terminal cursor. At the end of each frame it asks the focused element where the cursor belongs and moves the hardware cursor there, so the cursor blinks and behaves natively instead of being painted into the buffer.
+
+```go
+func WithCursorSource(fn func() (col, row int, visible bool)) Option
+func (e *Element) SetCursorSource(fn func() (col, row int, visible bool))
+func (e *Element) ReportCursor() (col, row int, visible bool)
+```
+
+An element reports its cursor by installing a source, either with `WithCursorSource` at creation or `SetCursorSource` afterward. The source returns the cursor position in display cells measured from the element's content origin, plus whether it is visible. The framework converts that to an absolute terminal cell, accounting for the scroll offset and any clipping ancestor.
+
+`Input` and `TextArea` install a source on their own, so a focused text widget places the real cursor with no extra wiring. To take over cursor placement yourself, or to suppress it, build the App with `WithManualCursor()` (see the [App Reference](app.md)).
+
+```go
+type CursorReporter interface {
+    ReportCursor() (col, row int, visible bool)
+}
+```
+
+`Element` implements `CursorReporter`. `ReportCursor` returns the absolute cell captured during the most recent render. It reports `visible == false` when no source is set, when the source reports invisible, or when the cursor was clipped out of view.
 
 ## Rendering
 

--- a/docs/content/reference/styling.md
+++ b/docs/content/reference/styling.md
@@ -449,15 +449,20 @@ chars := tui.BorderRounded.Chars()
 ```go
 func WithBorder(style BorderStyle) Option
 func WithBorderTitle(title string) Option
+func WithBorderTitleAlign(align TextAlign) Option
+func WithBorderTitleStyle(style Style) Option
+func WithFocusBorderStyle(style Style) Option
 ```
 
-`WithBorder` sets the border shape. `WithBorderTitle` draws a label centered in the top border line, styled to match the border and truncated when wider than the top edge:
+`WithBorder` sets the border shape. `WithBorderTitle` draws a label in the top border line, truncated when wider than the top edge. `WithBorderTitleAlign` moves the title to `TextAlignLeft`, `TextAlignCenter` (the default), or `TextAlignRight`. The title matches the border style unless `WithBorderTitleStyle` gives it its own color and attributes. `WithFocusBorderStyle` sets a border style used only while the element is focused, falling back to `WithBorderStyle` otherwise:
 
 ```go
 el := tui.New(
     tui.WithBorder(tui.BorderRounded),
     tui.WithBorderStyle(tui.NewStyle().Foreground(tui.ANSIColor(tui.Cyan))),
     tui.WithBorderTitle(" Status "),
+    tui.WithBorderTitleAlign(tui.TextAlignLeft),
+    tui.WithFocusBorderStyle(tui.NewStyle().Foreground(tui.ANSIColor(tui.Magenta))),
     tui.WithText("Bordered content"),
 )
 ```

--- a/editor/vscode/README.md
+++ b/editor/vscode/README.md
@@ -31,6 +31,8 @@ Syntax highlighting and language support for `.gsx` files used with the [go-tui]
   - Semantic token highlighting
   - Code formatting
 
+- **File Nesting**: Collapses each generated `*_gsx.go` file under its `.gsx` source in the Explorer (opt-in, see below)
+
 ## Installation
 
 ### From Source
@@ -119,6 +121,25 @@ templ (c *counter) Render() {
     </div>
 }
 ```
+
+## File Nesting
+
+Each `.gsx` file generates a sibling `*_gsx.go` file in the same directory (`header.gsx` produces `header_gsx.go`). The extension registers a VS Code [file nesting](https://code.visualstudio.com/docs/getstarted/userinterface#_file-nesting) pattern that tucks the generated file under its source, so the Explorer shows one entry per component instead of two.
+
+The pattern ships with the extension, but VS Code's file nesting is off by default. Turn it on once in your settings:
+
+```json
+{
+  "explorer.fileNesting.enabled": true
+}
+```
+
+To scope it to a single project, put that line in the project's `.vscode/settings.json` instead of your user settings. Adding the line there (rather than extension-wide) keeps file nesting from also reorganizing your non-gsx repositories.
+
+Notes:
+
+- This is VS Code only. Other editors have their own nesting mechanisms.
+- Source files with hyphens do not nest: the generator rewrites `my-app.gsx` to `my_app_gsx.go`, which the file nesting glob cannot match. Dot and underscore names nest normally.
 
 ## Supported Constructs
 

--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -84,6 +84,9 @@
         "rules": {
           "typeParameter:gsx": "#C586C0"
         }
+      },
+      "explorer.fileNesting.patterns": {
+        "*.gsx": "${capture}_gsx.go"
       }
     }
   },


### PR DESCRIPTION
## Summary

Hides generated `*_gsx.go` files in the VS Code Explorer by nesting each one under its `.gsx` source, using VS Code's built-in file nesting. This is the editor-side approach that came out of the discussion on #105 (an `-o`/`--output` flag was rejected because the generator and LSP rely on generated code being co-located with its source).

## How it works

- The extension contributes an `explorer.fileNesting.patterns` default (`*.gsx` -> `${capture}_gsx.go`) via the existing `configurationDefaults` block in `package.json`.
- It deliberately does **not** force `explorer.fileNesting.enabled`. That switch is workspace-wide, so forcing it would reorganize every repository the user opens, not just gsx ones. Users opt in with a single setting. This mirrors how the Ionide (F#) extension ships its nesting patterns.
- A repo-level `.vscode/settings.json` turns nesting on for go-tui itself and repeats the pattern so it works even without the extension installed. `.gitignore` is narrowed (`.vscode/*` + `!.vscode/settings.json`) to track just that shared file while still ignoring personal editor state.

## Docs

- `editor/vscode/README.md`: new Features bullet and a "File Nesting" section with the opt-in snippet and caveats.
- `docs/content/reference/cli.md`: opt-in note in the VS Code editor-integration section.

## Caveats

- VS Code only; other editors have their own nesting mechanisms.
- Hyphenated names do not nest: the generator rewrites `my-app.gsx` to `my_app_gsx.go`, which a file nesting glob cannot match. Dot/underscore names nest normally.

Refs #105
