### PR TITLE
feat: wrap frame output in DEC 2026 synchronized updates

### DIFF
--- a/app_render.go
+++ b/app_render.go
@@ -248,9 +248,9 @@ func (a *App) RenderFull() {
 	a.placeCursor()
 }
 
-// syncUpdater is implemented by terminals that support DEC 2026 synchronized
-// updates (ANSITerminal). Kept off the Terminal interface so external
-// implementations keep compiling; non-implementers render unwrapped.
+// syncUpdater is an optional capability in the http.Flusher style: only
+// terminals that can promise atomic frame presentation implement it
+// (ANSITerminal); mocks and emulators render unwrapped instead of stubbing it.
 type syncUpdater interface {
 	BeginSyncUpdate()
 	EndSyncUpdate()

--- a/app_render.go
+++ b/app_render.go
@@ -256,6 +256,10 @@ type syncUpdater interface {
 	EndSyncUpdate()
 }
 
+// Compile-time pin: renaming the ANSITerminal methods would otherwise
+// silently disable frame synchronization (tests use their own implementers).
+var _ syncUpdater = (*ANSITerminal)(nil)
+
 func (a *App) beginSyncUpdate() {
 	if s, ok := a.terminal.(syncUpdater); ok {
 		s.BeginSyncUpdate()

--- a/app_render.go
+++ b/app_render.go
@@ -95,7 +95,12 @@ func (a *App) renderFrame() {
 		a.componentWatchersStarted = true
 	}
 
-	// Flush to terminal (inline mode offsets Y coordinates)
+	// Flush to terminal (inline mode offsets Y coordinates). The output phase
+	// is wrapped in a synchronized update so supporting terminals paint the
+	// frame atomically; deferred so a panicking hook cannot leave the terminal
+	// buffering forever.
+	a.beginSyncUpdate()
+	defer a.endSyncUpdate()
 	if !a.inAlternateScreen && a.inlineHeight > 0 {
 		a.renderInline()
 	} else if a.needsFullRedraw {
@@ -231,7 +236,9 @@ func (a *App) RenderFull() {
 
 	a.renderOverlays(width, height)
 
-	// Full render to terminal
+	// Full render to terminal, wrapped like renderFrame's output phase.
+	a.beginSyncUpdate()
+	defer a.endSyncUpdate()
 	RenderFull(a.terminal, a.buffer)
 
 	a.rebuildDispatchTable()
@@ -239,6 +246,26 @@ func (a *App) RenderFull() {
 		a.postRenderHook()
 	}
 	a.placeCursor()
+}
+
+// syncUpdater is implemented by terminals that support DEC 2026 synchronized
+// updates (ANSITerminal). Kept off the Terminal interface so external
+// implementations keep compiling; non-implementers render unwrapped.
+type syncUpdater interface {
+	BeginSyncUpdate()
+	EndSyncUpdate()
+}
+
+func (a *App) beginSyncUpdate() {
+	if s, ok := a.terminal.(syncUpdater); ok {
+		s.BeginSyncUpdate()
+	}
+}
+
+func (a *App) endSyncUpdate() {
+	if s, ok := a.terminal.(syncUpdater); ok {
+		s.EndSyncUpdate()
+	}
 }
 
 // rerenderComponent re-renders the root component to produce a fresh element tree.

--- a/app_render.go
+++ b/app_render.go
@@ -25,18 +25,18 @@ func (a *App) renderFrame() {
 		renderHeight = a.inlineHeight
 	}
 
-	// Ensure buffer matches expected size (handles rapid resize)
+	// Ensure buffer matches expected size (handles rapid resize). No terminal
+	// clear here: needsFullRedraw routes through RenderFull, which clears
+	// inside the synchronized update window instead of flashing before it.
 	if a.buffer.Width() != width || a.buffer.Height() != renderHeight {
 		if a.inAlternateScreen {
 			// Alternate screen mode: always use full-screen sizing
-			a.terminal.Clear()
 			a.buffer.Resize(width, termHeight)
 		} else if a.inlineHeight > 0 {
 			// Inline mode: keep buffer height fixed to inlineHeight.
 			a.syncInlineGeometryOnResize(width, termHeight)
 		} else {
-			// Full screen mode: clear terminal and resize buffer
-			a.terminal.Clear()
+			// Full screen mode: resize buffer
 			a.buffer.Resize(width, termHeight)
 		}
 		if a.root != nil {

--- a/sync_update_test.go
+++ b/sync_update_test.go
@@ -1,0 +1,162 @@
+package tui
+
+import (
+	"testing"
+)
+
+// syncRecordingTerminal embeds MockTerminal and records the order of sync
+// update markers relative to output operations.
+type syncRecordingTerminal struct {
+	*MockTerminal
+	ops []string
+}
+
+func newSyncRecordingTerminal(width, height int) *syncRecordingTerminal {
+	return &syncRecordingTerminal{MockTerminal: NewMockTerminal(width, height)}
+}
+
+func (s *syncRecordingTerminal) BeginSyncUpdate() {
+	s.ops = append(s.ops, "begin")
+}
+
+func (s *syncRecordingTerminal) EndSyncUpdate() {
+	s.ops = append(s.ops, "end")
+}
+
+func (s *syncRecordingTerminal) Flush(changes []CellChange) {
+	s.ops = append(s.ops, "flush")
+	s.MockTerminal.Flush(changes)
+}
+
+func (s *syncRecordingTerminal) SetCursor(x, y int) {
+	s.ops = append(s.ops, "cursor")
+	s.MockTerminal.SetCursor(x, y)
+}
+
+// assertWrapped checks that ops contain exactly one begin and one end, that
+// begin comes first, end comes last, and at least one output op sits between.
+func assertWrapped(t *testing.T, ops []string) {
+	t.Helper()
+	if len(ops) < 3 {
+		t.Fatalf("ops = %v, want begin + output + end", ops)
+	}
+	if ops[0] != "begin" {
+		t.Fatalf("first op = %q, want %q (ops: %v)", ops[0], "begin", ops)
+	}
+	if ops[len(ops)-1] != "end" {
+		t.Fatalf("last op = %q, want %q (ops: %v)", ops[len(ops)-1], "end", ops)
+	}
+	begins, ends := 0, 0
+	for _, op := range ops {
+		switch op {
+		case "begin":
+			begins++
+		case "end":
+			ends++
+		}
+	}
+	if begins != 1 || ends != 1 {
+		t.Fatalf("begin/end counts = %d/%d, want 1/1 (ops: %v)", begins, ends, ops)
+	}
+}
+
+func TestRenderFrame_FullScreen_WrapsOutputInSyncUpdate(t *testing.T) {
+	term := newSyncRecordingTerminal(80, 24)
+	app := &App{
+		terminal: term,
+		buffer:   NewBuffer(80, 24),
+		focus:    newFocusManager(),
+		mounts:   newMountState(),
+		root:     New(WithText("hello")),
+	}
+	app.needsFullRedraw = true
+
+	app.renderFrame()
+
+	assertWrapped(t, term.ops)
+}
+
+func TestRenderFrame_InlineMode_WrapsOutputInSyncUpdate(t *testing.T) {
+	term := newSyncRecordingTerminal(80, 24)
+	app := &App{
+		terminal:       term,
+		buffer:         NewBuffer(80, 6),
+		inlineHeight:   6,
+		inlineStartRow: 18,
+		inlineLayout:   newInlineLayoutState(18),
+		focus:          newFocusManager(),
+		mounts:         newMountState(),
+		root:           New(WithText("hello")),
+	}
+	app.needsFullRedraw = true
+
+	app.renderFrame()
+
+	assertWrapped(t, term.ops)
+}
+
+func TestAppRenderFull_WrapsOutputInSyncUpdate(t *testing.T) {
+	term := newSyncRecordingTerminal(80, 24)
+	app := &App{
+		terminal: term,
+		buffer:   NewBuffer(80, 24),
+		focus:    newFocusManager(),
+		mounts:   newMountState(),
+		root:     New(WithText("hello")),
+	}
+
+	app.RenderFull()
+
+	assertWrapped(t, term.ops)
+}
+
+// TestRenderFrame_SyncUpdateEndsOnPanic pins the panic-safety contract: a
+// panicking postRenderHook must not leave the terminal stuck in a
+// synchronized update block, or the screen freezes on supporting terminals.
+func TestRenderFrame_SyncUpdateEndsOnPanic(t *testing.T) {
+	term := newSyncRecordingTerminal(80, 24)
+	app := &App{
+		terminal: term,
+		buffer:   NewBuffer(80, 24),
+		focus:    newFocusManager(),
+		mounts:   newMountState(),
+		root:     New(WithText("hello")),
+		postRenderHook: func() {
+			panic("hook failure")
+		},
+	}
+	app.needsFullRedraw = true
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected the hook panic to propagate")
+			}
+		}()
+		app.renderFrame()
+	}()
+
+	if len(term.ops) == 0 || term.ops[len(term.ops)-1] != "end" {
+		t.Fatalf("last op = %v, want trailing %q even on panic", term.ops, "end")
+	}
+}
+
+// TestRenderFrame_PlainTerminal_NoSyncUpdate pins that terminals without the
+// sync update methods (like MockTerminal itself) render without them.
+func TestRenderFrame_PlainTerminal_NoSyncUpdate(t *testing.T) {
+	term := NewMockTerminal(80, 24)
+	app := &App{
+		terminal: term,
+		buffer:   NewBuffer(80, 24),
+		focus:    newFocusManager(),
+		mounts:   newMountState(),
+		root:     New(WithText("hello")),
+	}
+	app.needsFullRedraw = true
+
+	app.renderFrame()
+
+	if got := rowText(term, 0); got != "hello" {
+		t.Fatalf("row 0 = %q, want %q", got, "hello")
+	}
+}

--- a/sync_update_test.go
+++ b/sync_update_test.go
@@ -33,6 +33,16 @@ func (s *syncRecordingTerminal) SetCursor(x, y int) {
 	s.MockTerminal.SetCursor(x, y)
 }
 
+func (s *syncRecordingTerminal) Clear() {
+	s.ops = append(s.ops, "clear")
+	s.MockTerminal.Clear()
+}
+
+func (s *syncRecordingTerminal) ClearToEnd() {
+	s.ops = append(s.ops, "clearToEnd")
+	s.MockTerminal.ClearToEnd()
+}
+
 // assertWrapped checks that ops contain exactly one begin and one end, that
 // begin comes first, end comes last, and at least one output op sits between.
 func assertWrapped(t *testing.T, ops []string) {
@@ -106,6 +116,25 @@ func TestAppRenderFull_WrapsOutputInSyncUpdate(t *testing.T) {
 	}
 
 	app.RenderFull()
+
+	assertWrapped(t, term.ops)
+}
+
+// TestRenderFrame_Resize_AllOutputInsideSyncWindow pins that a resize frame
+// (buffer/terminal size mismatch) emits every terminal write inside the sync
+// window. The screen clear on resize used to run before the window opened,
+// flashing blank on exactly the frame type synchronized updates target.
+func TestRenderFrame_Resize_AllOutputInsideSyncWindow(t *testing.T) {
+	term := newSyncRecordingTerminal(100, 30)
+	app := &App{
+		terminal: term,
+		buffer:   NewBuffer(80, 24), // stale size: forces the resize branch
+		focus:    newFocusManager(),
+		mounts:   newMountState(),
+		root:     New(WithText("hello")),
+	}
+
+	app.renderFrame()
 
 	assertWrapped(t, term.ops)
 }


### PR DESCRIPTION
## Summary

Terminals that support DEC 2026 synchronized updates can buffer a whole frame and paint it atomically, which stops the tearing and partial paints you can see during resize drags and busy redraws. The escape primitives for this have been in the codebase for a while (`escBuilder.BeginSyncUpdate`/`EndSyncUpdate` and the `ANSITerminal` wrappers, complete with tests) but nothing ever called them, so every frame still went out unsynchronized. This idea came out of PR #120, which wrapped only the inline render path; this wires it in at the frame level for all modes.

## The change

`renderFrame` and `App.RenderFull` now wrap their terminal output phase, covering the flush, the post-render hook, and the final cursor placement, in a begin/end pair. The end is deferred, so a panicking hook cannot leave the terminal buffering in sync mode with a frozen screen. Terminals that do not support the sequences ignore them, per the DEC 2026 spec, so there is no capability probing; querying support via DECRQM would need an async stdin round trip that is not worth it.

The wrapping goes through an unexported `syncUpdater` interface with a type assertion rather than new methods on `Terminal`, since that interface is exported and adding methods would break external implementations. `ANSITerminal` picks it up automatically; `MockTerminal` and the test emulator render unwrapped as before.

Review of the branch caught one real gap: the resize path in `renderFrame` called `terminal.Clear()` before the sync window opened, flashing a blank screen on exactly the frame type this feature targets. That clear was also redundant, because a resize frame always routes through `RenderFull`, which clears again inside the window. The pre-window clears are removed and a test pins that every terminal write on a resize frame lands inside the window.

Out of scope: `PrintAbove`/`StreamAbove` sequences already go out as single writes, and streaming chunks are where per-write framing bytes cost the most, so they stay unwrapped unless flicker shows up there in practice.
