### PR TITLE
fix: honor user-defined UpdateProps on receiver components

### DIFF
--- a/cmd/tui/check.go
+++ b/cmd/tui/check.go
@@ -90,6 +90,7 @@ func checkFile(inputPath string) error {
 
 	// Analyze (validates elements and attributes)
 	analyzer := tuigen.NewAnalyzer()
+	analyzer.SetPackageContext(loadPackageContext(inputPath))
 	if err := analyzer.Analyze(file); err != nil {
 		return err
 	}

--- a/cmd/tui/generate.go
+++ b/cmd/tui/generate.go
@@ -169,14 +169,20 @@ func generateFile(inputPath, outputPath string) error {
 		return err
 	}
 
+	// Sibling declarations in the package inform user-method detection and
+	// collision checks
+	pkgCtx := loadPackageContext(inputPath)
+
 	// Analyze (validates and adds missing imports)
 	analyzer := tuigen.NewAnalyzer()
+	analyzer.SetPackageContext(pkgCtx)
 	if err := analyzer.Analyze(file); err != nil {
 		return err
 	}
 
 	// Generate Go code
 	generator := tuigen.NewGenerator()
+	generator.SetPackageContext(pkgCtx)
 	output, err := generator.Generate(file, filename)
 	if err != nil {
 		return fmt.Errorf("generating code: %w", err)

--- a/cmd/tui/integration_test.go
+++ b/cmd/tui/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -67,6 +68,137 @@ func TestCLI_Fmt_Stdout(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCLI_Generate_SiblingFileDetection verifies that a lifecycle method
+// declared in a sibling .go file of the package suppresses the generated one,
+// and that collisions with sibling declarations are reported at check time.
+func TestCLI_Generate_SiblingFileDetection(t *testing.T) {
+	writeFile := func(t *testing.T, dir, name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	t.Run("sibling UpdateProps suppresses generation", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "row.gsx", `package x
+
+type row struct{ v string }
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}
+`)
+		writeFile(t, dir, "row_lifecycle.go", `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+func (r *row) UpdateProps(fresh tui.Component) {
+	r.updatePropsFields(fresh)
+}
+`)
+
+		cmd := exec.Command(testBin, "generate", dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("generate failed: %v\n%s", err, out)
+		}
+
+		generated, err := os.ReadFile(filepath.Join(dir, "row_gsx.go"))
+		if err != nil {
+			t.Fatalf("reading generated file: %v", err)
+		}
+		code := string(generated)
+		if strings.Contains(code, "func (r *row) UpdateProps(") {
+			t.Errorf("generated UpdateProps despite sibling declaration:\n%s", code)
+		}
+		if !strings.Contains(code, "func (r *row) updatePropsFields(") {
+			t.Errorf("missing updatePropsFields helper:\n%s", code)
+		}
+	})
+
+	t.Run("generated sibling files are not treated as user code", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "row.gsx", `package x
+
+type row struct{ v string }
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}
+`)
+
+		// Generate twice: the first run's output must not suppress the second.
+		for i := range 2 {
+			cmd := exec.Command(testBin, "generate", dir)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("generate run %d failed: %v\n%s", i+1, err, out)
+			}
+		}
+
+		generated, err := os.ReadFile(filepath.Join(dir, "row_gsx.go"))
+		if err != nil {
+			t.Fatalf("reading generated file: %v", err)
+		}
+		if !strings.Contains(string(generated), "func (r *row) UpdateProps(") {
+			t.Errorf("second generate run suppressed UpdateProps; generated output was treated as user code:\n%s", generated)
+		}
+	})
+
+	t.Run("check reports collision with sibling function", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "foo.gsx", `package x
+
+templ Foo() {
+	<span>hi</span>
+}
+`)
+		writeFile(t, dir, "helpers.go", `package x
+
+func Foo() string { return "x" }
+`)
+
+		cmd := exec.Command(testBin, "check", filepath.Join(dir, "foo.gsx"))
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("check succeeded, expected collision error\n%s", out)
+		}
+		if !strings.Contains(string(out), "conflicts with a Go function") {
+			t.Errorf("output missing collision error:\n%s", out)
+		}
+	})
+
+	t.Run("test file declarations are ignored", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "row.gsx", `package x
+
+type row struct{ v string }
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}
+`)
+		writeFile(t, dir, "row_test.go", `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+func (r *row) UpdateProps(fresh tui.Component) {}
+`)
+
+		cmd := exec.Command(testBin, "generate", dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("generate failed: %v\n%s", err, out)
+		}
+
+		generated, err := os.ReadFile(filepath.Join(dir, "row_gsx.go"))
+		if err != nil {
+			t.Fatalf("reading generated file: %v", err)
+		}
+		if !strings.Contains(string(generated), "func (r *row) UpdateProps(") {
+			t.Errorf("test-file declaration suppressed UpdateProps; prod builds would lack the method:\n%s", generated)
+		}
+	})
 }
 
 func TestCLI_Version(t *testing.T) {

--- a/cmd/tui/package_context.go
+++ b/cmd/tui/package_context.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/grindlemire/go-tui/internal/tuigen"
+)
+
+// loadPackageContext builds a PackageContext from the sibling files of
+// inputPath's directory, so generation and analysis can detect user code
+// declared outside the .gsx file itself.
+func loadPackageContext(inputPath string) *tuigen.PackageContext {
+	ctx := tuigen.NewPackageContext()
+	self := filepath.Base(inputPath)
+	ctx.AddDirectory(filepath.Dir(inputPath), func(filename string) bool {
+		return filename == self
+	})
+	return ctx
+}

--- a/cmd/tui/testdata/input_gsx.go
+++ b/cmd/tui/testdata/input_gsx.go
@@ -36,12 +36,19 @@ func (c *myInput) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (c *myInput) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (c *myInput) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*myInput)
 	if !ok {
 		return
 	}
 	c.app = f.app
+}
+
+func (c *myInput) UpdateProps(fresh tui.Component) {
+	c.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*myInput)(nil)

--- a/cmd/tui/testdata/markdown_gsx.go
+++ b/cmd/tui/testdata/markdown_gsx.go
@@ -31,12 +31,19 @@ func (c *docView) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (c *docView) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (c *docView) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*docView)
 	if !ok {
 		return
 	}
 	c.readme = f.readme
+}
+
+func (c *docView) UpdateProps(fresh tui.Component) {
+	c.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*docView)(nil)

--- a/cmd/tui/testdata/modal_gsx.go
+++ b/cmd/tui/testdata/modal_gsx.go
@@ -83,12 +83,19 @@ func (c *myModal) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (c *myModal) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (c *myModal) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*myModal)
 	if !ok {
 		return
 	}
 	c.app = f.app
+}
+
+func (c *myModal) UpdateProps(fresh tui.Component) {
+	c.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*myModal)(nil)

--- a/cmd/tui/testdata/textarea_gsx.go
+++ b/cmd/tui/testdata/textarea_gsx.go
@@ -35,12 +35,19 @@ func (c *myForm) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (c *myForm) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (c *myForm) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*myForm)
 	if !ok {
 		return
 	}
 	c.app = f.app
+}
+
+func (c *myForm) UpdateProps(fresh tui.Component) {
+	c.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*myForm)(nil)

--- a/docs/content/reference/interfaces.md
+++ b/docs/content/reference/interfaces.md
@@ -203,7 +203,7 @@ Called on cached component instances when the parent re-renders and the componen
 
 Without `PropsUpdater`, a mounted component's props are fixed at the values passed during the first render. Implement this interface when the component's constructor takes parameters that may change across renders.
 
