### PR TITLE
fix: clear stale inline widget rows when the terminal grows taller

### DIFF
--- a/app.go
+++ b/app.go
@@ -61,6 +61,8 @@ type App struct {
 	// Inline mode (set via WithInlineHeight)
 	inlineHeight       int               // Number of rows for inline widget (0 = full screen mode)
 	inlineStartRow     int               // Terminal row where inline region starts (calculated at init)
+	inlineClearFromRow int               // Clear from this row on the next inline full redraw (valid when inlineClearPending)
+	inlineClearPending bool              // Set when a resize moved the widget down, leaving stale rows above the new start row
 	inlineStartupMode  InlineStartupMode // Startup behavior for inline viewport ownership
 	inlineLayout       inlineLayoutState
 	inlineSession      *inlineSession

--- a/app_events.go
+++ b/app_events.go
@@ -127,7 +127,8 @@ func (a *App) syncInlineGeometryOnResize(width, termHeight int) {
 	oldStart := a.inlineStartRow
 	a.inlineStartRow = termHeight - a.inlineHeight
 	// Terminal grew: the old widget band sits above the new start row and must
-	// be cleared on the next full redraw (min across rapid resize events).
+	// be cleared on the next full redraw. Min across rapid resize events: the
+	// band may sit anywhere down to the lowest start row since the last paint.
 	if oldStart < a.inlineStartRow && (!a.inlineClearPending || oldStart < a.inlineClearFromRow) {
 		a.inlineClearFromRow = oldStart
 		a.inlineClearPending = true

--- a/app_events.go
+++ b/app_events.go
@@ -125,7 +125,7 @@ func (a *App) readInputEvents() {
 
 func (a *App) syncInlineGeometryOnResize(width, termHeight int) {
 	oldStart := a.inlineStartRow
-	a.inlineStartRow = termHeight - a.inlineHeight
+	a.inlineStartRow = max(termHeight-a.inlineHeight, 0)
 	// Terminal grew: the old widget band sits above the new start row and must
 	// be cleared on the next full redraw. Min across rapid resize events: the
 	// band may sit anywhere down to the lowest start row since the last paint.

--- a/app_events.go
+++ b/app_events.go
@@ -124,7 +124,14 @@ func (a *App) readInputEvents() {
 }
 
 func (a *App) syncInlineGeometryOnResize(width, termHeight int) {
+	oldStart := a.inlineStartRow
 	a.inlineStartRow = termHeight - a.inlineHeight
+	// Terminal grew: the old widget band sits above the new start row and must
+	// be cleared on the next full redraw (min across rapid resize events).
+	if oldStart < a.inlineStartRow && (!a.inlineClearPending || oldStart < a.inlineClearFromRow) {
+		a.inlineClearFromRow = oldStart
+		a.inlineClearPending = true
+	}
 	if a.buffer.Width() == width {
 		return
 	}

--- a/app_render.go
+++ b/app_render.go
@@ -172,7 +172,7 @@ func (a *App) renderInline() {
 			}
 			a.inlineClearPending = false
 		}
-		// Guard against a negative start row (terminal shorter than inlineHeight).
+		// Defensive: never clear from a negative row, whatever produced it.
 		clearFrom = max(clearFrom, 0)
 		debug.Log("renderInline: fullRedraw — SetCursor(0, %d), ClearToEnd, flushing %dx%d cells at Y offset %d",
 			clearFrom, width, height, a.inlineStartRow)

--- a/app_render.go
+++ b/app_render.go
@@ -172,6 +172,8 @@ func (a *App) renderInline() {
 			}
 			a.inlineClearPending = false
 		}
+		// Guard against a negative start row (terminal shorter than inlineHeight).
+		clearFrom = max(clearFrom, 0)
 		debug.Log("renderInline: fullRedraw — SetCursor(0, %d), ClearToEnd, flushing %dx%d cells at Y offset %d",
 			clearFrom, width, height, a.inlineStartRow)
 		a.terminal.SetCursor(0, clearFrom)

--- a/app_render.go
+++ b/app_render.go
@@ -162,10 +162,19 @@ func (a *App) renderInline() {
 				changes = append(changes, CellChange{X: x, Y: y + a.inlineStartRow, Cell: cell})
 			}
 		}
-		// Clear only the inline region, not the whole screen
+		// Clear only the inline region, not the whole screen. If a resize moved
+		// the widget down, start clearing at the old start row so the stale
+		// band above the new position is erased too.
+		clearFrom := a.inlineStartRow
+		if a.inlineClearPending {
+			if a.inlineClearFromRow < clearFrom {
+				clearFrom = a.inlineClearFromRow
+			}
+			a.inlineClearPending = false
+		}
 		debug.Log("renderInline: fullRedraw — SetCursor(0, %d), ClearToEnd, flushing %dx%d cells at Y offset %d",
-			a.inlineStartRow, width, height, a.inlineStartRow)
-		a.terminal.SetCursor(0, a.inlineStartRow)
+			clearFrom, width, height, a.inlineStartRow)
+		a.terminal.SetCursor(0, clearFrom)
 		a.terminal.ClearToEnd()
 		a.needsFullRedraw = false
 	} else {

--- a/app_screen.go
+++ b/app_screen.go
@@ -68,7 +68,7 @@ func (a *App) ExitAlternateScreen() error {
 	// Reconfigure buffer for restored mode
 	if a.inlineHeight > 0 {
 		// Inline mode: recalculate start row, resize buffer to inline height
-		a.inlineStartRow = height - a.inlineHeight
+		a.inlineStartRow = max(height-a.inlineHeight, 0)
 		a.inlineLayout.clamp(a.inlineStartRow)
 		a.buffer.Resize(width, a.inlineHeight)
 	} else {

--- a/app_suspend_test.go
+++ b/app_suspend_test.go
@@ -260,6 +260,30 @@ func TestResumeSequence_InlineMode(t *testing.T) {
 	}
 }
 
+func TestResumeSequence_InlineMode_DropsPendingClearMarker(t *testing.T) {
+	term := newRecordingTerminal(80, 24)
+
+	app := &App{
+		terminal:       term,
+		inlineHeight:   5,
+		inlineStartRow: 19,
+		stopCh:         make(chan struct{}),
+		buffer:         NewBuffer(80, 5),
+		dirty:          atomic.Bool{},
+	}
+	// A resize recorded a clear marker, then the app suspended before
+	// rendering. The shell may have scrolled the screen while stopped, so the
+	// marker no longer describes what is at that row.
+	app.inlineClearFromRow = 12
+	app.inlineClearPending = true
+
+	app.resumeTerminal()
+
+	if app.inlineClearPending {
+		t.Fatal("inlineClearPending should be dropped on resume")
+	}
+}
+
 func TestSuspendSequence_MouseDisabled(t *testing.T) {
 	term := newRecordingTerminal(80, 24)
 	term.inRawMode = true

--- a/app_suspend_unix.go
+++ b/app_suspend_unix.go
@@ -75,6 +75,9 @@ func (a *App) resumeTerminal() {
 		// Recalculate where the widget should be drawn.
 		_, termHeight := a.terminal.Size()
 		a.inlineStartRow = max(termHeight-a.inlineHeight, 0)
+		// The shell may have scrolled the screen while stopped, so a clear
+		// marker recorded before suspension no longer describes what is there.
+		a.inlineClearPending = false
 		// Reset style tracking: the terminal's SGR state is unknown after
 		// going through cooked mode and shell interaction. Without this,
 		// Flush may skip emitting style codes for cells whose style matches

--- a/inline_resize_test.go
+++ b/inline_resize_test.go
@@ -92,11 +92,32 @@ func TestInlineResize_TerminalGrowth_RepeatedSteps(t *testing.T) {
 	}
 }
 
-// TestInlineResize_ShrinkBelowHeightThenGrow_ClampsClearRow covers the tiny
-// terminal case: shrinking below the inline height leaves a negative start row
-// (unclamped, pre-existing), and a later grow records it as the pending clear
-// marker. The full redraw must clamp the clear row at 0 rather than emit a
-// negative cursor position.
+// TestInlineResize_ShrinkBelowHeight_ClampsStartRow covers issue #122: a
+// terminal shorter than the inline height must clamp the start row at 0, like
+// the startup and resume paths already do, instead of going negative and
+// producing negative cursor rows.
+func TestInlineResize_ShrinkBelowHeight_ClampsStartRow(t *testing.T) {
+	app, term := newInlineResizeTestApp(80, 8, 6)
+	app.root = New(WithText("COMPOSER"))
+
+	app.needsFullRedraw = true
+	app.renderFrame()
+
+	term.Resize(80, 4)
+	app.Dispatch(ResizeEvent{Width: 80, Height: 4})
+
+	if app.inlineStartRow != 0 {
+		t.Fatalf("inlineStartRow = %d, want 0 (clamped)", app.inlineStartRow)
+	}
+	app.renderFrame()
+	if _, cy := term.Cursor(); cy != 0 {
+		t.Fatalf("clear start row = %d, want 0", cy)
+	}
+}
+
+// TestInlineResize_ShrinkBelowHeightThenGrow_ClampsClearRow pins the tiny
+// terminal round trip: shrinking below the inline height then growing back
+// must clear from row 0, never a negative cursor row.
 func TestInlineResize_ShrinkBelowHeightThenGrow_ClampsClearRow(t *testing.T) {
 	app, term := newInlineResizeTestApp(80, 8, 6)
 	app.root = New(WithText("COMPOSER"))

--- a/inline_resize_test.go
+++ b/inline_resize_test.go
@@ -92,6 +92,31 @@ func TestInlineResize_TerminalGrowth_RepeatedSteps(t *testing.T) {
 	}
 }
 
+// TestInlineResize_ShrinkBelowHeightThenGrow_ClampsClearRow covers the tiny
+// terminal case: shrinking below the inline height leaves a negative start row
+// (unclamped, pre-existing), and a later grow records it as the pending clear
+// marker. The full redraw must clamp the clear row at 0 rather than emit a
+// negative cursor position.
+func TestInlineResize_ShrinkBelowHeightThenGrow_ClampsClearRow(t *testing.T) {
+	app, term := newInlineResizeTestApp(80, 8, 6)
+	app.root = New(WithText("COMPOSER"))
+
+	app.needsFullRedraw = true
+	app.renderFrame()
+
+	// Shrink below the inline height: start row becomes 4-6 = -2.
+	term.Resize(80, 4)
+	app.Dispatch(ResizeEvent{Width: 80, Height: 4})
+	// Grow back: the negative row is recorded as the clear marker.
+	term.Resize(80, 8)
+	app.Dispatch(ResizeEvent{Width: 80, Height: 8})
+	app.renderFrame()
+
+	if _, cy := term.Cursor(); cy != 0 {
+		t.Fatalf("clear start row = %d, want 0 (clamped)", cy)
+	}
+}
+
 // TestInlineResize_TerminalShrink_UnchangedBehavior pins the shrink path: the
 // new start row is above the old one, so clearing from the new start row
 // already covers the old band. No extra clearing should occur above it.

--- a/inline_resize_test.go
+++ b/inline_resize_test.go
@@ -115,6 +115,27 @@ func TestInlineResize_ShrinkBelowHeight_ClampsStartRow(t *testing.T) {
 	}
 }
 
+// TestExitAlternateScreen_TerminalShorterThanInlineHeight_ClampsStartRow
+// covers the last unclamped start-row computation: a resize while in alt
+// screen only resizes the buffer, so the exit path recomputes the start row
+// and must clamp it at 0 like every other path.
+func TestExitAlternateScreen_TerminalShorterThanInlineHeight_ClampsStartRow(t *testing.T) {
+	app, term := newInlineResizeTestApp(80, 30, 6)
+
+	if err := app.EnterAlternateScreen(); err != nil {
+		t.Fatal(err)
+	}
+	term.Resize(80, 4)
+	app.Dispatch(ResizeEvent{Width: 80, Height: 4})
+	if err := app.ExitAlternateScreen(); err != nil {
+		t.Fatal(err)
+	}
+
+	if app.inlineStartRow != 0 {
+		t.Fatalf("inlineStartRow = %d, want 0 (clamped)", app.inlineStartRow)
+	}
+}
+
 // TestInlineResize_ShrinkBelowHeightThenGrow_ClampsClearRow pins the tiny
 // terminal round trip: shrinking below the inline height then growing back
 // must clear from row 0, never a negative cursor row.
@@ -125,10 +146,10 @@ func TestInlineResize_ShrinkBelowHeightThenGrow_ClampsClearRow(t *testing.T) {
 	app.needsFullRedraw = true
 	app.renderFrame()
 
-	// Shrink below the inline height: start row becomes 4-6 = -2.
+	// Shrink below the inline height: the start row clamps at 0.
 	term.Resize(80, 4)
 	app.Dispatch(ResizeEvent{Width: 80, Height: 4})
-	// Grow back: the negative row is recorded as the clear marker.
+	// Grow back: the clamped row is recorded as the clear marker.
 	term.Resize(80, 8)
 	app.Dispatch(ResizeEvent{Width: 80, Height: 8})
 	app.renderFrame()

--- a/inline_resize_test.go
+++ b/inline_resize_test.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// newInlineResizeTestApp constructs an inline-mode App on a MockTerminal.
+// MockTerminal.Resize preserves content top-anchored (rows keep their
+// positions, blank rows appear at the bottom), matching how terminals behave
+// when the window grows and the inline widget's rows stay where they were.
+func newInlineResizeTestApp(width, termHeight, inlineHeight int) (*App, *MockTerminal) {
+	term := NewMockTerminal(width, termHeight)
+	app := &App{
+		terminal:       term,
+		inlineHeight:   inlineHeight,
+		inlineStartRow: termHeight - inlineHeight,
+		inlineLayout:   newInlineLayoutState(termHeight - inlineHeight),
+		buffer:         NewBuffer(width, inlineHeight),
+		focus:          newFocusManager(),
+		mounts:         newMountState(),
+	}
+	return app, term
+}
+
+// rowText returns the trimmed text content of a terminal row.
+func rowText(term *MockTerminal, row int) string {
+	lines := strings.Split(term.String(), "\n")
+	if row < 0 || row >= len(lines) {
+		return ""
+	}
+	return strings.TrimRight(lines[row], " ")
+}
+
+// TestInlineResize_TerminalGrowth_ClearsOldWidgetRows reproduces the resize
+// ghost bug from issue #119: when the terminal grows taller, the full redraw
+// after the ResizeEvent must erase the widget rows at the old (higher) start
+// row, not just repaint at the new one.
+func TestInlineResize_TerminalGrowth_ClearsOldWidgetRows(t *testing.T) {
+	app, term := newInlineResizeTestApp(80, 30, 6)
+	app.root = New(WithText("COMPOSER"))
+
+	// Initial paint: widget occupies rows 24-29.
+	app.needsFullRedraw = true
+	app.renderFrame()
+	if got := rowText(term, 24); got != "COMPOSER" {
+		t.Fatalf("precondition: row 24 = %q, want %q", got, "COMPOSER")
+	}
+
+	// Terminal grows to 40 rows. Content stays top-anchored, so the old
+	// widget band is still visible at rows 24-29.
+	term.Resize(80, 40)
+	app.Dispatch(ResizeEvent{Width: 80, Height: 40})
+	app.renderFrame()
+
+	// The widget must now be at rows 34-39.
+	if got := rowText(term, 34); got != "COMPOSER" {
+		t.Fatalf("row 34 = %q, want %q", got, "COMPOSER")
+	}
+	// The old band (rows 24-29) and the gap below it must be blank.
+	for row := 24; row < 34; row++ {
+		if got := rowText(term, row); got != "" {
+			t.Fatalf("ghost row %d = %q, want blank", row, got)
+		}
+	}
+}
+
+// TestInlineResize_TerminalGrowth_RepeatedSteps mimics a resize drag: several
+// growth steps between renders must clear every stale band, down to the
+// earliest start row painted since the last full redraw.
+func TestInlineResize_TerminalGrowth_RepeatedSteps(t *testing.T) {
+	app, term := newInlineResizeTestApp(80, 30, 6)
+	app.root = New(WithText("COMPOSER"))
+
+	app.needsFullRedraw = true
+	app.renderFrame()
+
+	// Two growth events arrive before the next render (drag).
+	term.Resize(80, 34)
+	app.Dispatch(ResizeEvent{Width: 80, Height: 34})
+	term.Resize(80, 42)
+	app.Dispatch(ResizeEvent{Width: 80, Height: 42})
+	app.renderFrame()
+
+	if got := rowText(term, 36); got != "COMPOSER" {
+		t.Fatalf("row 36 = %q, want %q", got, "COMPOSER")
+	}
+	for row := 24; row < 36; row++ {
+		if got := rowText(term, row); got != "" {
+			t.Fatalf("ghost row %d = %q, want blank", row, got)
+		}
+	}
+}
+
+// TestInlineResize_TerminalShrink_UnchangedBehavior pins the shrink path: the
+// new start row is above the old one, so clearing from the new start row
+// already covers the old band. No extra clearing should occur above it.
+func TestInlineResize_TerminalShrink_UnchangedBehavior(t *testing.T) {
+	app, term := newInlineResizeTestApp(80, 40, 6)
+	app.root = New(WithText("COMPOSER"))
+
+	app.needsFullRedraw = true
+	app.renderFrame()
+	if got := rowText(term, 34); got != "COMPOSER" {
+		t.Fatalf("precondition: row 34 = %q, want %q", got, "COMPOSER")
+	}
+
+	// History line above the shrunken viewport must survive the redraw.
+	term.SetCell(0, 23, NewCell('H', NewStyle()))
+
+	term.Resize(80, 30)
+	app.Dispatch(ResizeEvent{Width: 80, Height: 30})
+	app.renderFrame()
+
+	if got := rowText(term, 24); got != "COMPOSER" {
+		t.Fatalf("row 24 = %q, want %q", got, "COMPOSER")
+	}
+	if got := rowText(term, 23); got != "H" {
+		t.Fatalf("history row 23 = %q, want %q (must not be cleared)", got, "H")
+	}
+}


### PR DESCRIPTION
## Summary

In inline mode the widget is pinned to the bottom of the terminal. When the terminal grows taller, `Dispatch(ResizeEvent)` moves `inlineStartRow` down to the new bottom edge, and the full redraw that follows cleared only from that new start row. The old widget rows sit above that point and were never erased, so each growth step during a window drag left another stale copy of the input band on screen. 

## The fix

`syncInlineGeometryOnResize` now records the old start row as a one-shot clear marker whenever the start row moves down, keeping the minimum across successive resize events so a drag that delivers several heights in one frame batch still clears every stale band. The next full redraw in `renderInline` starts its clear at the marker instead of the new start row, then discards it. This mirrors how Codex handles the same situation (clear from `min(old.y, new.y)`, then repaint). The marker is an int plus a bool on `App` whose zero value preserves the old behavior exactly, so it needs no constructor or option wiring and directly constructed Apps in tests are unaffected.

Review turned up two hardening cases that are included here. The clear row is clamped at 0 as a guard against ever emitting a negative cursor escape. And `resumeTerminal` drops any pending marker, since the shell may have scrolled the screen while the process was stopped, so a marker recorded before Ctrl+Z no longer describes what sits at that row.

This also fixes #122: the resize path computed `inlineStartRow = termHeight - inlineHeight` without a floor, so a terminal shorter than the inline height produced a negative start row (and negative cursor rows in the frames that followed). It now clamps at 0 the same way the startup and resume paths already did. Capping the effective widget height at the terminal height, like `SetInlineHeight` does for its callers, would mean auto-restoring the height on regrowth and stays out of scope.

The tests in `inline_resize_test.go` reproduce the ghost at the terminal-cell level (single grow, multi-step drag, the degenerate tiny-terminal case) and pin the shrink path as unchanged, since clearing from the new, higher start row already covers the old band there.

## Scope notes

The exit-alternate-screen and suspend paths already clear the old widget area before their geometry changes, so they cannot ghost and are untouched. `renderFrame` still does not poll the live terminal size every frame; a render that lands between the physical resize and the ResizeEvent paints at the old position for one frame, and the full redraw that follows now cleans that up, so the extra polling is not worth its failure modes.

Fixes #119
Fixes #122
