### PR TITLE
feat: add SetWrap setter to match the Element wrap API

### DIFF
--- a/docs/content/reference/element.md
+++ b/docs/content/reference/element.md
@@ -325,6 +325,15 @@ func (e *Element) SetTruncate(truncate bool)
 
 When enabled, text that overflows the element's content width is cut off with an ellipsis character (`…`).
 
+### Wrap
+
+```go
+func (e *Element) Wrap() bool
+func (e *Element) SetWrap(wrap bool)
+```
+
+Controls whether text content wraps within the element's width. Wrapping is enabled by default; disabling it keeps text on a single line.
+
 ### Hidden
 
 ```go

--- a/element_accessors.go
+++ b/element_accessors.go
@@ -189,6 +189,13 @@ func (e *Element) Wrap() bool {
 	return !e.noWrap
 }
 
+// SetWrap sets whether text content wraps within this element's width.
+// Wrapping is enabled by default; disabling it keeps text on a single line.
+func (e *Element) SetWrap(wrap bool) {
+	e.noWrap = !wrap
+	e.MarkDirty()
+}
+
 // --- Hidden API ---
 
 // Hidden returns whether this element is hidden.

--- a/element_accessors_test.go
+++ b/element_accessors_test.go
@@ -273,3 +273,46 @@ func TestElement_Wrap(t *testing.T) {
 		})
 	}
 }
+
+func TestElement_SetWrap(t *testing.T) {
+	type tc struct {
+		set  bool
+		want bool
+	}
+
+	tests := map[string]tc{
+		"disable wrapping": {
+			set:  false,
+			want: false,
+		},
+		"enable wrapping": {
+			set:  true,
+			want: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := New(WithWrap(!tt.set))
+			e.SetWrap(tt.set)
+			if got := e.Wrap(); got != tt.want {
+				t.Errorf("Wrap() after SetWrap(%v) = %v, want %v", tt.set, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestElement_SetWrap_MarksDirty(t *testing.T) {
+	// Reset global dirty flag
+	_ = testApp.checkAndClearDirty()
+
+	e := New()
+	e.app = testApp
+	e.dirty = false
+
+	e.SetWrap(false)
+
+	if !testApp.checkAndClearDirty() {
+		t.Error("SetWrap should mark the global dirty flag")
+	}
+}


### PR DESCRIPTION
## Summary

`Element` exposes a `Wrap()` getter and a `WithWrap` construction option, but had no imperative `SetWrap()` setter. Every comparable toggle (`SetTruncate`, `SetHidden`, `SetOverflow`, ...) has one, so this fills a small API-consistency gap.

- Add `SetWrap(wrap bool)` next to the `Wrap()` getter, mirroring `SetTruncate` (sets `noWrap` and marks the element dirty).
- Add unit tests covering the toggle and dirty-flag behavior.
- Document the previously-undocumented Wrap API in the element reference (`docs/content/reference/element.md`), alongside Truncate.