-**When to implement:** When your component receives props from a parent and those props can change.
+**When to implement:** When your component receives props from a parent and those props can change. For `.gsx` receiver components the generator emits this automatically; see [Generated lifecycle methods](#generated-lifecycle-methods) for the override and delegation rules.
 
 ```go
 type statusBar struct {
@@ -225,6 +225,29 @@ func (s *statusBar) UpdateProps(fresh tui.Component) {
     }
 }
 ```
+
+## Generated lifecycle methods
+
+For a receiver component defined in a `.gsx` file (`templ (c *T) Render()`), the generator emits `UpdateProps`, `BindApp`, and `UnbindApp` automatically when the struct has fields that need them. If you declare one of these methods yourself in the same `.gsx` file, the generator skips its version and yours is used.
+
+Each generated method is a thin wrapper around an unexported helper containing the actual logic:
+
+| Generated method | Delegation helper |
+|------------------|-------------------|
+| `UpdateProps` | `updatePropsFields(fresh Component)` copies prop fields |
+| `BindApp` | `bindAppFields(app *App)` wires `State`, `Events`, and `*App` fields |
+| `UnbindApp` | `unbindAppFields()` detaches `Events` subscriptions |
+
+The helpers are always emitted, so an override can delegate the generated work and add custom behavior on top:
+
+```go
+func (c *statusBar) UpdateProps(fresh tui.Component) {
+    c.updatePropsFields(fresh)
+    c.recomputeLayout()
+}
+```
+
+The three helper names are reserved by the generator; declaring your own method with one of these names collides with generated code. For function templs (`templ Name()`), the generator also reserves the `<Name>View` type name for the generated view struct.
 
 ## Viewable
 

--- a/docs/content/reference/interfaces.md
+++ b/docs/content/reference/interfaces.md
@@ -228,7 +228,9 @@ func (s *statusBar) UpdateProps(fresh tui.Component) {
 
 ## Generated lifecycle methods
 
-For a receiver component defined in a `.gsx` file (`templ (c *T) Render()`), the generator emits `UpdateProps`, `BindApp`, and `UnbindApp` automatically when the struct has fields that need them. If you declare one of these methods yourself in the same `.gsx` file, the generator skips its version and yours is used.
+For a receiver component defined in a `.gsx` file (`templ (c *T) Render()`), the generator emits `UpdateProps`, `BindApp`, and `UnbindApp` automatically when the struct has fields that need them. If you declare one of these methods yourself, in the `.gsx` file or in any plain `.go` file of the same package, the generator skips its version and yours is used. Test files (`_test.go`) are ignored so a test-only method cannot suppress a method production builds need.
+
+Because generation reads sibling files, adding or removing one of these methods in a `.go` file changes what the `.gsx` file should generate. Rerun `tui generate` after such an edit; until then the stale generated file may fail to compile.
 
 Each generated method is a thin wrapper around an unexported helper containing the actual logic:
 

--- a/docs/content/reference/interfaces.md
+++ b/docs/content/reference/interfaces.md
@@ -249,7 +249,7 @@ func (c *statusBar) UpdateProps(fresh tui.Component) {
 }
 ```
 
-The three helper names are reserved by the generator; declaring your own method with one of these names collides with generated code. For function templs (`templ Name()`), the generator also reserves the `<Name>View` type name for the generated view struct.
+The three helper names are reserved by the generator; declaring your own method with one of these names on a templ receiver type is rejected at `tui generate`/`tui check` time. For function templs (`templ Name()`), the generator also reserves the `<Name>View` type name for the generated view struct.
 
 ## Viewable
 

--- a/examples/02-gsx-syntax/syntax_gsx.go
+++ b/examples/02-gsx-syntax/syntax_gsx.go
@@ -173,12 +173,19 @@ func (l *listApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (l *listApp) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (l *listApp) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*listApp)
 	if !ok {
 		return
 	}
 	l.items = f.items
+}
+
+func (l *listApp) UpdateProps(fresh tui.Component) {
+	l.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*listApp)(nil)

--- a/examples/06-state/state_gsx.go
+++ b/examples/06-state/state_gsx.go
@@ -276,12 +276,19 @@ func (d *demoApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (d *demoApp) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (d *demoApp) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*demoApp)
 	if !ok {
 		return
 	}
 	d.items = f.items
+}
+
+func (d *demoApp) UpdateProps(fresh tui.Component) {
+	d.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*demoApp)(nil)

--- a/examples/07-components/components_gsx.go
+++ b/examples/07-components/components_gsx.go
@@ -730,12 +730,19 @@ func (d *dashboard) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (d *dashboard) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (d *dashboard) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*dashboard)
 	if !ok {
 		return
 	}
 	d.tabs = f.tabs
+}
+
+func (d *dashboard) UpdateProps(fresh tui.Component) {
+	d.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*dashboard)(nil)

--- a/examples/10-scrolling/scrolling_gsx.go
+++ b/examples/10-scrolling/scrolling_gsx.go
@@ -160,12 +160,19 @@ func (f *fileList) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (f *fileList) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (f *fileList) updatePropsFields(fresh tui.Component) {
 	ff, ok := fresh.(*fileList)
 	if !ok {
 		return
 	}
 	f.files = ff.files
+}
+
+func (f *fileList) UpdateProps(fresh tui.Component) {
+	f.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*fileList)(nil)

--- a/examples/11-focus/focus_gsx.go
+++ b/examples/11-focus/focus_gsx.go
@@ -105,13 +105,20 @@ func (p *panelForm) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (p *panelForm) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (p *panelForm) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*panelForm)
 	if !ok {
 		return
 	}
 	p.panels = f.panels
 	p.focus = f.focus
+}
+
+func (p *panelForm) UpdateProps(fresh tui.Component) {
+	p.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*panelForm)(nil)

--- a/examples/15-inline-mode/inline_gsx.go
+++ b/examples/15-inline-mode/inline_gsx.go
@@ -104,13 +104,20 @@ func (a *myApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (a *myApp) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (a *myApp) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*myApp)
 	if !ok {
 		return
 	}
 	a.app = f.app
 	a.textarea = f.textarea
+}
+
+func (a *myApp) UpdateProps(fresh tui.Component) {
+	a.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*myApp)(nil)

--- a/examples/17-inline-streaming/stream_gsx.go
+++ b/examples/17-inline-streaming/stream_gsx.go
@@ -300,13 +300,20 @@ func (s *streamDemo) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (s *streamDemo) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (s *streamDemo) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*streamDemo)
 	if !ok {
 		return
 	}
 	s.app = f.app
 	s.phraseIdx = f.phraseIdx
+}
+
+func (s *streamDemo) UpdateProps(fresh tui.Component) {
+	s.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*streamDemo)(nil)

--- a/examples/20-animation/animation_gsx.go
+++ b/examples/20-animation/animation_gsx.go
@@ -347,7 +347,10 @@ func (a *animationApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (a *animationApp) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (a *animationApp) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*animationApp)
 	if !ok {
 		return
@@ -355,6 +358,10 @@ func (a *animationApp) UpdateProps(fresh tui.Component) {
 	a.startTime = f.startTime
 	a.frame = f.frame
 	a.paused = f.paused
+}
+
+func (a *animationApp) UpdateProps(fresh tui.Component) {
+	a.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*animationApp)(nil)

--- a/examples/21-directory-tree/tree_gsx.go
+++ b/examples/21-directory-tree/tree_gsx.go
@@ -485,7 +485,10 @@ func (d *directoryTree) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (d *directoryTree) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (d *directoryTree) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*directoryTree)
 	if !ok {
 		return
@@ -496,6 +499,10 @@ func (d *directoryTree) UpdateProps(fresh tui.Component) {
 	d.snapCursor = f.snapCursor
 	d.snapExpanded = f.snapExpanded
 	d.snapSelectedPath = f.snapSelectedPath
+}
+
+func (d *directoryTree) UpdateProps(fresh tui.Component) {
+	d.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*directoryTree)(nil)

--- a/examples/22-event-loop/feed_gsx.go
+++ b/examples/22-event-loop/feed_gsx.go
@@ -249,12 +249,19 @@ func (f *feedApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (f *feedApp) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (f *feedApp) updatePropsFields(fresh tui.Component) {
 	ff, ok := fresh.(*feedApp)
 	if !ok {
 		return
 	}
 	f.mode = ff.mode
+}
+
+func (f *feedApp) UpdateProps(fresh tui.Component) {
+	f.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*feedApp)(nil)

--- a/examples/24-markdown/markdown_gsx.go
+++ b/examples/24-markdown/markdown_gsx.go
@@ -104,12 +104,19 @@ func (v *viewer) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (v *viewer) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (v *viewer) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*viewer)
 	if !ok {
 		return
 	}
 	v.doc = f.doc
+}
+
+func (v *viewer) UpdateProps(fresh tui.Component) {
+	v.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*viewer)(nil)

--- a/examples/ai-chat/chat_gsx.go
+++ b/examples/ai-chat/chat_gsx.go
@@ -255,7 +255,10 @@ func (c *chat) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (c *chat) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (c *chat) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*chat)
 	if !ok {
 		return
@@ -266,6 +269,10 @@ func (c *chat) UpdateProps(fresh tui.Component) {
 	c.streamWriter = f.streamWriter
 	c.cmd = f.cmd
 	c.firstMsg = f.firstMsg
+}
+
+func (c *chat) UpdateProps(fresh tui.Component) {
+	c.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*chat)(nil)

--- a/examples/ai-chat/settings/settings_gsx.go
+++ b/examples/ai-chat/settings/settings_gsx.go
@@ -713,7 +713,10 @@ func (s *SettingsApp) Render(app *tui.App) *tui.Element {
 	return __tui_0
 }
 
-func (s *SettingsApp) UpdateProps(fresh tui.Component) {
+// updatePropsFields is generated. It copies prop fields from fresh onto
+// the receiver. When you override UpdateProps, call this helper instead
+// of hand-maintaining the copy list.
+func (s *SettingsApp) updatePropsFields(fresh tui.Component) {
 	f, ok := fresh.(*SettingsApp)
 	if !ok {
 		return
@@ -721,6 +724,10 @@ func (s *SettingsApp) UpdateProps(fresh tui.Component) {
 	s.SystemPromptPresets = f.SystemPromptPresets
 	s.AvailableModels = f.AvailableModels
 	s.AvailablePermModes = f.AvailablePermModes
+}
+
+func (s *SettingsApp) UpdateProps(fresh tui.Component) {
+	s.updatePropsFields(fresh)
 }
 
 var _ tui.PropsUpdater = (*SettingsApp)(nil)

--- a/internal/lsp/document.go
+++ b/internal/lsp/document.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"path/filepath"
 	"sync"
 
 	"github.com/grindlemire/go-tui/internal/lsp/provider"
@@ -118,6 +119,7 @@ func (dm *DocumentManager) parseDocument(doc *Document) {
 	// Run analyzer to collect semantic errors (including Tailwind class validation)
 	if ast != nil {
 		analyzer := tuigen.NewAnalyzer()
+		analyzer.SetPackageContext(dm.buildPackageContext(doc))
 		if analyzerErr := analyzer.Analyze(ast); analyzerErr != nil {
 			if errList, ok := analyzerErr.(*tuigen.ErrorList); ok {
 				doc.Errors = append(doc.Errors, errList.Errors()...)
@@ -126,6 +128,40 @@ func (dm *DocumentManager) parseDocument(doc *Document) {
 			}
 		}
 	}
+}
+
+// buildPackageContext collects sibling declarations for cross-file collision
+// detection. Open sibling .gsx documents contribute their in-memory ASTs
+// (unsaved edits included); everything else comes from disk. Callers must
+// hold dm.mu.
+func (dm *DocumentManager) buildPackageContext(doc *Document) *tuigen.PackageContext {
+	ctx := tuigen.NewPackageContext()
+
+	path := uriToPath(doc.URI)
+	dir := filepath.Dir(path)
+
+	// Sibling documents open in the editor: use their parsed ASTs and note
+	// their filenames so the disk scan skips the stale on-disk copies.
+	openSiblings := make(map[string]bool)
+	for uri, other := range dm.docs {
+		if uri == doc.URI {
+			continue
+		}
+		otherPath := uriToPath(uri)
+		if filepath.Dir(otherPath) != dir {
+			continue
+		}
+		openSiblings[filepath.Base(otherPath)] = true
+		if other.AST != nil {
+			ctx.AddGSXFile(other.AST)
+		}
+	}
+
+	self := filepath.Base(path)
+	ctx.AddDirectory(dir, func(filename string) bool {
+		return filename == self || openSiblings[filename]
+	})
+	return ctx
 }
 
 // uriToPath converts a file:// URI to a file path.

--- a/internal/lsp/document_coverage_test.go
+++ b/internal/lsp/document_coverage_test.go
@@ -1,6 +1,9 @@
 package lsp
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/grindlemire/go-tui/internal/tuigen"
@@ -22,6 +25,53 @@ func TestDocumentManagerUpdate_UnopenedDocument(t *testing.T) {
 	}
 	if dm.Get(uri) != doc {
 		t.Error("document not registered in the manager")
+	}
+}
+
+// TestDocumentManager_CrossFileCollisions verifies that analysis of one
+// document sees declarations from sibling files: open documents through
+// their in-memory ASTs (unsaved edits included), unopened files from disk.
+func TestDocumentManager_CrossFileCollisions(t *testing.T) {
+	dm := NewDocumentManager()
+
+	// Open a sibling that declares templ Foo. There is no disk file at all,
+	// proving detection went through the open-buffer path.
+	dm.Open("file:///ws/a.gsx", "package x\n\ntempl Foo() {\n\t<span>a</span>\n}\n", 1)
+
+	doc := dm.Open("file:///ws/b.gsx", "package x\n\ntempl Foo() {\n\t<span>b</span>\n}\n", 1)
+
+	found := false
+	for _, e := range doc.Errors {
+		if strings.Contains(e.Message, "duplicate templ") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate templ error from open sibling, got %v", doc.Errors)
+	}
+
+	// A document in a different directory must not collide.
+	other := dm.Open("file:///elsewhere/c.gsx", "package x\n\ntempl Foo() {\n\t<span>c</span>\n}\n", 1)
+	for _, e := range other.Errors {
+		if strings.Contains(e.Message, "duplicate templ") {
+			t.Errorf("unexpected collision across directories: %v", e.Message)
+		}
+	}
+
+	// Unopened sibling .go file on disk is picked up.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "helpers.go"), []byte("package x\n\nfunc Bar() string { return \"x\" }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	diskDoc := dm.Open("file://"+filepath.Join(dir, "d.gsx"), "package x\n\ntempl Bar() {\n\t<span>d</span>\n}\n", 1)
+	found = false
+	for _, e := range diskDoc.Errors {
+		if strings.Contains(e.Message, "conflicts with a Go function") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected collision with on-disk sibling function, got %v", diskDoc.Errors)
 	}
 }
 

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -79,6 +79,17 @@ type Analyzer struct {
 	// Calling one via @Name() in a function templ generates broken code, so the
 	// set lets analyzeComponentCall reject it.
 	structComponentFactories map[string]bool
+
+	// pkgCtx holds declarations from sibling files of the package, so
+	// collision checks also catch conflicts declared outside this .gsx file.
+	// Nil when no context is available.
+	pkgCtx *PackageContext
+}
+
+// SetPackageContext supplies declarations from sibling files of the package
+// for cross-file collision detection.
+func (a *Analyzer) SetPackageContext(ctx *PackageContext) {
+	a.pkgCtx = ctx
 }
 
 // NewAnalyzer creates a new semantic analyzer.

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -258,6 +258,9 @@ func (a *Analyzer) Analyze(file *File) error {
 		a.componentDefs[comp.Name] = comp.AcceptsChildren
 	}
 
+	// Reject declarations that collide with generated code
+	a.validateNameCollisions(file)
+
 	// Resolve which local factory functions return a struct component, so
 	// analyzeComponentCall can reject @Factory() calls in function templs.
 	a.structComponentFactories = collectStructComponentFactories(file)

--- a/internal/tuigen/analyzer_collisions.go
+++ b/internal/tuigen/analyzer_collisions.go
@@ -30,14 +30,22 @@ func (a *Analyzer) validateFunctionTemplCollisions(file *File, comp *Component, 
 	}
 	seen[comp.Name] = comp.Position
 
-	if hasTopLevelFunc(file.Decls, file.Funcs, comp.Name) {
+	if a.pkgCtx != nil && a.pkgCtx.HasTempl(comp.Name) {
+		a.errors.AddErrorf(comp.Position,
+			"duplicate templ %q (also defined in another file of this package)", comp.Name)
+		return
+	}
+
+	if hasTopLevelFunc(file.Decls, file.Funcs, comp.Name) ||
+		(a.pkgCtx != nil && a.pkgCtx.HasFunc(comp.Name)) {
 		a.errors.Add(NewErrorWithHint(comp.Position,
 			"templ \""+comp.Name+"\" conflicts with a Go function of the same name",
 			"rename the templ or the function"))
 	}
 
 	viewName := comp.Name + "View"
-	if hasTypeDecl(file.Decls, viewName) {
+	if hasTypeDecl(file.Decls, viewName) ||
+		(a.pkgCtx != nil && a.pkgCtx.HasType(viewName)) {
 		a.errors.Add(NewErrorWithHint(comp.Position,
 			"type \""+viewName+"\" conflicts with the view struct generated for templ \""+comp.Name+"\"",
 			"rename the type; the generator reserves the <Name>View suffix for function templs"))
@@ -53,7 +61,14 @@ func (a *Analyzer) validateMethodTemplCollisions(file *File, comp *Component, se
 	}
 	seen[typeName] = comp.Position
 
-	if hasUserMethod(file.Decls, file.Funcs, comp.ReceiverType, "Render") {
+	if a.pkgCtx != nil && a.pkgCtx.HasRenderTempl(typeName) {
+		a.errors.AddErrorf(comp.Position,
+			"duplicate Render templ for receiver type %s (also defined in another file of this package)", typeName)
+		return
+	}
+
+	if hasUserMethod(file.Decls, file.Funcs, comp.ReceiverType, "Render") ||
+		(a.pkgCtx != nil && a.pkgCtx.HasMethod(typeName, "Render")) {
 		a.errors.Add(NewErrorWithHint(comp.Position,
 			typeName+" already declares a Render method; the templ generates Render",
 			"remove the handwritten Render method or the templ"))

--- a/internal/tuigen/analyzer_collisions.go
+++ b/internal/tuigen/analyzer_collisions.go
@@ -1,0 +1,89 @@
+package tuigen
+
+import (
+	"regexp"
+	"strings"
+)
+
+// validateNameCollisions rejects declarations that would collide with
+// generated code. Without these checks the collisions still fail, but as raw
+// Go "redeclared" errors inside the generated file; catching them here points
+// the error at the .gsx source with a hint.
+func (a *Analyzer) validateNameCollisions(file *File) {
+	seenFuncTempl := make(map[string]Position)
+	seenMethodTempl := make(map[string]Position)
+
+	for _, comp := range file.Components {
+		if comp.Receiver == "" {
+			a.validateFunctionTemplCollisions(file, comp, seenFuncTempl)
+		} else {
+			a.validateMethodTemplCollisions(file, comp, seenMethodTempl)
+		}
+	}
+}
+
+func (a *Analyzer) validateFunctionTemplCollisions(file *File, comp *Component, seen map[string]Position) {
+	if first, ok := seen[comp.Name]; ok {
+		a.errors.AddErrorf(comp.Position,
+			"duplicate templ %q (first defined at %s)", comp.Name, first)
+		return
+	}
+	seen[comp.Name] = comp.Position
+
+	if hasTopLevelFunc(file.Decls, file.Funcs, comp.Name) {
+		a.errors.Add(NewErrorWithHint(comp.Position,
+			"templ \""+comp.Name+"\" conflicts with a Go function of the same name",
+			"rename the templ or the function"))
+	}
+
+	viewName := comp.Name + "View"
+	if hasTypeDecl(file.Decls, viewName) {
+		a.errors.Add(NewErrorWithHint(comp.Position,
+			"type \""+viewName+"\" conflicts with the view struct generated for templ \""+comp.Name+"\"",
+			"rename the type; the generator reserves the <Name>View suffix for function templs"))
+	}
+}
+
+func (a *Analyzer) validateMethodTemplCollisions(file *File, comp *Component, seen map[string]Position) {
+	typeName := strings.TrimPrefix(comp.ReceiverType, "*")
+	if first, ok := seen[typeName]; ok {
+		a.errors.AddErrorf(comp.Position,
+			"duplicate Render templ for receiver type %s (first defined at %s)", typeName, first)
+		return
+	}
+	seen[typeName] = comp.Position
+
+	if hasUserMethod(file.Decls, file.Funcs, comp.ReceiverType, "Render") {
+		a.errors.Add(NewErrorWithHint(comp.Position,
+			typeName+" already declares a Render method; the templ generates Render",
+			"remove the handwritten Render method or the templ"))
+	}
+}
+
+// hasTopLevelFunc reports whether the file declares a plain (receiver-less)
+// function with the given name.
+func hasTopLevelFunc(decls []*GoDecl, funcs []*GoFunc, name string) bool {
+	pattern := regexp.MustCompile(`func\s+` + regexp.QuoteMeta(name) + `\s*\(`)
+	for _, decl := range decls {
+		if decl.Kind == "func" && pattern.MatchString(decl.Code) {
+			return true
+		}
+	}
+	for _, fn := range funcs {
+		if pattern.MatchString(fn.Code) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasTypeDecl reports whether the file declares a type with the given name.
+func hasTypeDecl(decls []*GoDecl, name string) bool {
+	pattern := regexp.MustCompile(`type\s+` + regexp.QuoteMeta(name) + `\b`)
+	for _, decl := range decls {
+		if decl.Kind == "type" && pattern.MatchString(decl.Code) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tuigen/analyzer_collisions.go
+++ b/internal/tuigen/analyzer_collisions.go
@@ -73,6 +73,19 @@ func (a *Analyzer) validateMethodTemplCollisions(file *File, comp *Component, se
 			typeName+" already declares a Render method; the templ generates Render",
 			"remove the handwritten Render method or the templ"))
 	}
+
+	// The generator owns the unexported delegation helpers on templ receiver
+	// types. A user method with one of these names would collide with the
+	// emitted helper (or silently become the generated wrapper's delegation
+	// target), so the names are reserved outright.
+	for _, helper := range []string{"updatePropsFields", "bindAppFields", "unbindAppFields"} {
+		if hasUserMethod(file.Decls, file.Funcs, comp.ReceiverType, helper) ||
+			(a.pkgCtx != nil && a.pkgCtx.HasMethod(typeName, helper)) {
+			a.errors.Add(NewErrorWithHint(comp.Position,
+				typeName+" declares method \""+helper+"\", which is a reserved generated helper name",
+				"rename the method; the generator reserves updatePropsFields, bindAppFields, and unbindAppFields on templ receiver types"))
+		}
+	}
 }
 
 // hasTopLevelFunc reports whether the file declares a plain (receiver-less)

--- a/internal/tuigen/analyzer_collisions_test.go
+++ b/internal/tuigen/analyzer_collisions_test.go
@@ -1,0 +1,142 @@
+package tuigen
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAnalyzer_NameCollisions verifies that declarations colliding with
+// generated code are rejected at analysis time with an error pointing at the
+// .gsx source, instead of surfacing as a raw Go "redeclared" error inside the
+// generated file.
+func TestAnalyzer_NameCollisions(t *testing.T) {
+	type tc struct {
+		input         string
+		wantError     bool
+		errorContains string
+	}
+
+	tests := map[string]tc{
+		"templ conflicts with Go function of the same name": {
+			input: `package x
+
+func Foo() string { return "x" }
+
+templ Foo() {
+	<span>hi</span>
+}`,
+			wantError:     true,
+			errorContains: "conflicts with a Go function",
+		},
+		"duplicate function templ names": {
+			input: `package x
+
+templ Foo() {
+	<span>one</span>
+}
+
+templ Foo() {
+	<span>two</span>
+}`,
+			wantError:     true,
+			errorContains: "duplicate templ",
+		},
+		"handwritten Render method alongside a method templ": {
+			input: `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+type row struct{ v string }
+
+func (r *row) Render(app *tui.App) *tui.Element { return nil }
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}`,
+			wantError:     true,
+			errorContains: "already declares a Render method",
+		},
+		"user type collides with generated view struct": {
+			input: `package x
+
+type FooView struct{ n int }
+
+templ Foo() {
+	<span>hi</span>
+}`,
+			wantError:     true,
+			errorContains: "conflicts with the view struct",
+		},
+		"duplicate Render templs on the same receiver": {
+			input: `package x
+
+type row struct{ v string }
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}
+
+templ (r *row) Render() {
+	<span>again</span>
+}`,
+			wantError:     true,
+			errorContains: "duplicate Render templ",
+		},
+		"unrelated Go function name is fine": {
+			input: `package x
+
+func helper() string { return "x" }
+
+templ Foo() {
+	<span>hi</span>
+}`,
+			wantError: false,
+		},
+		"Render method on a different type is fine": {
+			input: `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+type other struct{}
+
+func (o *other) Render(app *tui.App) *tui.Element { return nil }
+
+type row struct{ v string }
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}`,
+			wantError: false,
+		},
+		"user type without the View suffix is fine": {
+			input: `package x
+
+type FooModel struct{ n int }
+
+templ Foo() {
+	<span>hi</span>
+}`,
+			wantError: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := AnalyzeFile("test.gsx", tt.input)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error, got nil")
+					return
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errorContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/tuigen/analyzer_collisions_test.go
+++ b/internal/tuigen/analyzer_collisions_test.go
@@ -140,3 +140,135 @@ templ Foo() {
 		})
 	}
 }
+
+// TestAnalyzer_CrossFileNameCollisions verifies the same collisions are
+// caught when the conflicting declaration lives in a sibling file of the
+// package, supplied via PackageContext.
+func TestAnalyzer_CrossFileNameCollisions(t *testing.T) {
+	type tc struct {
+		input         string
+		siblingGo     string // parsed as a sibling .go file
+		siblingGSX    string // parsed as a sibling .gsx file
+		wantError     bool
+		errorContains string
+	}
+
+	tests := map[string]tc{
+		"templ conflicts with function in sibling file": {
+			input: `package x
+
+templ Foo() {
+	<span>hi</span>
+}`,
+			siblingGo:     "package x\n\nfunc Foo() string { return \"x\" }",
+			wantError:     true,
+			errorContains: "conflicts with a Go function",
+		},
+		"templ duplicated in sibling gsx file": {
+			input: `package x
+
+templ Foo() {
+	<span>hi</span>
+}`,
+			siblingGSX: `package x
+
+templ Foo() {
+	<span>other</span>
+}`,
+			wantError:     true,
+			errorContains: "another file",
+		},
+		"view struct conflicts with type in sibling file": {
+			input: `package x
+
+templ Foo() {
+	<span>hi</span>
+}`,
+			siblingGo:     "package x\n\ntype FooView struct{ n int }",
+			wantError:     true,
+			errorContains: "conflicts with the view struct",
+		},
+		"handwritten Render in sibling file": {
+			input: `package x
+
+type row struct{ v string }
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}`,
+			siblingGo:     "package x\n\nimport tui \"github.com/grindlemire/go-tui\"\n\nfunc (r *row) Render(app *tui.App) *tui.Element { return nil }",
+			wantError:     true,
+			errorContains: "already declares a Render method",
+		},
+		"Render templ duplicated in sibling gsx file": {
+			input: `package x
+
+type row struct{ v string }
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}`,
+			siblingGSX: `package x
+
+templ (r *row) Render() {
+	<span>other</span>
+}`,
+			wantError:     true,
+			errorContains: "another file",
+		},
+		"unrelated sibling declarations are fine": {
+			input: `package x
+
+templ Foo() {
+	<span>hi</span>
+}`,
+			siblingGo: "package x\n\nfunc Bar() {}\n\ntype BarView struct{}",
+			wantError: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := NewPackageContext()
+			if tt.siblingGo != "" {
+				if err := ctx.AddGoSource("sibling.go", tt.siblingGo); err != nil {
+					t.Fatalf("AddGoSource failed: %v", err)
+				}
+			}
+			if tt.siblingGSX != "" {
+				lexer := NewLexer("sibling.gsx", tt.siblingGSX)
+				parser := NewParser(lexer)
+				sib, err := parser.ParseFile()
+				if err != nil {
+					t.Fatalf("sibling parse failed: %v", err)
+				}
+				ctx.AddGSXFile(sib)
+			}
+
+			lexer := NewLexer("test.gsx", tt.input)
+			parser := NewParser(lexer)
+			file, err := parser.ParseFile()
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+
+			analyzer := NewAnalyzer()
+			analyzer.SetPackageContext(ctx)
+			err = analyzer.Analyze(file)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error, got nil")
+					return
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errorContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/tuigen/analyzer_collisions_test.go
+++ b/internal/tuigen/analyzer_collisions_test.go
@@ -118,6 +118,68 @@ templ Foo() {
 }`,
 			wantError: false,
 		},
