### PR TITLE
fix(tui): eliminate inline-mode resize ghosts by clearing the union of old/new viewport areas

### DIFF
--- a/app.go
+++ b/app.go
@@ -61,6 +61,7 @@ type App struct {
 	// Inline mode (set via WithInlineHeight)
 	inlineHeight       int               // Number of rows for inline widget (0 = full screen mode)
 	inlineStartRow     int               // Terminal row where inline region starts (calculated at init)
+	prevInlineStartRow int               // Start row of the previous full redraw (-1 = unset); used to clear the union of old/new viewport areas on resize
 	inlineStartupMode  InlineStartupMode // Startup behavior for inline viewport ownership
 	inlineLayout       inlineLayoutState
 	inlineSession      *inlineSession

--- a/app_options.go
+++ b/app_options.go
@@ -192,6 +192,7 @@ func WithInlineHeight(rows int) AppOption {
 			return fmt.Errorf("inline height must be at least 1 row")
 		}
 		a.inlineHeight = rows
+		a.prevInlineStartRow = -1
 		return nil
 	}
 }

--- a/app_render.go
+++ b/app_render.go
@@ -1,7 +1,5 @@
 package tui
 
-import "github.com/grindlemire/go-tui/internal/debug"
-
 // Render performs layout and renders to the terminal if the dirty flag is set.
 // No-op if nothing has changed since the last render. After rendering, the
 // dispatch table is rebuilt from the current component tree.
@@ -25,20 +23,26 @@ func (a *App) renderFrame() {
 		renderHeight = a.inlineHeight
 	}
 
