### PR TITLE
feat(tui): wrap inline frames in a synchronized update and add ForceFullRedraw

### DIFF
--- a/app_render.go
+++ b/app_render.go
@@ -149,6 +149,14 @@ func (a *App) placeCursor() {
 
 // renderInline handles rendering for inline mode by offsetting Y coordinates.
 func (a *App) renderInline() {
+	// Wrap the whole frame in a synchronized update (DEC 2026). Terminals that
+	// support it buffer the complete frame before painting, so resize drags do
+	// not flash partially-rendered intermediate states. Unsupported terminals
+	// simply ignore the private mode sequences. Mirrors Codex's
+	// stdout().sync_update().
+	a.terminal.WriteDirect([]byte("\x1b[?2026h"))
+	defer a.terminal.WriteDirect([]byte("\x1b[?2026l"))
+
 	var changes []CellChange
 
 	if a.needsFullRedraw {
@@ -186,6 +194,17 @@ func (a *App) renderInline() {
 		a.terminal.Flush(changes)
 	}
 	a.buffer.Swap()
+}
+
+// ForceFullRedraw marks the next inline render as a full repaint of the whole
+// viewport, independent of the buffer diff. This is useful after raw terminal
+// operations (e.g. clearing scrollback or replaying history outside the app)
+// so the composer is repainted even though the buffer diff would otherwise be
+// empty. Unlike RenderFull, it stays within inline mode and does not draw at
+// full-screen coordinates.
+func (a *App) ForceFullRedraw() {
+	a.needsFullRedraw = true
+	a.MarkDirty()
 }
 
 // RenderFull forces a complete redraw of the buffer to the terminal.

--- a/inline_sync_test.go
+++ b/inline_sync_test.go
@@ -1,0 +1,55 @@
+package tui
+
+import (
+	"testing"
+)
+
+// writeDirectRecorder wraps MockTerminal to capture raw WriteDirect payloads.
+type writeDirectRecorder struct {
+	*MockTerminal
+	writes []string
+}
+
+func (t *writeDirectRecorder) WriteDirect(b []byte) (int, error) {
+	t.writes = append(t.writes, string(b))
+	return len(b), nil
+}
+
+// TestRenderInline_WrapsFrameInSynchronizedUpdate verifies the whole inline
+// frame is wrapped in a DEC 2026 synchronized update so resize drags do not
+// flash partially-rendered intermediate states.
+func TestRenderInline_WrapsFrameInSynchronizedUpdate(t *testing.T) {
+	const width, termHeight, inlineHeight = 80, 24, 6
+	rec := &writeDirectRecorder{MockTerminal: NewMockTerminal(width, termHeight)}
+	app := &App{
+		terminal:       rec,
+		buffer:         NewBuffer(width, inlineHeight),
+		inlineHeight:   inlineHeight,
+		inlineStartRow: 18,
+	}
+	app.needsFullRedraw = true
+	app.renderInline()
+
+	if len(rec.writes) < 2 {
+		t.Fatalf("expected at least 2 WriteDirect calls, got %d", len(rec.writes))
+	}
+	if rec.writes[0] != "\x1b[?2026h" {
+		t.Fatalf("first WriteDirect = %q, want synchronized update begin", rec.writes[0])
+	}
+	if last := rec.writes[len(rec.writes)-1]; last != "\x1b[?2026l" {
+		t.Fatalf("last WriteDirect = %q, want synchronized update end", last)
+	}
+}
+
+// TestForceFullRedraw verifies ForceFullRedraw sets needsFullRedraw and marks
+// the app dirty so the next render repaints the whole viewport.
+func TestForceFullRedraw(t *testing.T) {
+	app := &App{}
+	app.ForceFullRedraw()
+	if !app.needsFullRedraw {
+		t.Fatal("ForceFullRedraw should set needsFullRedraw")
+	}
+	if !app.dirty.Load() {
+		t.Fatal("ForceFullRedraw should mark the app dirty")
+	}
+}


### PR DESCRIPTION
## What
Two small improvements to the inline renderer:

1. **`renderInline` wraps the whole frame in a DEC 2026 synchronized update** (`\x1b[?2026h` … `\x1b[?2026l`). Terminals that support it buffer the complete frame before painting, so resize drags do not flash partially-rendered intermediate states; unsupported terminals simply ignore the private-mode sequences (no capability probe needed, harmless no-op there). This mirrors how Codex (openai/codex) wraps its draw pass in `stdout().sync_update()`.

2. **Adds `App.ForceFullRedraw`**, which marks the next inline render as a full repaint regardless of the buffer diff. Useful after raw terminal operations (e.g. clearing scrollback or replaying history outside the app) so the composer is repainted even though the diff would otherwise be empty. Unlike `RenderFull`, it stays within inline-mode coordinates.

## Tests
Added in `inline_sync_test.go`:
- `TestRenderInline_WrapsFrameInSynchronizedUpdate` — frame starts with begin and ends with end sequence.
- `TestForceFullRedraw` — sets `needsFullRedraw` and marks the app dirty.

`go test ./...` passes.