+		"reserved helper name updatePropsFields is rejected": {
+			input: `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+type row struct{ v string }
+
+func (r *row) updatePropsFields(fresh tui.Component) {}
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}`,
+			wantError:     true,
+			errorContains: "reserved generated helper name",
+		},
+		"reserved helper name bindAppFields is rejected": {
+			input: `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+type row struct{ v string }
+
+func (r *row) bindAppFields(app *tui.App) {}
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}`,
+			wantError:     true,
+			errorContains: "reserved generated helper name",
+		},
+		"reserved helper name on a type without a templ is fine": {
+			input: `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+type other struct{}
+
+func (o *other) updatePropsFields(fresh tui.Component) {}
+
+type row struct{ v string }
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}`,
+			wantError: false,
+		},
+		"calling the helper from an override is fine": {
+			input: `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+type row struct{ v string }
+
+func (r *row) UpdateProps(fresh tui.Component) {
+	r.updatePropsFields(fresh)
+}
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}`,
+			wantError: false,
+		},
 	}
 
 	for name, tt := range tests {
@@ -224,6 +286,18 @@ templ Foo() {
 }`,
 			siblingGo: "package x\n\nfunc Bar() {}\n\ntype BarView struct{}",
 			wantError: false,
+		},
+		"reserved helper name in sibling file is rejected": {
+			input: `package x
+
+type row struct{ v string }
+
+templ (r *row) Render() {
+	<span>{r.v}</span>
+}`,
+			siblingGo:     "package x\n\nimport tui \"github.com/grindlemire/go-tui\"\n\nfunc (r *row) unbindAppFields() {}",
+			wantError:     true,
+			errorContains: "reserved generated helper name",
 		},
 	}
 

--- a/internal/tuigen/generator.go
+++ b/internal/tuigen/generator.go
@@ -64,6 +64,11 @@ type Generator struct {
 	// Used to detect user-defined BindApp methods and avoid duplicate generation.
 	fileFuncs []*GoFunc
 
+	// pkgCtx holds declarations from sibling files of the package, so
+	// user-defined lifecycle methods declared outside this .gsx file also
+	// suppress generation. Nil when no context is available.
+	pkgCtx *PackageContext
+
 	// SkipImports uses format.Source instead of imports.Process (faster for tests)
 	SkipImports bool
 
@@ -102,6 +107,13 @@ func viewTypeName(componentName string) string {
 // NewGenerator creates a new code generator.
 func NewGenerator() *Generator {
 	return &Generator{}
+}
+
+// SetPackageContext supplies declarations from sibling files of the package.
+// User-defined lifecycle methods found there suppress generation the same as
+// declarations in the .gsx file itself.
+func (g *Generator) SetPackageContext(ctx *PackageContext) {
+	g.pkgCtx = ctx
 }
 
 // Generate produces Go source code from a parsed and analyzed AST.

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -503,24 +503,36 @@ func findStructDecl(decls []*GoDecl, typeName string) *GoDecl {
 	return nil
 }
 
-// hasUserBindAppMethod returns true when the source file already declares a
-// BindApp method on the receiver type.
-func hasUserBindAppMethod(decls []*GoDecl, funcs []*GoFunc, receiverType string) bool {
-	return hasUserMethod(decls, funcs, receiverType, "BindApp")
+// hasUserBindAppMethod returns true when the user already declares a BindApp
+// method on the receiver type, in this file or a sibling file of the package.
+func (g *Generator) hasUserBindAppMethod(receiverType string) bool {
+	return g.userDeclaresMethod(receiverType, "BindApp")
 }
 
-// hasUserUnbindAppMethod returns true when the source file already declares an
+// hasUserUnbindAppMethod returns true when the user already declares an
 // UnbindApp method on the receiver type. Kept distinct from BindApp detection
 // so that users who override BindApp alone still receive an auto-generated
 // UnbindApp (otherwise their Events fields would leak subscriptions).
-func hasUserUnbindAppMethod(decls []*GoDecl, funcs []*GoFunc, receiverType string) bool {
-	return hasUserMethod(decls, funcs, receiverType, "UnbindApp")
+func (g *Generator) hasUserUnbindAppMethod(receiverType string) bool {
+	return g.userDeclaresMethod(receiverType, "UnbindApp")
 }
 
-// hasUserUpdatePropsMethod returns true when the source file already declares
-// an UpdateProps method on the receiver type.
-func hasUserUpdatePropsMethod(decls []*GoDecl, funcs []*GoFunc, receiverType string) bool {
-	return hasUserMethod(decls, funcs, receiverType, "UpdateProps")
+// hasUserUpdatePropsMethod returns true when the user already declares an
+// UpdateProps method on the receiver type.
+func (g *Generator) hasUserUpdatePropsMethod(receiverType string) bool {
+	return g.userDeclaresMethod(receiverType, "UpdateProps")
+}
+
+// userDeclaresMethod reports whether the user declares the method on the
+// receiver type, checking the current file and any sibling-file context.
+func (g *Generator) userDeclaresMethod(receiverType, methodName string) bool {
+	if hasUserMethod(g.fileDecls, g.fileFuncs, receiverType, methodName) {
+		return true
+	}
+	if g.pkgCtx != nil {
+		return g.pkgCtx.HasMethod(strings.TrimPrefix(receiverType, "*"), methodName)
+	}
+	return false
 }
 
 func hasUserMethod(decls []*GoDecl, funcs []*GoFunc, receiverType, methodName string) bool {
@@ -580,7 +592,7 @@ func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 	// overrides can call it instead of hand-maintaining the copy list.
 	g.emitUpdatePropsFieldsHelper(comp, propFields)
 
-	if hasUserUpdatePropsMethod(decls, g.fileFuncs, comp.ReceiverType) {
+	if g.hasUserUpdatePropsMethod(comp.ReceiverType) {
 		// Still assert PropsUpdater so a user UpdateProps with the wrong
 		// signature fails at compile time instead of silently dropping
 		// prop refresh on cached components.
@@ -708,7 +720,7 @@ func (g *Generator) generateBindApp(comp *Component, decls []*GoDecl) {
 	// can call it instead of hand-maintaining the delegation list.
 	g.emitBindAppFieldsHelper(comp, appFields, bindableFields, componentBindFields)
 
-	if hasUserBindAppMethod(decls, g.fileFuncs, comp.ReceiverType) {
+	if g.hasUserBindAppMethod(comp.ReceiverType) {
 		return
 	}
 
@@ -806,7 +818,7 @@ func (g *Generator) generateUnbindApp(comp *Component, decls []*GoDecl) {
 	// Always emit the unbindAppFields helper.
 	g.emitUnbindAppFieldsHelper(comp, unbindFields, componentUnbindFields)
 
-	if hasUserUnbindAppMethod(decls, g.fileFuncs, comp.ReceiverType) {
+	if g.hasUserUnbindAppMethod(comp.ReceiverType) {
 		return
 	}
 

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -525,7 +525,8 @@ func hasUserUpdatePropsMethod(decls []*GoDecl, funcs []*GoFunc, receiverType str
 
 func hasUserMethod(decls []*GoDecl, funcs []*GoFunc, receiverType, methodName string) bool {
 	typeName := strings.TrimPrefix(receiverType, "*")
-	pattern := regexp.MustCompile(`func\s*\(\s*\w+\s+\*?` + regexp.QuoteMeta(typeName) + `\s*\)\s*` + regexp.QuoteMeta(methodName) + `\s*\(`)
+	// The receiver name is optional: func (*row) M() is legal Go.
+	pattern := regexp.MustCompile(`func\s*\(\s*(?:\w+\s+)?\*?` + regexp.QuoteMeta(typeName) + `\s*\)\s*` + regexp.QuoteMeta(methodName) + `\s*\(`)
 
 	for _, decl := range decls {
 		if decl.Kind == "func" && pattern.MatchString(decl.Code) {

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -580,6 +580,11 @@ func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 	g.emitUpdatePropsFieldsHelper(comp, propFields)
 
 	if hasUserUpdatePropsMethod(decls, g.fileFuncs, comp.ReceiverType) {
+		// Still assert PropsUpdater so a user UpdateProps with the wrong
+		// signature fails at compile time instead of silently dropping
+		// prop refresh on cached components.
+		g.writef("var _ tui.PropsUpdater = (*%s)(nil)\n", typeName)
+		g.writeln("")
 		return
 	}
 

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -517,6 +517,12 @@ func hasUserUnbindAppMethod(decls []*GoDecl, funcs []*GoFunc, receiverType strin
 	return hasUserMethod(decls, funcs, receiverType, "UnbindApp")
 }
 
+// hasUserUpdatePropsMethod returns true when the source file already declares
+// an UpdateProps method on the receiver type.
+func hasUserUpdatePropsMethod(decls []*GoDecl, funcs []*GoFunc, receiverType string) bool {
+	return hasUserMethod(decls, funcs, receiverType, "UpdateProps")
+}
+
 func hasUserMethod(decls []*GoDecl, funcs []*GoFunc, receiverType, methodName string) bool {
 	typeName := strings.TrimPrefix(receiverType, "*")
 	pattern := regexp.MustCompile(`func\s*\(\s*\w+\s+\*?` + regexp.QuoteMeta(typeName) + `\s*\)\s*` + regexp.QuoteMeta(methodName) + `\s*\(`)
@@ -536,6 +542,11 @@ func hasUserMethod(decls []*GoDecl, funcs []*GoFunc, receiverType, methodName st
 
 // generateUpdateProps generates an UpdateProps method for a method component.
 // This allows Mount to update cached component instances with fresh props.
+//
+// Like generateBindApp, the generator always emits an updatePropsFields helper
+// so a user-defined UpdateProps override can delegate the prop copying to it.
+// The public UpdateProps is only auto-generated when the user has not declared
+// their own; emitting it unconditionally would produce a duplicate method.
 func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 	// Find the struct declaration for this component's receiver type
 	structDecl := findStructDecl(decls, comp.ReceiverType)
@@ -564,6 +575,31 @@ func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 	// Get the receiver type name without pointer
 	typeName := strings.TrimPrefix(comp.ReceiverType, "*")
 
+	// Always emit the updatePropsFields helper so user-defined UpdateProps
+	// overrides can call it instead of hand-maintaining the copy list.
+	g.emitUpdatePropsFieldsHelper(comp, propFields)
+
+	if hasUserUpdatePropsMethod(decls, g.fileFuncs, comp.ReceiverType) {
+		return
+	}
+
+	// Auto-generate UpdateProps: a thin wrapper that calls the helper.
+	g.writef("func (%s) UpdateProps(fresh tui.Component) {\n", comp.Receiver)
+	g.indent++
+	g.writef("%s.updatePropsFields(fresh)\n", comp.ReceiverName)
+	g.indent--
+	g.writeln("}")
+	g.writeln("")
+
+	// Add a compile-time check that the type implements PropsUpdater
+	g.writef("var _ tui.PropsUpdater = (*%s)(nil)\n", typeName)
+	g.writeln("")
+}
+
+// emitUpdatePropsFieldsHelper writes the unexported updatePropsFields method
+// containing the actual prop copying: type-asserting fresh to the receiver
+// type and copying each prop field onto the receiver.
+func (g *Generator) emitUpdatePropsFieldsHelper(comp *Component, propFields []StructField) {
 	// Pick a local name for the type-asserted fresh component that does not
 	// shadow the receiver; shadowing would turn every prop copy below into a
 	// self-assignment.
@@ -572,8 +608,10 @@ func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 		freshName += "f"
 	}
 
-	// Generate UpdateProps method
-	g.writef("func (%s) UpdateProps(fresh tui.Component) {\n", comp.Receiver)
+	g.writef("// updatePropsFields is generated. It copies prop fields from fresh onto\n")
+	g.writef("// the receiver. When you override UpdateProps, call this helper instead\n")
+	g.writef("// of hand-maintaining the copy list.\n")
+	g.writef("func (%s) updatePropsFields(fresh tui.Component) {\n", comp.Receiver)
 	g.indent++
 	g.writef("%s, ok := fresh.(%s)\n", freshName, comp.ReceiverType)
 	g.writeln("if !ok {")
@@ -589,10 +627,6 @@ func (g *Generator) generateUpdateProps(comp *Component, decls []*GoDecl) {
 
 	g.indent--
 	g.writeln("}")
-	g.writeln("")
-
-	// Add a compile-time check that the type implements PropsUpdater
-	g.writef("var _ tui.PropsUpdater = (*%s)(nil)\n", typeName)
 	g.writeln("")
 }
 

--- a/internal/tuigen/generator_test.go
+++ b/internal/tuigen/generator_test.go
@@ -1472,3 +1472,94 @@ templ (l *fileList) Render() {
 		})
 	}
 }
+
+// TestGenerator_UserUpdatePropsSuppressesGenerated verifies that a
+// user-defined UpdateProps on the receiver type suppresses the generated
+// wrapper. Without the check, the generator emitted a second UpdateProps and
+// Go rejected the package with a duplicate-method error. The unexported
+// updatePropsFields helper is always emitted so overrides can delegate to it.
+func TestGenerator_UserUpdatePropsSuppressesGenerated(t *testing.T) {
+	type tc struct {
+		input           string
+		wantCount       map[string]int
+		wantContains    []string
+		wantNotContains []string
+	}
+
+	tests := map[string]tc{
+		"user-defined UpdateProps suppresses the generated wrapper": {
+			input: `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+type lifecycleRow struct {
+	value string
+}
+
+func (r *lifecycleRow) UpdateProps(fresh tui.Component) {
+	r.updatePropsFields(fresh)
+}
+
+templ (r *lifecycleRow) Render() {
+	<span>{r.value}</span>
+}`,
+			// The user's own method passes through to the output; the
+			// generator must not add a second one.
+			wantCount: map[string]int{
+				"func (r *lifecycleRow) UpdateProps(": 1,
+			},
+			wantContains: []string{
+				"func (r *lifecycleRow) updatePropsFields(fresh tui.Component) {",
+				"r.value = f.value",
+			},
+			wantNotContains: []string{
+				"var _ tui.PropsUpdater = (*lifecycleRow)(nil)",
+			},
+		},
+		"no user method generates wrapper delegating to helper": {
+			input: `package x
+
+type lifecycleRow struct {
+	value string
+}
+
+templ (r *lifecycleRow) Render() {
+	<span>{r.value}</span>
+}`,
+			wantCount: map[string]int{
+				"func (r *lifecycleRow) UpdateProps(": 1,
+			},
+			wantContains: []string{
+				"func (r *lifecycleRow) updatePropsFields(fresh tui.Component) {",
+				"r.updatePropsFields(fresh)",
+				"var _ tui.PropsUpdater = (*lifecycleRow)(nil)",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			output, err := parseAndGenerateSkipImports("test.gsx", tt.input)
+			if err != nil {
+				t.Fatalf("generation failed: %v", err)
+			}
+			code := string(output)
+
+			for substr, want := range tt.wantCount {
+				if got := strings.Count(code, substr); got != want {
+					t.Errorf("substring %q appears %d times, want %d\nGot:\n%s", substr, got, want, code)
+				}
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(code, want) {
+					t.Errorf("output missing expected string: %q\nGot:\n%s", want, code)
+				}
+			}
+			for _, notWant := range tt.wantNotContains {
+				if strings.Contains(code, notWant) {
+					t.Errorf("output contains unexpected string: %q\nGot:\n%s", notWant, code)
+				}
+			}
+		})
+	}
+}

--- a/internal/tuigen/generator_test.go
+++ b/internal/tuigen/generator_test.go
@@ -1511,8 +1511,9 @@ templ (r *lifecycleRow) Render() {
 			wantContains: []string{
 				"func (r *lifecycleRow) updatePropsFields(fresh tui.Component) {",
 				"r.value = f.value",
-			},
-			wantNotContains: []string{
+				// The assertion is still emitted so a wrong-signature user
+				// UpdateProps fails loudly instead of silently dropping
+				// prop refresh on cached components.
 				"var _ tui.PropsUpdater = (*lifecycleRow)(nil)",
 			},
 		},

--- a/internal/tuigen/generator_test.go
+++ b/internal/tuigen/generator_test.go
@@ -1473,6 +1473,56 @@ templ (l *fileList) Render() {
 	}
 }
 
+// TestHasUserMethod verifies user-method detection across the receiver forms
+// Go allows. Unnamed receivers are legal and must be detected, or the
+// generator emits a duplicate lifecycle method.
+func TestHasUserMethod(t *testing.T) {
+	type tc struct {
+		code string
+		want bool
+	}
+
+	tests := map[string]tc{
+		"named pointer receiver": {
+			code: "func (r *row) UpdateProps(fresh tui.Component) {}",
+			want: true,
+		},
+		"named value receiver": {
+			code: "func (r row) UpdateProps(fresh tui.Component) {}",
+			want: true,
+		},
+		"unnamed pointer receiver": {
+			code: "func (*row) UpdateProps(fresh tui.Component) {}",
+			want: true,
+		},
+		"unnamed value receiver": {
+			code: "func (row) UpdateProps(fresh tui.Component) {}",
+			want: true,
+		},
+		"method on another type": {
+			code: "func (r *other) UpdateProps(fresh tui.Component) {}",
+			want: false,
+		},
+		"type name is a prefix of another type": {
+			code: "func (r *rowExtra) UpdateProps(fresh tui.Component) {}",
+			want: false,
+		},
+		"plain function with the method name": {
+			code: "func UpdateProps(fresh tui.Component) {}",
+			want: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			funcs := []*GoFunc{{Code: tt.code}}
+			if got := hasUserMethod(nil, funcs, "*row", "UpdateProps"); got != tt.want {
+				t.Errorf("hasUserMethod(%q) = %v, want %v", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestGenerator_UserUpdatePropsSuppressesGenerated verifies that a
 // user-defined UpdateProps on the receiver type suppresses the generated
 // wrapper. Without the check, the generator emitted a second UpdateProps and

--- a/internal/tuigen/generator_test.go
+++ b/internal/tuigen/generator_test.go
@@ -1473,6 +1473,77 @@ templ (l *fileList) Render() {
 	}
 }
 
+// TestGenerator_PackageContextSuppressesLifecycleMethods verifies that a
+// lifecycle method declared in a sibling file of the package (via
+// PackageContext) suppresses the generated wrapper, the same as a
+// declaration in the .gsx file itself.
+func TestGenerator_PackageContextSuppressesLifecycleMethods(t *testing.T) {
+	input := `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+type row struct {
+	value  string
+	events *tui.Events[string]
+}
+
+templ (r *row) Render() {
+	<span>{r.value}</span>
+}
+`
+	sibling := `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+func (r *row) UpdateProps(fresh tui.Component) {
+	r.updatePropsFields(fresh)
+}
+
+func (r *row) UnbindApp() {
+	r.unbindAppFields()
+}
+`
+
+	lexer := NewLexer("test.gsx", input)
+	parser := NewParser(lexer)
+	file, err := parser.ParseFile()
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	ctx := NewPackageContext()
+	if err := ctx.AddGoSource("sibling.go", sibling); err != nil {
+		t.Fatalf("AddGoSource failed: %v", err)
+	}
+
+	gen := NewGenerator()
+	gen.SkipImports = true
+	gen.SetPackageContext(ctx)
+	output, err := gen.Generate(file, "test.gsx")
+	if err != nil {
+		t.Fatalf("generation failed: %v", err)
+	}
+	code := string(output)
+
+	if strings.Contains(code, "func (r *row) UpdateProps(") {
+		t.Errorf("generated UpdateProps despite sibling declaration\nGot:\n%s", code)
+	}
+	if strings.Contains(code, "func (r *row) UnbindApp(") {
+		t.Errorf("generated UnbindApp despite sibling declaration\nGot:\n%s", code)
+	}
+	// BindApp has no sibling declaration, so it is still generated, and the
+	// delegation helpers are always emitted.
+	for _, want := range []string{
+		"func (r *row) BindApp(app *tui.App) {",
+		"func (r *row) updatePropsFields(fresh tui.Component) {",
+		"func (r *row) unbindAppFields() {",
+	} {
+		if !strings.Contains(code, want) {
+			t.Errorf("output missing expected string: %q\nGot:\n%s", want, code)
+		}
+	}
+}
+
 // TestHasUserMethod verifies user-method detection across the receiver forms
 // Go allows. Unnamed receivers are legal and must be detected, or the
 // generator emits a duplicate lifecycle method.

--- a/internal/tuigen/package_context.go
+++ b/internal/tuigen/package_context.go
@@ -1,0 +1,210 @@
+package tuigen
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// PackageContext holds declarations from sibling files of the same package,
+// so generating or analyzing one .gsx file can detect collisions with code
+// declared elsewhere in the package. Callers decide which files to feed in;
+// generated files (*_gsx.go) and test files must be excluded, or the
+// generator would detect its own previous output as user code.
+type PackageContext struct {
+	methods         map[string]map[string]bool // type name -> method name
+	funcs           map[string]bool            // top-level function names
+	types           map[string]bool            // top-level type names
+	templs          map[string]bool            // function templ names
+	renderReceivers map[string]bool            // receiver types with a method templ
+}
+
+// NewPackageContext creates an empty package context.
+func NewPackageContext() *PackageContext {
+	return &PackageContext{
+		methods:         make(map[string]map[string]bool),
+		funcs:           make(map[string]bool),
+		types:           make(map[string]bool),
+		templs:          make(map[string]bool),
+		renderReceivers: make(map[string]bool),
+	}
+}
+
+// AddGoSource parses a sibling .go file and records its top-level methods,
+// functions, and types.
+func (c *PackageContext) AddGoSource(filename, src string) error {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, src, parser.SkipObjectResolution)
+	if err != nil {
+		return err
+	}
+	c.addParsedFile(f)
+	return nil
+}
+
+// AddGSXFile records the declarations a sibling .gsx file contributes to the
+// package: its top-level Go functions and types (which pass through to the
+// generated file), its function templ names, and the receiver types of its
+// method templs.
+func (c *PackageContext) AddGSXFile(file *File) {
+	for _, fn := range file.Funcs {
+		// GoFunc.Code is a complete declaration; parse it as a tiny file so
+		// method receivers are extracted accurately (not by regex). Snippets
+		// that fail to parse are skipped; the sibling reports its own errors.
+		c.addSnippet(fn.Code)
+	}
+	for _, decl := range file.Decls {
+		c.addSnippet(decl.Code)
+	}
+	for _, comp := range file.Components {
+		if comp.Receiver == "" {
+			c.templs[comp.Name] = true
+		} else {
+			c.renderReceivers[strings.TrimPrefix(comp.ReceiverType, "*")] = true
+		}
+	}
+}
+
+// HasMethod reports whether a sibling file declares the method on the type.
+func (c *PackageContext) HasMethod(typeName, methodName string) bool {
+	return c.methods[typeName][methodName]
+}
+
+// HasFunc reports whether a sibling file declares a top-level function.
+func (c *PackageContext) HasFunc(name string) bool {
+	return c.funcs[name]
+}
+
+// HasType reports whether a sibling file declares a type.
+func (c *PackageContext) HasType(name string) bool {
+	return c.types[name]
+}
+
+// HasTempl reports whether a sibling .gsx file declares a function templ.
+func (c *PackageContext) HasTempl(name string) bool {
+	return c.templs[name]
+}
+
+// HasRenderTempl reports whether a sibling .gsx file declares a method templ
+// for the receiver type.
+func (c *PackageContext) HasRenderTempl(typeName string) bool {
+	return c.renderReceivers[typeName]
+}
+
+// generatedHeader matches the standard Go generated-file marker
+// (https://go.dev/s/generatedcode) before the package clause.
+var generatedHeader = regexp.MustCompile(`(?m)^// Code generated .* DO NOT EDIT\.$`)
+
+// AddDirectory scans dir and adds every sibling source the context should
+// know about: plain .go files and .gsx files. Always excluded: generated
+// files (by _gsx.go suffix or generated-code header, so the generator never
+// treats its own previous output as user code) and _test.go files (a
+// test-only method must not suppress a method production builds need).
+// skip filters further by filename; callers use it to exclude the file being
+// processed and files they source elsewhere (e.g. open editor buffers).
+// Siblings that fail to parse are skipped; they report their own errors when
+// processed. Errors reading the directory degrade to no additions.
+func (c *PackageContext) AddDirectory(dir string, skip func(filename string) bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || (skip != nil && skip(name)) {
+			continue
+		}
+
+		switch {
+		case strings.HasSuffix(name, ".gsx"):
+			source, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				continue
+			}
+			lexer := NewLexer(name, string(source))
+			parser := NewParser(lexer)
+			file, err := parser.ParseFile()
+			if err != nil || file == nil {
+				continue
+			}
+			c.AddGSXFile(file)
+
+		case strings.HasSuffix(name, ".go"):
+			if strings.HasSuffix(name, "_gsx.go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			source, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil || isGeneratedFile(source) {
+				continue
+			}
+			_ = c.AddGoSource(name, string(source))
+		}
+	}
+}
+
+// isGeneratedFile reports whether the source carries a generated-code header
+// before its package clause.
+func isGeneratedFile(source []byte) bool {
+	src := source
+	if idx := strings.Index(string(source), "\npackage "); idx >= 0 {
+		src = source[:idx]
+	}
+	return generatedHeader.Match(src)
+}
+
+func (c *PackageContext) addSnippet(code string) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "snippet.go", "package _\n"+code, parser.SkipObjectResolution)
+	if err != nil {
+		return
+	}
+	c.addParsedFile(f)
+}
+
+func (c *PackageContext) addParsedFile(f *ast.File) {
+	for _, decl := range f.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Recv == nil || len(d.Recv.List) == 0 {
+				c.funcs[d.Name.Name] = true
+				continue
+			}
+			if typeName := receiverTypeName(d.Recv.List[0].Type); typeName != "" {
+				if c.methods[typeName] == nil {
+					c.methods[typeName] = make(map[string]bool)
+				}
+				c.methods[typeName][d.Name.Name] = true
+			}
+		case *ast.GenDecl:
+			if d.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range d.Specs {
+				if ts, ok := spec.(*ast.TypeSpec); ok {
+					c.types[ts.Name.Name] = true
+				}
+			}
+		}
+	}
+}
+
+// receiverTypeName extracts the base type name from a receiver expression,
+// unwrapping pointers and generic type parameters.
+func receiverTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return receiverTypeName(t.X)
+	case *ast.IndexExpr:
+		return receiverTypeName(t.X)
+	case *ast.IndexListExpr:
+		return receiverTypeName(t.X)
+	}
+	return ""
+}

