### PR TITLE
fix: reject component factory calls returning tui.Component in function templs

### DIFF
--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -55,7 +55,7 @@ templ UserList(users []string, maxVisible int) {
 }
 ```
 
-Pure components cannot host constructs that mount against a receiver: the component elements (`<input>`, `<textarea>`, `<modal>`, `<markdown>`), `@expr` component expressions, and `@Factory()` calls that return a struct component. Put those in a struct method component, which supplies the receiver they mount against. `tui generate` reports an error with a message pointing at the fix if you use one in a pure component.
+Pure components cannot host constructs that mount against a receiver: the component elements (`<input>`, `<textarea>`, `<modal>`, `<markdown>`), `@expr` component expressions, and `@Factory()` calls that return a component (a struct component, a `tui.Component`, or a type whose `Render` method is written in plain Go). Put those in a struct method component, which supplies the receiver they mount against. `tui generate` reports an error with a message pointing at the fix if you use one in a pure component.
 
 ### Children slot
 

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -75,9 +75,10 @@ type Analyzer struct {
 	currentComponent *Component
 
 	// structComponentFactories holds the names of local functions that return a
-	// struct-component type (a `func Name(...) *T` where T has a method templ).
-	// Calling one via @Name() in a function templ generates broken code, so the
-	// set lets analyzeComponentCall reject it.
+	// component: a struct-component receiver type, a type with a plain-Go
+	// Render(...) *tui.Element method, or the tui.Component interface (see
+	// collectStructComponentFactories). Calling one via @Name() in a function
+	// templ generates broken code, so the set lets analyzeComponentCall reject it.
 	structComponentFactories map[string]bool
 }
 
@@ -600,7 +601,7 @@ func collectStructComponentFactories(file *File, tuiAlias string) map[string]boo
 	// A type whose Render(...) *tui.Element method is written in plain Go is a
 	// component too; mounting is the only way to use it from a templ.
 	renderPattern := regexp.MustCompile(
-		`^func\s*\(\s*\w+\s+\*?(\w+)\s*\)\s*Render\s*\([^)]*\)\s*\*` + regexp.QuoteMeta(tuiAlias) + `\.Element\s*\{`)
+		`^func\s*\(\s*(?:\w+\s+)?\*?(\w+)\s*\)\s*Render\s*\([^)]*\)\s*\*` + regexp.QuoteMeta(tuiAlias) + `\.Element\s*\{`)
 	for _, fn := range file.Funcs {
 		if m := renderPattern.FindStringSubmatch(strings.TrimSpace(fn.Code)); m != nil {
 			structTypes[m[1]] = true

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -260,7 +260,7 @@ func (a *Analyzer) Analyze(file *File) error {
 
 	// Resolve which local factory functions return a struct component, so
 	// analyzeComponentCall can reject @Factory() calls in function templs.
-	a.structComponentFactories = collectStructComponentFactories(file)
+	a.structComponentFactories = collectStructComponentFactories(file, a.getTUIAlias())
 
 	// Validate method templs using {children...} have a children field on their struct
 	for _, comp := range file.Components {
@@ -585,9 +585,11 @@ func (a *Analyzer) analyzeComponentCall(call *ComponentCall) {
 var factoryReturnPattern = regexp.MustCompile(`^func\s+(\w+)\s*\([^{]*?\)\s*(\*?[\w.]+)\s*\{`)
 
 // collectStructComponentFactories returns the names of local functions whose
-// return type is a struct-component receiver type (a type with a method templ).
-// These are the @Name() calls that only work inside a struct component.
-func collectStructComponentFactories(file *File) map[string]bool {
+// return type is a component: a struct-component receiver type (a type with a
+// method templ), a type whose Render method is written in plain Go, or the
+// tui.Component interface itself (issue #115). These are the @Name() calls
+// that only work inside a struct component.
+func collectStructComponentFactories(file *File, tuiAlias string) map[string]bool {
 	structTypes := make(map[string]bool)
 	for _, comp := range file.Components {
 		if comp.Receiver != "" {
@@ -595,16 +597,24 @@ func collectStructComponentFactories(file *File) map[string]bool {
 		}
 	}
 
-	factories := make(map[string]bool)
-	if len(structTypes) == 0 {
-		return factories
+	// A type whose Render(...) *tui.Element method is written in plain Go is a
+	// component too; mounting is the only way to use it from a templ.
+	renderPattern := regexp.MustCompile(
+		`^func\s*\(\s*\w+\s+\*?(\w+)\s*\)\s*Render\s*\([^)]*\)\s*\*` + regexp.QuoteMeta(tuiAlias) + `\.Element\s*\{`)
+	for _, fn := range file.Funcs {
+		if m := renderPattern.FindStringSubmatch(strings.TrimSpace(fn.Code)); m != nil {
+			structTypes[m[1]] = true
+		}
 	}
+
+	componentIface := tuiAlias + ".Component"
+	factories := make(map[string]bool)
 	for _, fn := range file.Funcs {
 		m := factoryReturnPattern.FindStringSubmatch(strings.TrimSpace(fn.Code))
 		if m == nil {
 			continue
 		}
-		if structTypes[strings.TrimPrefix(m[2], "*")] {
+		if m[2] == componentIface || structTypes[strings.TrimPrefix(m[2], "*")] {
 			factories[m[1]] = true
 		}
 	}

--- a/internal/tuigen/analyzer_component_element_test.go
+++ b/internal/tuigen/analyzer_component_element_test.go
@@ -224,6 +224,144 @@ templ (h *host) Render() {
 	}
 }
 
+// A @Factory() call whose factory returns tui.Component (or a local type whose
+// Render method is written in plain Go) also mounts, so it is just as invalid in
+// a function templ as a struct-component factory (issue #115). The analyzer
+// rejects these while leaving method-templ usage alone.
+func TestAnalyzer_ComponentFactoryCallRequiresReceiver(t *testing.T) {
+	type tc struct {
+		input         string
+		wantError     bool
+		errorContains string
+		hintContains  string
+	}
+
+	// Shared preamble: a plain-Go component `row` with an interface factory.
+	const ifaceFactory = `package x
+type row struct{}
+func NewRow() tui.Component { return &row{} }
+func (r *row) Render(*tui.App) *tui.Element {
+	return tui.New(tui.WithText("row"))
+}
+`
+
+	tests := map[string]tc{
+		"factory returning tui.Component in function templ errors": {
+			input: ifaceFactory + `templ Field() {
+	@NewRow()
+}`,
+			wantError:     true,
+			errorContains: "@NewRow() mounts a struct component and can only be used inside a struct component",
+			hintContains:  "give Field a receiver",
+		},
+		"factory returning aliased Component in function templ errors": {
+			input: `package x
+import gotui "github.com/grindlemire/go-tui"
+type row struct{}
+func NewRow() gotui.Component { return &row{} }
+func (r *row) Render(*gotui.App) *gotui.Element {
+	return gotui.New(gotui.WithText("row"))
+}
+templ Field() {
+	@NewRow()
+}`,
+			wantError:     true,
+			errorContains: "@NewRow() mounts a struct component and can only be used inside a struct component",
+		},
+		"factory returning plain-Go component pointer in function templ errors": {
+			input: `package x
+type row struct{}
+func NewRow() *row { return &row{} }
+func (r *row) Render(app *tui.App) *tui.Element {
+	return tui.New(tui.WithText("row"))
+}
+templ Field() {
+	@NewRow()
+}`,
+			wantError:     true,
+			errorContains: "@NewRow() mounts a struct component and can only be used inside a struct component",
+		},
+		"factory returning plain-Go component value in function templ errors": {
+			input: `package x
+type row struct{}
+func NewRow() row { return row{} }
+func (r row) Render(*tui.App) *tui.Element {
+	return tui.New(tui.WithText("row"))
+}
+templ Field() {
+	@NewRow()
+}`,
+			wantError:     true,
+			errorContains: "@NewRow() mounts a struct component and can only be used inside a struct component",
+		},
+		"factory returning tui.Component in let binding in function templ errors": {
+			input: ifaceFactory + `templ Field() {
+	r := @NewRow()
+	<div>{r}</div>
+}`,
+			wantError:     true,
+			errorContains: "@NewRow() mounts a struct component and can only be used inside a struct component",
+		},
+		"factory returning tui.Component in method templ is allowed": {
+			input: ifaceFactory + `type host struct{}
+templ (h *host) Render() {
+	<div>@NewRow()</div>
+}`,
+			wantError: false,
+		},
+		"factory returning plain-Go component in method templ is allowed": {
+			input: `package x
+type row struct{}
+func NewRow() *row { return &row{} }
+func (r *row) Render(*tui.App) *tui.Element {
+	return tui.New(tui.WithText("row"))
+}
+type host struct{}
+templ (h *host) Render() {
+	<div>@NewRow()</div>
+}`,
+			wantError: false,
+		},
+		"helper with Render-free return type is not flagged": {
+			input: `package x
+type stats struct{}
+func Stats() *stats { return &stats{} }
+func (s *stats) Render(indent int) string { return "" }
+templ Page() {
+	<div>hi</div>
+}`,
+			wantError: false,
+		},
+		"factory returning tui.Component in a go expression is not flagged": {
+			input: ifaceFactory + `templ Page() {
+	<div>{NewRow()}</div>
+}`,
+			wantError: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := AnalyzeFile("test.gsx", tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errorContains)
+				}
+				if tt.hintContains != "" && !strings.Contains(err.Error(), tt.hintContains) {
+					t.Errorf("error %q does not contain hint %q", err.Error(), tt.hintContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
 // A @Factory() call that returns a struct component mounts via app.Mount against
 // the caller's receiver. In a function templ the generator instead emits a plain
 // call and reads .Root on a type that has none. The analyzer rejects the call in

--- a/internal/tuigen/analyzer_component_element_test.go
+++ b/internal/tuigen/analyzer_component_element_test.go
@@ -281,6 +281,19 @@ templ Field() {
 			wantError:     true,
 			errorContains: "@NewRow() mounts a struct component and can only be used inside a struct component",
 		},
+		"factory returning component with unnamed receiver Render in function templ errors": {
+			input: `package x
+type row struct{}
+func NewRow() *row { return &row{} }
+func (*row) Render(*tui.App) *tui.Element {
+	return tui.New(tui.WithText("row"))
+}
+templ Field() {
+	@NewRow()
+}`,
+			wantError:     true,
+			errorContains: "@NewRow() mounts a struct component and can only be used inside a struct component",
+		},
 		"factory returning plain-Go component value in function templ errors": {
 			input: `package x
 type row struct{}


### PR DESCRIPTION
## Summary

Calling `@NewRow()` in a function templ, where `NewRow` is a plain Go function returning `tui.Component`, passed `tui generate` but produced Go that fails to compile with `__tui_0.GetWatchers undefined` and `__tui_0.Root undefined`. The generator assumes any `@Name()` call in a function templ returns a generated view struct and reads `.Root` and `.GetWatchers()` on the result, which the `tui.Component` interface does not have.

#112 added the analyzer check for exactly this class of mistake, but it only recognized factories returning a local type with a method templ. Two factory shapes slipped through to the same broken codegen path: functions returning the `tui.Component` interface, and functions returning a type whose `Render` method is written in plain Go rather than as a method templ.

## The fix

`collectStructComponentFactories` now also flags local functions that return `tui.Component` (resolved through the file's import alias) and local functions returning a type with a plain-Go `Render(...) *tui.Element` method, including unnamed receivers. These calls get the same generate-time error as struct-component factories, in both the `@NewRow()` and `x := @NewRow()` forms:

```
repro.gsx:14:2: error: @NewRow() mounts a struct component and can only be used inside a struct component (NewRow returns a struct component; give Field a receiver, e.g. templ (c *T) Render() { ... })
```

The same call inside a method templ is untouched. It already generates `app.Mount(...)` and compiles, so a struct component remains the supported way to mount a hand-written component, and the error hint points there. The GSX reference now mentions the broader factory rule.

Two things stay out of scope. Factories defined in other packages are invisible to the per-file analyzer, so those still surface as a Go compile error. And the `@component(...)`/`@mount(...)` primitive requested in the issue would require mounting inside function templs, which means deferring view construction until an app exists; that deserves its own design discussion on the issue rather than riding along with a diagnostics fix.

Fixes #115