-	// Ensure buffer matches expected size (handles rapid resize)
-	if a.buffer.Width() != width || a.buffer.Height() != renderHeight {
-		if a.inAlternateScreen {
-			// Alternate screen mode: always use full-screen sizing
-			a.terminal.Clear()
-			a.buffer.Resize(width, termHeight)
-		} else if a.inlineHeight > 0 {
-			// Inline mode: keep buffer height fixed to inlineHeight.
+	// Ensure buffer matches expected size (handles rapid resize).
+	// Inline mode additionally re-syncs geometry whenever the live terminal
+	// height differs from the current inlineStartRow, even if the ResizeEvent
+	// for this frame has not been dispatched yet. Without this, the composer
+	// can be drawn at a stale row while the terminal has already grown/shrunk,
+	// leaving the old band behind (the resize-ghost bug). Any geometry change
+	// implies a full redraw so stale rows outside the new viewport get cleared.
+	if !a.inAlternateScreen && a.inlineHeight > 0 {
+		wantStart := termHeight - a.inlineHeight
+		if a.inlineStartRow != wantStart || a.buffer.Width() != width {
 			a.syncInlineGeometryOnResize(width, termHeight)
-		} else {
-			// Full screen mode: clear terminal and resize buffer
-			a.terminal.Clear()
-			a.buffer.Resize(width, termHeight)
+			if a.root != nil {
+				a.root.MarkDirty()
+			}
+			a.needsFullRedraw = true
 		}
+	} else if a.buffer.Width() != width || a.buffer.Height() != renderHeight {
+		// Alternate screen / full screen mode: clear and resize buffer
+		a.terminal.Clear()
+		a.buffer.Resize(width, termHeight)
 		if a.root != nil {
 			a.root.MarkDirty()
 		}
@@ -149,6 +153,14 @@ func (a *App) placeCursor() {
 
 // renderInline handles rendering for inline mode by offsetting Y coordinates.
 func (a *App) renderInline() {
+	// Wrap the whole frame in a synchronized update (DEC 2026). Terminals that
+	// support it buffer the complete frame before painting, so resize drags do
+	// not flash partially-rendered intermediate states. Unsupported terminals
+	// simply ignore the private mode sequences. Mirrors Codex's
+	// stdout().sync_update().
+	a.terminal.WriteDirect([]byte("\x1b[?2026h"))
+	defer a.terminal.WriteDirect([]byte("\x1b[?2026l"))
+
 	var changes []CellChange
 
 	if a.needsFullRedraw {
@@ -162,12 +174,22 @@ func (a *App) renderInline() {
 				changes = append(changes, CellChange{X: x, Y: y + a.inlineStartRow, Cell: cell})
 			}
 		}
-		// Clear only the inline region, not the whole screen
-		debug.Log("renderInline: fullRedraw — SetCursor(0, %d), ClearToEnd, flushing %dx%d cells at Y offset %d",
-			a.inlineStartRow, width, height, a.inlineStartRow)
-		a.terminal.SetCursor(0, a.inlineStartRow)
+		// Clear the union of the previous and current viewport areas before
+		// repainting. Clearing only from the new start row left the old
+		// composer band above the new viewport whenever the terminal grew
+		// (resize ghosts). Codex clears the same union via
+		// clear_after_position(min(old.y, new.y)).
+		if a.prevInlineStartRow < 0 {
+			a.prevInlineStartRow = a.inlineStartRow
+		}
+		clearFrom := a.inlineStartRow
+		if a.prevInlineStartRow < clearFrom {
+			clearFrom = a.prevInlineStartRow
+		}
+		a.terminal.SetCursor(0, clearFrom)
 		a.terminal.ClearToEnd()
 		a.needsFullRedraw = false
+		a.prevInlineStartRow = a.inlineStartRow
 	} else {
 		// Get diff and offset Y coordinates
 		diff := a.buffer.Diff()
@@ -186,6 +208,17 @@ func (a *App) renderInline() {
 		a.terminal.Flush(changes)
 	}
 	a.buffer.Swap()
+}
+
+// ForceFullRedraw marks the next inline render as a full repaint of the whole
+// viewport, independent of the buffer diff. This is useful after raw terminal
+// operations (e.g. clearing scrollback or replaying history outside the app)
+// so the composer is repainted even though the buffer diff would otherwise be
+// empty. Unlike RenderFull, it stays within inline mode and does not draw at
+// full-screen coordinates.
+func (a *App) ForceFullRedraw() {
+	a.needsFullRedraw = true
+	a.MarkDirty()
 }
 
 // RenderFull forces a complete redraw of the buffer to the terminal.

--- a/inline_resize_test.go
+++ b/inline_resize_test.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"testing"
+)
+
+// TestRenderInline_FullRedrawClearsUnionOfViewports is a regression test for
+// the inline-mode resize ghost bug: after the terminal grows, a full redraw
+// must clear from the union of the previous and current viewport start rows
+// (min), otherwise the old composer band stays above the new viewport.
+func TestRenderInline_FullRedrawClearsUnionOfViewports(t *testing.T) {
+	const width, termHeight, inlineHeight = 80, 40, 6
+	term := NewMockTerminal(width, termHeight)
+	app := &App{
+		terminal:           term,
+		buffer:             NewBuffer(width, inlineHeight),
+		inlineHeight:       inlineHeight,
+		inlineStartRow:     34, // current viewport top (terminal grew from 36 to 40 rows)
+		prevInlineStartRow: 30, // previous viewport top
+	}
+	app.needsFullRedraw = true
+	app.renderInline()
+
+	// Clear must start at min(30, 34) = 30.
+	if _, cy := term.Cursor(); cy != 30 {
+		t.Fatalf("full redraw clear start row = %d, want 30 (union of old/new viewport)", cy)
+	}
+	if app.needsFullRedraw {
+		t.Fatal("needsFullRedraw should be consumed by the full redraw")
+	}
+	if app.prevInlineStartRow != 34 {
+		t.Fatalf("prevInlineStartRow = %d, want 34", app.prevInlineStartRow)
+	}
+}
+// TestRenderInline_FirstFullRedrawUsesCurrentStartRow is a regression test:
+// on the very first full redraw (prevInlineStartRow = -1) the clear must start
+// at the current viewport top, never degrade to row 0 and wipe the log area.
+func TestRenderInline_FirstFullRedrawUsesCurrentStartRow(t *testing.T) {
+	const width, termHeight, inlineHeight = 80, 40, 6
+	term := NewMockTerminal(width, termHeight)
+	app := &App{
+		terminal:           term,
+		buffer:             NewBuffer(width, inlineHeight),
+		inlineHeight:       inlineHeight,
+		inlineStartRow:     34,
+		prevInlineStartRow: -1,
+	}
+	app.needsFullRedraw = true
+	app.renderInline()
+
+	if _, cy := term.Cursor(); cy != 34 {
+		t.Fatalf("first full redraw clear start row = %d, want 34", cy)
+	}
+}
+// TestRenderFrame_ResyncsInlineGeometryOnHeightChange is a regression test:
+// when the terminal height changes (even before the ResizeEvent is dispatched),
+// renderFrame must immediately re-sync inlineStartRow to the live size and force
+// a full redraw; otherwise the composer is drawn at a stale row, leaving the old
+// band behind (resize ghosts).
+func TestRenderFrame_ResyncsInlineGeometryOnHeightChange(t *testing.T) {
+	term := NewMockTerminal(80, 24)
+	app := &App{
+		terminal:           term,
+		buffer:             NewBuffer(80, 6),
+		inlineHeight:       6,
+		inlineStartRow:     18,
+		prevInlineStartRow: 18,
+		inlineLayout:       newInlineLayoutState(18),
+		focus:              newFocusManager(),
+	}
+	// Simulate the terminal growing to 30 rows with no ResizeEvent dispatched.
+	term.Resize(80, 30)
+
+	app.renderFrame()
+
+	if app.inlineStartRow != 24 {
+		t.Fatalf("inlineStartRow = %d, want 24 (30-6)", app.inlineStartRow)
+	}
+	// The full redraw ran and recorded the new start row.
+	if app.prevInlineStartRow != 24 {
+		t.Fatalf("prevInlineStartRow = %d, want 24", app.prevInlineStartRow)
+	}
+}
+


### PR DESCRIPTION
Closes #119

## What
Two changes fix stale composer rows ("ghosts") left on screen when an inline-mode terminal grows taller than the viewport height:

1. **`renderInline` clears the union of old/new viewport areas.** On a full redraw it now clears from `min(prevInlineStartRow, inlineStartRow)` instead of only from the new start row, erasing the old composer band that sits above the new viewport after growth. Tracks `prevInlineStartRow` on `App` (initialized to `-1` by `WithInlineHeight`; the first redraw degrades to the current start row).

2. **`renderFrame` re-syncs inline geometry against the live terminal size every frame.** Previously geometry only re-synced when the buffer width changed; on a pure height change with the `ResizeEvent` still queued, the composer could be drawn at a stale row for a frame. Now any `inlineStartRow` / width mismatch forces `syncInlineGeometryOnResize` + a full redraw.

This mirrors how Codex (openai/codex) clears inline viewports on resize: `clear_after_position(min(old.y, new.y))` then full repaint.

## Tests
Added in `inline_resize_test.go`:
- `TestRenderInline_FullRedrawClearsUnionOfViewports` — clear starts at min(old,new).
- `TestRenderInline_FirstFullRedrawUsesCurrentStartRow` — first redraw never clears from row 0.
- `TestRenderFrame_ResyncsInlineGeometryOnHeightChange` — height change without a dispatched event re-syncs geometry and triggers full redraw.

`go test ./...` passes.