--- a/internal/tuigen/package_context_test.go
+++ b/internal/tuigen/package_context_test.go
@@ -1,0 +1,160 @@
+package tuigen
+
+import (
+	"testing"
+)
+
+func TestPackageContext_AddGoSource(t *testing.T) {
+	type tc struct {
+		src            string
+		wantMethods    map[string][]string // type -> methods present
+		wantNotMethods map[string][]string // type -> methods absent
+		wantFuncs      []string
+		wantTypes      []string
+	}
+
+	tests := map[string]tc{
+		"pointer receiver method": {
+			src: `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+func (r *row) UpdateProps(fresh tui.Component) {}`,
+			wantMethods: map[string][]string{"row": {"UpdateProps"}},
+		},
+		"value receiver method": {
+			src: `package x
+
+func (r row) BindApp(app *App) {}`,
+			wantMethods: map[string][]string{"row": {"BindApp"}},
+		},
+		"unnamed receiver method": {
+			src: `package x
+
+func (*row) UnbindApp() {}`,
+			wantMethods: map[string][]string{"row": {"UnbindApp"}},
+		},
+		"generic receiver method": {
+			src: `package x
+
+func (r *box[T]) UpdateProps(fresh Component) {}`,
+			wantMethods: map[string][]string{"box": {"UpdateProps"}},
+		},
+		"plain function is not a method": {
+			src: `package x
+
+func UpdateProps() {}`,
+			wantFuncs:      []string{"UpdateProps"},
+			wantNotMethods: map[string][]string{"row": {"UpdateProps"}},
+		},
+		"type declarations including grouped": {
+			src: `package x
+
+type FooView struct{ n int }
+
+type (
+	BarView int
+	other   string
+)`,
+			wantTypes: []string{"FooView", "BarView", "other"},
+		},
+		"method mentioned only in a comment is ignored": {
+			src: `package x
+
+// func (r *row) UpdateProps(fresh tui.Component) {}
+func helper() {}`,
+			wantFuncs:      []string{"helper"},
+			wantNotMethods: map[string][]string{"row": {"UpdateProps"}},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := NewPackageContext()
+			if err := ctx.AddGoSource("sibling.go", tt.src); err != nil {
+				t.Fatalf("AddGoSource failed: %v", err)
+			}
+
+			for typeName, methods := range tt.wantMethods {
+				for _, m := range methods {
+					if !ctx.HasMethod(typeName, m) {
+						t.Errorf("HasMethod(%q, %q) = false, want true", typeName, m)
+					}
+				}
+			}
+			for typeName, methods := range tt.wantNotMethods {
+				for _, m := range methods {
+					if ctx.HasMethod(typeName, m) {
+						t.Errorf("HasMethod(%q, %q) = true, want false", typeName, m)
+					}
+				}
+			}
+			for _, f := range tt.wantFuncs {
+				if !ctx.HasFunc(f) {
+					t.Errorf("HasFunc(%q) = false, want true", f)
+				}
+			}
+			for _, ty := range tt.wantTypes {
+				if !ctx.HasType(ty) {
+					t.Errorf("HasType(%q) = false, want true", ty)
+				}
+			}
+		})
+	}
+}
+
+func TestPackageContext_AddGoSource_ParseError(t *testing.T) {
+	ctx := NewPackageContext()
+	if err := ctx.AddGoSource("bad.go", "package x\nfunc ("); err == nil {
+		t.Error("expected parse error, got nil")
+	}
+}
+
+func TestPackageContext_AddGSXFile(t *testing.T) {
+	input := `package x
+
+import tui "github.com/grindlemire/go-tui"
+
+type helper struct{}
+
+func topLevel() string { return "x" }
+
+func (h *helper) UpdateProps(fresh tui.Component) {}
+
+templ FnTempl() {
+	<span>hi</span>
+}
+
+templ (h *helper) Render() {
+	<span>hi</span>
+}`
+
+	lexer := NewLexer("sibling.gsx", input)
+	parser := NewParser(lexer)
+	file, err := parser.ParseFile()
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	ctx := NewPackageContext()
+	ctx.AddGSXFile(file)
+
+	if !ctx.HasFunc("topLevel") {
+		t.Error("HasFunc(topLevel) = false, want true")
+	}
+	if !ctx.HasType("helper") {
+		t.Error("HasType(helper) = false, want true")
+	}
+	if !ctx.HasMethod("helper", "UpdateProps") {
+		t.Error("HasMethod(helper, UpdateProps) = false, want true")
+	}
+	if !ctx.HasTempl("FnTempl") {
+		t.Error("HasTempl(FnTempl) = false, want true")
+	}
+	if !ctx.HasRenderTempl("helper") {
+		t.Error("HasRenderTempl(helper) = false, want true")
+	}
+	if ctx.HasTempl("helper") {
+		t.Error("HasTempl(helper) = true, want false (method templ, not function templ)")
+	}
+}


