### PR TITLE
fix: reject component elements, expressions, and struct calls in function templs

### DIFF
--- a/docs/content/guides/04-layout.md
+++ b/docs/content/guides/04-layout.md
@@ -467,8 +467,16 @@ The top row has three equally-sized panels (each with `grow`). The bottom row us
 
 ### Stacked Form Fields
 
+The `<input>` elements mount against a receiver, so this layout is a struct method component rather than a pure `templ` function:
+
 ```gsx
-templ FormLayout() {
+type formLayout struct{}
+
+func FormLayout() *formLayout {
+    return &formLayout{}
+}
+
+templ (f *formLayout) Render() {
     <div class="flex-col gap-1 p-2 w-40">
         <div class="flex-col">
             <span class="font-bold">Username</span>

--- a/docs/content/guides/24-markdown.md
+++ b/docs/content/guides/24-markdown.md
@@ -10,29 +10,31 @@ It is a pure content renderer that owns no scroll position or key handling, so y
 
 The tag is self-closing. Content comes from an expression attribute rather than from children, because the generator cannot tell a literal markdown string apart from a Go expression that returns one.
 
+Because `<markdown>` mounts as a component, it lives inside a struct component's `Render`, with the source on a field of that struct:
+
 ```gsx
-templ Doc() {
-    <markdown source={"# Hello\n\nSome **bold** text and `inline code`."} />
+type viewer struct {
+    doc string
+}
+
+templ (v *viewer) Render() {
+    <markdown source={v.doc} />
 }
 ```
 
-The `source` attribute takes any string expression, so the document usually lives in a variable or a function:
-
-```gsx
-templ Doc(readme string) {
-    <markdown source={readme} />
-}
-```
-
-A markdown string with backticks and newlines is awkward to write inline in `.gsx`. The example keeps its sample document in `main.go` as a plain Go constant, where a double-quoted string concatenation can hold the backticks that code fences and inline code need, then passes it through the component constructor.
+The `source` attribute takes any string expression. A markdown document with backticks and newlines is awkward to write inline in `.gsx`, so the example keeps its sample in `main.go` as a plain Go constant, where double-quoted string concatenation can hold the backticks that code fences and inline code need, and stores it on the struct when it builds the viewer.
 
 ## Static and Reactive Sources
 
-`source` is for content that does not change. When the document updates at runtime, bind a `*State[string]` to the `state` attribute instead and the component re-renders on every change:
+`source` is for content that does not change. When the document updates at runtime, store a `*State[string]` on the struct and bind it to the `state` attribute instead, and the component re-renders on every change:
 
 ```gsx
-templ Preview(text *tui.State[string]) {
-    <markdown state={text} />
+type preview struct {
+    text *tui.State[string]
+}
+
+templ (p *preview) Render() {
+    <markdown state={p.text} />
 }
 ```
 

--- a/docs/content/reference/built-in-components.md
+++ b/docs/content/reference/built-in-components.md
@@ -6,6 +6,8 @@ go-tui ships with three built-in components: `Input` (single-line text), `TextAr
 
 All three implement `Component`, `KeyListener`, and `AppBinder`. Use them standalone or embed them in a larger UI.
 
+As GSX elements (`<input>`, `<textarea>`, `<modal>`), they mount against the component's receiver, so place them inside a struct method component rather than a pure `templ` function. The same applies to `<markdown>`.
+
 ## Input
 
 A single-line text input with cursor management, horizontal scrolling, and placeholder support.

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -55,6 +55,8 @@ templ UserList(users []string, maxVisible int) {
 }
 ```
 
+Pure components cannot host constructs that mount against a receiver: the component elements (`<input>`, `<textarea>`, `<modal>`, `<markdown>`), `@expr` component expressions, and `@Factory()` calls that return a struct component. Put those in a struct method component, which supplies the receiver they mount against. `tui generate` reports an error with a message pointing at the fix if you use one in a pure component.
+
 ### Children slot
 
 Pure components can accept nested content from their caller using `{children...}`:

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -1,6 +1,7 @@
 package tuigen
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -68,6 +69,10 @@ type Analyzer struct {
 
 	// Track component definitions for children validation
 	componentDefs map[string]bool // name -> accepts children
+
+	// currentComponent is the component whose body is being walked, used to
+	// reject component elements in function templs (no receiver to mount against).
+	currentComponent *Component
 }
 
 // NewAnalyzer creates a new semantic analyzer.
@@ -236,6 +241,7 @@ func (a *Analyzer) Analyze(file *File) error {
 	a.file = file
 	a.letBindings = make(map[string]bool)
 	a.componentDefs = make(map[string]bool)
+	a.currentComponent = nil
 	a.usesElement = false
 	a.usesLayout = false
 	a.usesTUI = false
@@ -298,6 +304,10 @@ func (a *Analyzer) analyzeComponent(comp *Component) {
 	// Track that we use elements
 	a.usesElement = true
 
+	// Record the enclosing component so element validation can tell whether it
+	// is a function templ (no receiver) or a struct component.
+	a.currentComponent = comp
+
 	// Analyze body nodes
 	for _, node := range comp.Body {
 		a.analyzeNode(node)
@@ -331,6 +341,14 @@ func (a *Analyzer) analyzeElement(elem *Element) {
 	// Check if tag is known
 	if !knownTags[elem.Tag] {
 		a.errors.AddErrorf(elem.Position, "unknown element tag <%s>", elem.Tag)
+	}
+
+	// Component elements mount via app.Mount against the host component's
+	// receiver. A function templ has no receiver, so this cannot be generated.
+	if isComponentElement(elem.Tag) && a.currentComponent != nil && a.currentComponent.Receiver == "" {
+		a.errors.Add(NewErrorWithHint(elem.Position,
+			fmt.Sprintf("<%s> can only be used inside a struct component", elem.Tag),
+			fmt.Sprintf("component elements mount against a receiver; give %s a receiver, e.g. templ (c *T) Render() { ... }", a.currentComponent.Name)))
 	}
 
 	// Check for children on void elements

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -73,6 +73,12 @@ type Analyzer struct {
 	// currentComponent is the component whose body is being walked, used to
 	// reject component elements in function templs (no receiver to mount against).
 	currentComponent *Component
+
+	// structComponentFactories holds the names of local functions that return a
+	// struct-component type (a `func Name(...) *T` where T has a method templ).
+	// Calling one via @Name() in a function templ generates broken code, so the
+	// set lets analyzeComponentCall reject it.
+	structComponentFactories map[string]bool
 }
 
 // NewAnalyzer creates a new semantic analyzer.
@@ -252,6 +258,10 @@ func (a *Analyzer) Analyze(file *File) error {
 		a.componentDefs[comp.Name] = comp.AcceptsChildren
 	}
 
+	// Resolve which local factory functions return a struct component, so
+	// analyzeComponentCall can reject @Factory() calls in function templs.
+	a.structComponentFactories = collectStructComponentFactories(file)
+
 	// Validate method templs using {children...} have a children field on their struct
 	for _, comp := range file.Components {
 		if comp.Receiver != "" && comp.AcceptsChildren {
@@ -331,8 +341,28 @@ func (a *Analyzer) analyzeNode(node Node) {
 		a.analyzeGoCode(n)
 	case *ComponentCall:
 		a.analyzeComponentCall(n)
+	case *ComponentExpr:
+		a.analyzeComponentExpr(n)
 	case *ChildrenSlot:
 		// ChildrenSlot is valid - no additional validation needed
+	}
+}
+
+// analyzeComponentExpr validates a component expression (@expr). Rendering it
+// lowers to expr.Render(app), which a function templ cannot satisfy: its body
+// has no app in scope. Only struct components (with a Render(app) receiver) can.
+func (a *Analyzer) analyzeComponentExpr(expr *ComponentExpr) {
+	a.rejectComponentExprInFunctionTempl(expr.Expr, expr.Position)
+}
+
+// rejectComponentExprInFunctionTempl reports the shared error for a component
+// expression used where no receiver is available. It also covers the
+// `name := @expr` let-binding form, which the generator lowers the same way.
+func (a *Analyzer) rejectComponentExprInFunctionTempl(exprText string, pos Position) {
+	if a.currentComponent != nil && a.currentComponent.Receiver == "" {
+		a.errors.Add(NewErrorWithHint(pos,
+			fmt.Sprintf("component expression @%s can only be used inside a struct component", exprText),
+			fmt.Sprintf("component expressions render against a receiver; give %s a receiver, e.g. templ (c *T) Render() { ... }", a.currentComponent.Name)))
 	}
 }
 
@@ -477,6 +507,9 @@ func (a *Analyzer) analyzeLetBinding(let *LetBinding) {
 		a.analyzeComponentCall(let.Call)
 	}
 	if let.Expr != "" {
+		// A let binding's Expr is only set for a `name := @expr` component
+		// expression, so it needs the same receiver check as a bare @expr.
+		a.rejectComponentExprInFunctionTempl(let.Expr, let.Position)
 		if strings.Contains(let.Expr, "tui.") {
 			a.usesTUI = true
 		}
@@ -506,6 +539,16 @@ func (a *Analyzer) analyzeIfStmt(stmt *IfStmt) {
 
 // analyzeComponentCall validates a component call.
 func (a *Analyzer) analyzeComponentCall(call *ComponentCall) {
+	// A @Factory() that returns a struct component mounts via app.Mount against
+	// the caller's receiver. In a function templ there is no receiver, so the
+	// generator falls back to a plain call and accesses .Root on a type that has
+	// none. Reject it here with a clear message instead.
+	if a.currentComponent != nil && a.currentComponent.Receiver == "" && a.structComponentFactories[call.Name] {
+		a.errors.Add(NewErrorWithHint(call.Position,
+			fmt.Sprintf("@%s() mounts a struct component and can only be used inside a struct component", call.Name),
+			fmt.Sprintf("%s returns a struct component; give %s a receiver, e.g. templ (c *T) Render() { ... }", call.Name, a.currentComponent.Name)))
+	}
+
 	// Check if component is defined in this file
 	acceptsChildren, defined := a.componentDefs[call.Name]
 
@@ -532,6 +575,40 @@ func (a *Analyzer) analyzeComponentCall(call *ComponentCall) {
 	for _, child := range call.Children {
 		a.analyzeNode(child)
 	}
+}
+
+// factoryReturnPattern matches a top-level factory function and captures its
+// name and single return type: `func Widget(...) *widget {`. The lazy param
+// group backtracks past nested parens in the parameter list to reach the real
+// return type. Tuple returns and generic result types do not match and stay
+// unflagged, which keeps the check free of false positives on ordinary code.
+var factoryReturnPattern = regexp.MustCompile(`^func\s+(\w+)\s*\([^{]*?\)\s*(\*?[\w.]+)\s*\{`)
+
+// collectStructComponentFactories returns the names of local functions whose
+// return type is a struct-component receiver type (a type with a method templ).
+// These are the @Name() calls that only work inside a struct component.
+func collectStructComponentFactories(file *File) map[string]bool {
+	structTypes := make(map[string]bool)
+	for _, comp := range file.Components {
+		if comp.Receiver != "" {
+			structTypes[strings.TrimPrefix(comp.ReceiverType, "*")] = true
+		}
+	}
+
+	factories := make(map[string]bool)
+	if len(structTypes) == 0 {
+		return factories
+	}
+	for _, fn := range file.Funcs {
+		m := factoryReturnPattern.FindStringSubmatch(strings.TrimSpace(fn.Code))
+		if m == nil {
+			continue
+		}
+		if structTypes[strings.TrimPrefix(m[2], "*")] {
+			factories[m[1]] = true
+		}
+	}
+	return factories
 }
 
 // analyzeGoExpr validates a Go expression.

--- a/internal/tuigen/analyzer_component_element_test.go
+++ b/internal/tuigen/analyzer_component_element_test.go
@@ -1,0 +1,139 @@
+package tuigen
+
+import (
+	"strings"
+	"testing"
+)
+
+// Component elements (textarea/input/modal/markdown) mount via app.Mount against
+// the host component's receiver. A function templ has no receiver, so using one
+// there generated invalid Go (issue #111). The analyzer now rejects it with a
+// message that points at the struct-component pattern.
+func TestAnalyzer_ComponentElementRequiresReceiver(t *testing.T) {
+	type tc struct {
+		input         string
+		wantError     bool
+		errorContains string
+		hintContains  string
+	}
+
+	tests := map[string]tc{
+		"textarea in function templ errors": {
+			input: `package x
+templ MyForm() {
+	<textarea placeholder="Type here..." />
+}`,
+			wantError:     true,
+			errorContains: "<textarea> can only be used inside a struct component",
+			hintContains:  "give MyForm a receiver",
+		},
+		"input in function templ errors": {
+			input: `package x
+templ MyForm() {
+	<input placeholder="Name" />
+}`,
+			wantError:     true,
+			errorContains: "<input> can only be used inside a struct component",
+		},
+		"markdown in function templ errors": {
+			input: `package x
+templ Doc(src string) {
+	<markdown source={src} />
+}`,
+			wantError:     true,
+			errorContains: "<markdown> can only be used inside a struct component",
+		},
+		"modal in function templ errors": {
+			input: `package x
+templ Dialog(show bool) {
+	<modal open={show}>
+		<span>hi</span>
+	</modal>
+}`,
+			wantError:     true,
+			errorContains: "<modal> can only be used inside a struct component",
+		},
+		"nested in for loop in function templ errors": {
+			input: `package x
+templ List(items []string) {
+	<div>
+		for _, item := range items {
+			<textarea placeholder={item} />
+		}
+	</div>
+}`,
+			wantError:     true,
+			errorContains: "<textarea> can only be used inside a struct component",
+		},
+		"nested in if in function templ errors": {
+			input: `package x
+templ Maybe(show bool) {
+	<div>
+		if show {
+			<input />
+		}
+	</div>
+}`,
+			wantError:     true,
+			errorContains: "<input> can only be used inside a struct component",
+		},
+		"in let binding in function templ errors": {
+			input: `package x
+templ MyForm() {
+	editor := <textarea />
+	<div>{editor}</div>
+}`,
+			wantError:     true,
+			errorContains: "<textarea> can only be used inside a struct component",
+		},
+		"in component-call children in function templ errors": {
+			input: `package x
+templ MyForm() {
+	@Card() {
+		<textarea />
+	}
+}`,
+			wantError:     true,
+			errorContains: "<textarea> can only be used inside a struct component",
+		},
+		"textarea in method templ is allowed": {
+			input: `package x
+type myForm struct{}
+templ (c *myForm) Render() {
+	<textarea placeholder="Type here..." />
+}`,
+			wantError: false,
+		},
+		"modal in method templ is allowed": {
+			input: `package x
+type myForm struct{}
+templ (c *myForm) Render() {
+	<modal open={c.show}>
+		<span>hi</span>
+	</modal>
+}`,
+			wantError: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := AnalyzeFile("test.gsx", tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errorContains)
+				}
+				if tt.hintContains != "" && !strings.Contains(err.Error(), tt.hintContains) {
+					t.Errorf("error %q does not contain hint %q", err.Error(), tt.hintContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/tuigen/analyzer_component_element_test.go
+++ b/internal/tuigen/analyzer_component_element_test.go
@@ -137,3 +137,180 @@ templ (c *myForm) Render() {
 		})
 	}
 }
+
+// Component expressions (@expr) render via expr.Render(app). A function templ
+// body has no app in scope, so the analyzer rejects them there while allowing
+// them in method templs, whose Render(app) receiver supplies app.
+func TestAnalyzer_ComponentExprRequiresReceiver(t *testing.T) {
+	type tc struct {
+		input         string
+		wantError     bool
+		errorContains string
+		hintContains  string
+	}
+
+	tests := map[string]tc{
+		"component expr in function templ errors": {
+			input: `package x
+templ Foo(child tui.Component) {
+	<div>@child</div>
+}`,
+			wantError:     true,
+			errorContains: "component expression @child can only be used inside a struct component",
+			hintContains:  "give Foo a receiver",
+		},
+		"component expr nested in for loop in function templ errors": {
+			input: `package x
+templ List(kids []tui.Component) {
+	<div>
+		for _, kid := range kids {
+			@kid
+		}
+	</div>
+}`,
+			wantError:     true,
+			errorContains: "component expression @kid can only be used inside a struct component",
+		},
+		"component expr in let binding in function templ errors": {
+			input: `package x
+templ Foo(child tui.Component) {
+	thing := @child
+	<div>{thing}</div>
+}`,
+			wantError:     true,
+			errorContains: "component expression @child can only be used inside a struct component",
+		},
+		"component expr nested in if in function templ errors": {
+			input: `package x
+templ Maybe(show bool, child tui.Component) {
+	<div>
+		if show {
+			@child
+		}
+	</div>
+}`,
+			wantError:     true,
+			errorContains: "component expression @child can only be used inside a struct component",
+		},
+		"component expr in method templ is allowed": {
+			input: `package x
+type host struct{ child tui.Component }
+templ (h *host) Render() {
+	<div>@h.child</div>
+}`,
+			wantError: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := AnalyzeFile("test.gsx", tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errorContains)
+				}
+				if tt.hintContains != "" && !strings.Contains(err.Error(), tt.hintContains) {
+					t.Errorf("error %q does not contain hint %q", err.Error(), tt.hintContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// A @Factory() call that returns a struct component mounts via app.Mount against
+// the caller's receiver. In a function templ the generator instead emits a plain
+// call and reads .Root on a type that has none. The analyzer rejects the call in
+// a function templ, but leaves it (and plain function-component calls) alone in a
+// method templ.
+func TestAnalyzer_StructComponentCallRequiresReceiver(t *testing.T) {
+	type tc struct {
+		input         string
+		wantError     bool
+		errorContains string
+		hintContains  string
+	}
+
+	// Shared preamble: a struct component `widget` with a factory `Widget()`.
+	const structComp = `package x
+type widget struct{}
+func Widget() *widget { return &widget{} }
+templ (w *widget) Render() {
+	<span>hi</span>
+}
+`
+
+	tests := map[string]tc{
+		"struct factory call in function templ errors": {
+			input: structComp + `templ Page() {
+	<div>@Widget()</div>
+}`,
+			wantError:     true,
+			errorContains: "@Widget() mounts a struct component and can only be used inside a struct component",
+			hintContains:  "give Page a receiver",
+		},
+		"struct factory with params call in function templ errors": {
+			input: `package x
+type widget struct{}
+func Widget(id string) *widget { return &widget{} }
+templ (w *widget) Render() {
+	<span>hi</span>
+}
+templ Page() {
+	<div>@Widget("a")</div>
+}`,
+			wantError:     true,
+			errorContains: "@Widget() mounts a struct component and can only be used inside a struct component",
+		},
+		"struct factory call in method templ is allowed": {
+			input: structComp + `type host struct{}
+templ (h *host) Render() {
+	<div>@Widget()</div>
+}`,
+			wantError: false,
+		},
+		"struct factory used in a go expression is not flagged": {
+			input: structComp + `templ Page() {
+	<div>{Widget()}</div>
+}`,
+			wantError: false,
+		},
+		"function component call in function templ is allowed": {
+			input: `package x
+templ Badge() {
+	<span>b</span>
+}
+templ Page() {
+	<div>@Badge()</div>
+}`,
+			wantError: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := AnalyzeFile("test.gsx", tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errorContains)
+				}
+				if tt.hintContains != "" && !strings.Contains(err.Error(), tt.hintContains) {
+					t.Errorf("error %q does not contain hint %q", err.Error(), tt.hintContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/tuigen/analyzer_test.go
+++ b/internal/tuigen/analyzer_test.go
@@ -52,14 +52,16 @@ templ Test() {
 		},
 		"textarea self-closing": {
 			input: `package x
-templ Test() {
+type myComp struct{}
+templ (c *myComp) Render() {
 	<textarea />
 }`,
 			wantError: false,
 		},
 		"textarea with children is error": {
 			input: `package x
-templ Test() {
+type myComp struct{}
+templ (c *myComp) Render() {
 	<textarea>text</textarea>
 }`,
 			wantError:     true,
@@ -427,7 +429,8 @@ func TestAnalyzer_KeyAndRefRequireExpressions(t *testing.T) {
 	tests := map[string]tc{
 		"key expression is valid": {
 			input: `package x
-templ Test() {
+type myComp struct{}
+templ (c *myComp) Render() {
 	<div>
 		for _, item := range items {
 			<markdown key={item.ID} source={item.Text} />
@@ -438,7 +441,8 @@ templ Test() {
 		},
 		"key string literal is rejected": {
 			input: `package x
-templ Test() {
+type myComp struct{}
+templ (c *myComp) Render() {
 	<markdown key="myid" source={src} />
 }`,
 			wantError:     true,
@@ -446,7 +450,8 @@ templ Test() {
 		},
 		"ref string literal is rejected": {
 			input: `package x
-templ Test() {
+type myComp struct{}
+templ (c *myComp) Render() {
 	<textarea ref="myref" />
 }`,
 			wantError:     true,

--- a/internal/tuigen/analyzer_validation_test.go
+++ b/internal/tuigen/analyzer_validation_test.go
@@ -157,8 +157,11 @@ func TestAnalyzer_AllKnownTags(t *testing.T) {
 
 	for _, tag := range tags {
 		t.Run(tag, func(t *testing.T) {
+			// Use a method templ so component elements (input, textarea), which
+			// mount against a receiver, are in a valid context alongside the rest.
 			input := `package x
-templ Test() {
+type myComp struct{}
+templ (c *myComp) Render() {
 	<` + tag + ` />
 }`
 			_, err := AnalyzeFile("test.gsx", input)

--- a/internal/tuigen/ast.go
+++ b/internal/tuigen/ast.go
@@ -206,7 +206,7 @@ type LetBinding struct {
 	Name            string
 	Element         *Element       // RHS is an element (e.g., <span>Hello</span>)
 	Call            *ComponentCall // RHS is a component call (e.g., @MyComponent())
-	Expr            string         // RHS is a Go expression (e.g., fmt.Sprintf(...))
+	Expr            string         // RHS is a component expression from @expr (e.g., "c.textarea"); rendered via <expr>.Render(app)
 	IsShortForm     bool           // true for :=, false for var
 	IsVarForm       bool           // true for var form, false for := form
 	Position        Position


### PR DESCRIPTION
## Summary

A function templ (`templ Name()`, no receiver) compiles to a plain builder function with no `app` in scope and no receiver. Three GSX constructs need one or both of those to generate valid Go, and using any of them in a function templ produced broken output. A component element gave a `tui generate` syntax error (issue #111), while a `@expr` component expression or a `@Factory()` struct-component call generated silently and only failed later at `go build`. The analyzer now rejects all three at generate time with a message that points at the fix.

## What breaks and why

Each of these lowers to code a function templ cannot satisfy:

- **Component elements** (`<textarea>`, `<input>`, `<modal>`, `<markdown>`) become `app.MountPersistent(receiver, ...)`. With no receiver the generator emitted `app.MountPersistent(, 0, ...)`, a syntax error that stopped `tui generate` outright.
- **Component expressions** (`@expr`, including the `name := @expr` binding) become `expr.Render(app)`. A function templ body has no `app`, so `tui generate` wrote the file but it failed to compile with `undefined: app`.
- **Struct-component calls** (`@Widget()` where `Widget` returns a struct component) mount via `app.Mount` in a method templ. In a function templ the generator falls back to a plain call and reads `.Root` on a type that has none.

The common cause is that these mount against a component's receiver, and a function templ has none. There is no small codegen patch. A `nil` parent still hits `undefined: app`, and even past that it would collide in the mount cache, because function templs carry no stable runtime identity. So the fix catches the mistake in the analyzer and tells you to use a struct component.

## The error

```
form.gsx:6:2: error: <textarea> can only be used inside a struct component (component elements mount against a receiver; give MyForm a receiver, e.g. templ (c *T) Render() { ... })
```

The struct-call check resolves a `@Name()` call to a local factory whose return type has a method templ, so imported and plain function-component calls are left alone. The element and expression checks reuse the generator's own `isComponentElement` set and fire on every path that reaches an element or expression, including for and if bodies, let bindings, and component-call children.

## Docs

The markdown and layout guides showed `<markdown>` and `<input>` inside function templs, which never compiled. Those examples now use struct components, and the GSX reference notes which constructs require one.

Fixes #111