### PR DESCRIPTION
## Summary

A receiver-method templ generates three lifecycle methods on the receiver type: `UpdateProps`, `BindApp`, and `UnbindApp`. BindApp and UnbindApp check whether the source file already declares the method and skip generation when it does, but UpdateProps was emitted unconditionally. Hand-writing `UpdateProps` on a receiver component (a documented extension point via the `PropsUpdater` interface) therefore failed to compile with "method already declared". The diagnosis in #114 was accurate.

## The fix

`generateUpdateProps` now uses the same user-method detection as BindApp/UnbindApp and skips the generated wrapper when the user owns the method. Following the `bindAppFields` pattern, the prop-copy logic moved into an always-emitted unexported `updatePropsFields` helper, so a handwritten override can delegate the copying and add custom behavior on top:

```go
func (r *lifecycleRow) UpdateProps(fresh tui.Component) {
    r.updatePropsFields(fresh)
    // custom behavior here
}
```

The `var _ tui.PropsUpdater` compile-time assertion is still emitted even when the user owns the method. Without it, an `UpdateProps` with the wrong signature would compile and the mount system would silently stop refreshing cached props (`mount.go` type-asserts and skips on failure). With it, the mistake is a clear interface error at build time.

All checked-in generated files were regenerated; their diffs are purely mechanical (the copy loop moved into `updatePropsFields` and a thin wrapper was added).

## Related hardening

Auditing for siblings of this bug turned up more issues in the same territory, fixed here because they share the detection code and failure mode:

- The `hasUserMethod` regex required a named receiver, so a legal unnamed declaration like `func (*row) UpdateProps(fresh tui.Component)` escaped detection and still hit the duplicate-method error. The receiver name is now optional in the pattern, which fixes detection for all three lifecycle methods at once.
- Declarations that collide with generated code used to surface as raw Go "redeclared" errors inside the generated `_gsx.go` file. The analyzer now rejects them at `tui generate`/`tui check` time with errors pointing at the `.gsx` source: a templ sharing a name with a Go function, duplicate templs, a handwritten `Render` next to a method templ, and a user type named `<Name>View`.

The interfaces reference now documents the generated lifecycle methods, the override rule, the delegation helpers, and the reserved names (`updatePropsFields`, `bindAppFields`, `unbindAppFields`, and the `<Name>View` suffix). The reserved helper names are enforced: declaring a method with one of those names on a templ receiver type is an analyzer error, since suppressing the generated helper instead would silently make a coincidentally named user method the wrapper's delegation target.

## Cross-file detection

Detection previously scanned only the `.gsx` file being processed, so a lifecycle method declared in a plain `.go` file of the same package still collided. A new `PackageContext` collects sibling declarations, using `go/parser` for `.go` files (so a method mentioned in a comment does not count) and the tuigen parser for `.gsx` files. Both the generator's user-method detection and the analyzer's collision checks consult it, which also catches cross-file variants of the collisions above (a duplicate templ in another `.gsx` file, a conflicting function or `<Name>View` type in a sibling `.go` file).

Two exclusions keep this sound. Generated files (by `_gsx.go` suffix or the standard generated-code header) are skipped, otherwise the second `tui generate` run would treat the first run's output as user code and flip-flop; an integration test pins generate-twice stability. Test files are skipped so a `_test.go`-only method cannot suppress a method production builds need.

`tui generate` and `tui check` build the context from the file's directory. The LSP builds it per document and prefers open editor buffers for sibling `.gsx` files, so unsaved edits are seen. One consequence to know about: generation now depends on sibling files, so after adding or removing a lifecycle method in a `.go` file, rerun `tui generate`. This is documented in the interfaces reference.

## Scope note

An embedded struct's promoted lifecycle method is still silently shadowed by the generated one; suppressing generation there would break prop copying differently (the embedded method cannot see the outer struct's fields), so that needs a design discussion rather than a quiet change. Left for a follow-up.

Fixes #114
