### PR TITLE
fix(layout): measure row heights at post-flex child widths

### DIFF
--- a/element_layout.go
+++ b/element_layout.go
@@ -99,6 +99,14 @@ func (e *Element) IntrinsicSize() (width, height int) {
 			width += 2
 			height += 2
 		}
+		// Explicit dimensions override content-derived size, matching the
+		// container branch below.
+		if e.style.Width.IsFixed() {
+			width = int(e.style.Width.Amount)
+		}
+		if e.style.Height.IsFixed() {
+			height = int(e.style.Height.Amount)
+		}
 		return width, height
 	}
 
@@ -109,6 +117,12 @@ func (e *Element) IntrinsicSize() (width, height int) {
 		if e.border != BorderNone {
 			width += 2
 			height += 2
+		}
+		if e.style.Width.IsFixed() {
+			width = int(e.style.Width.Amount)
+		}
+		if e.style.Height.IsFixed() {
+			height = int(e.style.Height.Amount)
 		}
 		return width, height
 	}

--- a/element_layout.go
+++ b/element_layout.go
@@ -205,6 +205,21 @@ func (e *Element) HeightForWidth(width int) int {
 		return h
 	}
 
+	// Tables: resolve column widths (with shrinking) and measure rows at
+	// those widths, rather than falling into the flex row branch below.
+	if e.tag == "table" {
+		contentWidth := width - e.style.Padding.Horizontal()
+		if e.border != BorderNone {
+			contentWidth -= 2
+		}
+		h := layout.TableHeightForWidth(e, contentWidth)
+		h += e.style.Padding.Vertical()
+		if e.border != BorderNone {
+			h += 2
+		}
+		return h
+	}
+
 	// Text elements with wrapping
 	if e.text != "" && !e.noWrap {
 		contentWidth := width - e.style.Padding.Horizontal()

--- a/element_layout.go
+++ b/element_layout.go
@@ -1,5 +1,7 @@
 package tui
 
+import "github.com/grindlemire/go-tui/internal/layout"
+
 // --- Implement Layoutable interface ---
 
 // LayoutStyle returns the layout style properties for this element.
@@ -274,33 +276,20 @@ func (e *Element) HeightForWidth(width int) int {
 		return totalH
 	}
 
-	// Row containers: recursively compute max child height.
-	// Children share the width via flex, so we approximate by giving each child
-	// its intrinsic width or a fair share. For text wrapping, the key case is
-	// row children with explicit or flex-computed widths which Phase 3.5 handles
-	// directly. Here we just find the max child height for the cross-axis.
+	// Row containers: measure children at their post-flex main-axis widths.
+	// RowContentHeight runs the same flex distribution as the layout pass, so
+	// wrapped text heights match the final layout exactly.
 	if len(e.children) > 0 {
 		contentWidth := width - e.style.Padding.Horizontal()
 		if e.border != BorderNone {
 			contentWidth -= 2
 		}
-		maxH := 0
-		for _, child := range e.children {
-			if child.hidden || child.overlay {
-				continue
-			}
-			// For row children, approximate: give each child the full width
-			// (overestimate). Phase 3.5 handles precise per-child widths.
-			childH := child.HeightForWidth(contentWidth)
-			if childH > maxH {
-				maxH = childH
-			}
-		}
-		maxH += e.style.Padding.Vertical()
+		h := layout.RowContentHeight(e.LayoutChildren(), e.LayoutStyle(), contentWidth)
+		h += e.style.Padding.Vertical()
 		if e.border != BorderNone {
-			maxH += 2
+			h += 2
 		}
-		return maxH
+		return h
 	}
 
 	// Default: intrinsic height

--- a/element_layout_rowwrap_test.go
+++ b/element_layout_rowwrap_test.go
@@ -154,6 +154,34 @@ func TestRowExplicitHeightWinsOverWrappedEstimate(t *testing.T) {
 	}
 }
 
+// A child's explicit height must win over its intrinsic height in the row
+// estimate: a bordered text child clamped to height 1 has intrinsic height 3
+// (1 line + 2 border rows), but the row must not grow past the clamp.
+func TestRowHeightHonorsExplicitChildHeight(t *testing.T) {
+	clamped := New(WithText("x"), WithBorder(BorderSingle), WithHeight(1))
+
+	row := New(WithDisplay(DisplayFlex), WithDirection(Row), WithWidthPercent(100))
+	row.AddChild(clamped)
+
+	sentinel := New(WithText("SENTINEL"))
+
+	root := New(WithDisplay(DisplayFlex), WithDirection(Column), WithWidth(40))
+	root.AddChild(row)
+	root.AddChild(sentinel)
+
+	root.Calculate(40, 24)
+
+	if got := row.HeightForWidth(40); got != 1 {
+		t.Errorf("row HeightForWidth(40) = %d, want 1 (explicit child height)", got)
+	}
+	if got := row.Rect().Height; got != 1 {
+		t.Errorf("row height = %d, want 1", got)
+	}
+	if got := sentinel.Rect().Y; got != 1 {
+		t.Errorf("sentinel Y = %d, want 1", got)
+	}
+}
+
 // Degenerate widths must not panic and must not report negative heights.
 func TestRowHeightForWidthDegenerateWidth(t *testing.T) {
 	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0))

--- a/element_layout_rowwrap_test.go
+++ b/element_layout_rowwrap_test.go
@@ -2,22 +2,23 @@ package tui
 
 import "testing"
 
+// rowWrapLongText is 12 five-char words (71 chars): 1 line at its intrinsic
+// width, 2 lines at width 40, 3 lines at width 30.
+const rowWrapLongText = "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj kkkkk lllll"
+
 // Reproduction for issue #126: a wrapping text child in a horizontal flex row
 // receives its final width from flex distribution, but the row's height is
 // estimated from pre-flex (full content width) wrapping, so the row does not
 // grow when the post-flex width wraps to more lines.
 func TestRowHeightGrowsForPostFlexWrappedChild(t *testing.T) {
-	// 12 five-char words: wraps to 2 lines at width 40, 3 lines at width 30.
-	longText := "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj kkkkk lllll"
-
-	fullLines := len(wrapText(longText, 40))
-	flexLines := len(wrapText(longText, 30))
+	fullLines := len(wrapText(rowWrapLongText, 40))
+	flexLines := len(wrapText(rowWrapLongText, 30))
 	if flexLines <= fullLines {
 		t.Fatalf("test setup: wrap at 30 (%d lines) must exceed wrap at 40 (%d lines)", flexLines, fullLines)
 	}
 
 	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0), WithWrap(false))
-	wrapped := New(WithText(longText), WithFlexGrow(1), WithMinWidth(0))
+	wrapped := New(WithText(rowWrapLongText), WithFlexGrow(1), WithMinWidth(0))
 
 	row := New(WithDisplay(DisplayFlex), WithDirection(Row), WithWidthPercent(100))
 	row.AddChild(label)
@@ -49,16 +50,13 @@ func TestRowHeightGrowsForPostFlexWrappedChild(t *testing.T) {
 // shrunk to the row width, wrapping its text to more lines than the pre-flex
 // base-size estimate predicted.
 func TestWrapRowHeightGrowsForPostFlexWrappedChild(t *testing.T) {
-	// 71 chars: 1 line at its intrinsic width 71, 2 lines at width 40.
-	longText := "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj kkkkk lllll"
-
-	lineLines := len(wrapText(longText, 40))
+	lineLines := len(wrapText(rowWrapLongText, 40))
 	if lineLines != 2 {
 		t.Fatalf("test setup: wrap at 40 = %d lines, want 2", lineLines)
 	}
 
 	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0), WithWrap(false))
-	wrapped := New(WithText(longText), WithFlexGrow(1), WithMinWidth(0))
+	wrapped := New(WithText(rowWrapLongText), WithFlexGrow(1), WithMinWidth(0))
 
 	row := New(WithDisplay(DisplayFlex), WithDirection(Row), WithWidthPercent(100), WithFlexWrap(Wrap))
 	row.AddChild(label)
@@ -88,10 +86,8 @@ func TestWrapRowHeightGrowsForPostFlexWrappedChild(t *testing.T) {
 
 // The post-flex width estimate must account for the row's gap.
 func TestRowHeightForWidthAccountsForGap(t *testing.T) {
-	longText := "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj kkkkk lllll"
-
 	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0), WithWrap(false))
-	wrapped := New(WithText(longText), WithFlexGrow(1), WithMinWidth(0))
+	wrapped := New(WithText(rowWrapLongText), WithFlexGrow(1), WithMinWidth(0))
 
 	row := New(WithDisplay(DisplayFlex), WithDirection(Row), WithWidthPercent(100), WithGap(2))
 	row.AddChild(label)
@@ -102,7 +98,7 @@ func TestRowHeightForWidthAccountsForGap(t *testing.T) {
 
 	root.Calculate(40, 24)
 
-	wantLines := len(wrapText(longText, 28)) // 40 - 10 label - 2 gap
+	wantLines := len(wrapText(rowWrapLongText, 28)) // 40 - 10 label - 2 gap
 	if got := wrapped.Rect().Width; got != 28 {
 		t.Fatalf("wrapped child width = %d, want 28", got)
 	}
@@ -138,10 +134,8 @@ func TestRowHeightUnchangedWhenNothingWraps(t *testing.T) {
 
 // An explicit row height wins over the post-flex wrapped estimate.
 func TestRowExplicitHeightWinsOverWrappedEstimate(t *testing.T) {
-	longText := "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj kkkkk lllll"
-
 	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0), WithWrap(false))
-	wrapped := New(WithText(longText), WithFlexGrow(1), WithMinWidth(0))
+	wrapped := New(WithText(rowWrapLongText), WithFlexGrow(1), WithMinWidth(0))
 
 	row := New(WithDisplay(DisplayFlex), WithDirection(Row), WithWidthPercent(100), WithHeight(2))
 	row.AddChild(label)

--- a/element_layout_rowwrap_test.go
+++ b/element_layout_rowwrap_test.go
@@ -1,0 +1,180 @@
+package tui
+
+import "testing"
+
+// Reproduction for issue #126: a wrapping text child in a horizontal flex row
+// receives its final width from flex distribution, but the row's height is
+// estimated from pre-flex (full content width) wrapping, so the row does not
+// grow when the post-flex width wraps to more lines.
+func TestRowHeightGrowsForPostFlexWrappedChild(t *testing.T) {
+	// 12 five-char words: wraps to 2 lines at width 40, 3 lines at width 30.
+	longText := "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj kkkkk lllll"
+
+	fullLines := len(wrapText(longText, 40))
+	flexLines := len(wrapText(longText, 30))
+	if flexLines <= fullLines {
+		t.Fatalf("test setup: wrap at 30 (%d lines) must exceed wrap at 40 (%d lines)", flexLines, fullLines)
+	}
+
+	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0), WithWrap(false))
+	wrapped := New(WithText(longText), WithFlexGrow(1), WithMinWidth(0))
+
+	row := New(WithDisplay(DisplayFlex), WithDirection(Row), WithWidthPercent(100))
+	row.AddChild(label)
+	row.AddChild(wrapped)
+
+	sentinel := New(WithText("SENTINEL"))
+
+	root := New(WithDisplay(DisplayFlex), WithDirection(Column), WithWidth(40))
+	root.AddChild(row)
+	root.AddChild(sentinel)
+
+	root.Calculate(40, 24)
+
+	if got := wrapped.Rect().Width; got != 30 {
+		t.Fatalf("wrapped child width = %d, want 30", got)
+	}
+	if got := row.Rect().Height; got != flexLines {
+		t.Errorf("row height = %d, want %d (post-flex wrapped lines)", got, flexLines)
+	}
+	if got := wrapped.Rect().Height; got != flexLines {
+		t.Errorf("wrapped child height = %d, want %d", got, flexLines)
+	}
+	if got := sentinel.Rect().Y; got != flexLines {
+		t.Errorf("sentinel Y = %d, want %d (below the wrapped row)", got, flexLines)
+	}
+}
+
+// Same bug class for flex-wrap rows: an item pushed to its own wrap line is
+// shrunk to the row width, wrapping its text to more lines than the pre-flex
+// base-size estimate predicted.
+func TestWrapRowHeightGrowsForPostFlexWrappedChild(t *testing.T) {
+	// 71 chars: 1 line at its intrinsic width 71, 2 lines at width 40.
+	longText := "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj kkkkk lllll"
+
+	lineLines := len(wrapText(longText, 40))
+	if lineLines != 2 {
+		t.Fatalf("test setup: wrap at 40 = %d lines, want 2", lineLines)
+	}
+
+	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0), WithWrap(false))
+	wrapped := New(WithText(longText), WithFlexGrow(1), WithMinWidth(0))
+
+	row := New(WithDisplay(DisplayFlex), WithDirection(Row), WithWidthPercent(100), WithFlexWrap(Wrap))
+	row.AddChild(label)
+	row.AddChild(wrapped)
+
+	sentinel := New(WithText("SENTINEL"))
+
+	root := New(WithDisplay(DisplayFlex), WithDirection(Column), WithWidth(40))
+	root.AddChild(row)
+	root.AddChild(sentinel)
+
+	root.Calculate(40, 24)
+
+	// label occupies wrap line 1 (1 row); the shrunk text child occupies
+	// wrap line 2 (2 rows).
+	wantRowH := 1 + lineLines
+	if got := wrapped.Rect().Width; got != 40 {
+		t.Fatalf("wrapped child width = %d, want 40", got)
+	}
+	if got := row.Rect().Height; got != wantRowH {
+		t.Errorf("row height = %d, want %d (sum of wrap line heights)", got, wantRowH)
+	}
+	if got := sentinel.Rect().Y; got != wantRowH {
+		t.Errorf("sentinel Y = %d, want %d (below the wrapped row)", got, wantRowH)
+	}
+}
+
+// The post-flex width estimate must account for the row's gap.
+func TestRowHeightForWidthAccountsForGap(t *testing.T) {
+	longText := "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj kkkkk lllll"
+
+	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0), WithWrap(false))
+	wrapped := New(WithText(longText), WithFlexGrow(1), WithMinWidth(0))
+
+	row := New(WithDisplay(DisplayFlex), WithDirection(Row), WithWidthPercent(100), WithGap(2))
+	row.AddChild(label)
+	row.AddChild(wrapped)
+
+	root := New(WithDisplay(DisplayFlex), WithDirection(Column), WithWidth(40))
+	root.AddChild(row)
+
+	root.Calculate(40, 24)
+
+	wantLines := len(wrapText(longText, 28)) // 40 - 10 label - 2 gap
+	if got := wrapped.Rect().Width; got != 28 {
+		t.Fatalf("wrapped child width = %d, want 28", got)
+	}
+	if got := row.Rect().Height; got != wantLines {
+		t.Errorf("row height = %d, want %d", got, wantLines)
+	}
+}
+
+// A row whose text fits without wrapping keeps its single-line height.
+func TestRowHeightUnchangedWhenNothingWraps(t *testing.T) {
+	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0), WithWrap(false))
+	short := New(WithText("short"), WithFlexGrow(1), WithMinWidth(0))
+
+	row := New(WithDisplay(DisplayFlex), WithDirection(Row), WithWidthPercent(100))
+	row.AddChild(label)
+	row.AddChild(short)
+
+	sentinel := New(WithText("SENTINEL"))
+
+	root := New(WithDisplay(DisplayFlex), WithDirection(Column), WithWidth(40))
+	root.AddChild(row)
+	root.AddChild(sentinel)
+
+	root.Calculate(40, 24)
+
+	if got := row.Rect().Height; got != 1 {
+		t.Errorf("row height = %d, want 1", got)
+	}
+	if got := sentinel.Rect().Y; got != 1 {
+		t.Errorf("sentinel Y = %d, want 1", got)
+	}
+}
+
+// An explicit row height wins over the post-flex wrapped estimate.
+func TestRowExplicitHeightWinsOverWrappedEstimate(t *testing.T) {
+	longText := "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj kkkkk lllll"
+
+	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0), WithWrap(false))
+	wrapped := New(WithText(longText), WithFlexGrow(1), WithMinWidth(0))
+
+	row := New(WithDisplay(DisplayFlex), WithDirection(Row), WithWidthPercent(100), WithHeight(2))
+	row.AddChild(label)
+	row.AddChild(wrapped)
+
+	root := New(WithDisplay(DisplayFlex), WithDirection(Column), WithWidth(40))
+	root.AddChild(row)
+
+	root.Calculate(40, 24)
+
+	if got := row.HeightForWidth(40); got != 2 {
+		t.Errorf("HeightForWidth(40) = %d, want explicit 2", got)
+	}
+	if got := row.Rect().Height; got != 2 {
+		t.Errorf("row height = %d, want explicit 2", got)
+	}
+}
+
+// Degenerate widths must not panic and must not report negative heights.
+func TestRowHeightForWidthDegenerateWidth(t *testing.T) {
+	label := New(WithText("label"), WithWidth(10), WithFlexShrink(0))
+	wrapped := New(WithText("some wrapping text here"), WithFlexGrow(1), WithMinWidth(0))
+
+	row := New(WithDisplay(DisplayFlex), WithDirection(Row))
+	row.AddChild(label)
+	row.AddChild(wrapped)
+
+	root := New(WithDisplay(DisplayFlex), WithDirection(Column), WithWidth(0))
+	root.AddChild(row)
+
+	root.Calculate(0, 24)
+
+	if got := row.HeightForWidth(0); got < 0 {
+		t.Errorf("HeightForWidth(0) = %d, want >= 0", got)
+	}
+}

--- a/element_layout_tablewrap_test.go
+++ b/element_layout_tablewrap_test.go
@@ -60,11 +60,11 @@ func TestTableHeightForWidthWrapAware(t *testing.T) {
 		t.Errorf("HeightForWidth(%d) = %d, want intrinsic %d", intrW, got, intrH)
 	}
 
-	// Narrow width: columns shrink, the wide cell wraps. Column math: id
-	// column keeps 2, the auto wide column absorbs the overflow.
-	got := table.HeightForWidth(20)
-	if got < 2 {
-		t.Errorf("HeightForWidth(20) = %d, want >= 2 (wrapped cell)", got)
+	// Narrow width: columns shrink, the wide cell wraps. Column math: the id
+	// column keeps 2, the auto wide column absorbs all overflow and lands at
+	// 17 (2 + 17 + 1 gap = 20), wrapping the 29-char text to exactly 2 lines.
+	if got := table.HeightForWidth(20); got != 2 {
+		t.Errorf("HeightForWidth(20) = %d, want 2 (wrapped cell)", got)
 	}
 }
 

--- a/element_layout_tablewrap_test.go
+++ b/element_layout_tablewrap_test.go
@@ -1,0 +1,89 @@
+package tui
+
+import "testing"
+
+// tableWrapCellText is 29 chars: one line at its intrinsic width, wrapping
+// once table columns are shrunk below it.
+const tableWrapCellText = "aaaaa bbbbb ccccc ddddd eeeee"
+
+func newWrapTestTable() (table, wideCell *Element) {
+	idCell := New(WithTag("td"), WithText("id"))
+	wideCell = New(WithTag("td"), WithText(tableWrapCellText))
+	row := New(WithTag("tr"))
+	row.AddChild(idCell)
+	row.AddChild(wideCell)
+	table = New(WithTag("table"))
+	table.AddChild(row)
+	return table, wideCell
+}
+
+// Issue #127: table columns are shrunk to fit the container, but row heights
+// were computed from unwrapped intrinsic cell sizes, clipping wrapped text.
+func TestTableRowHeightGrowsForShrunkWrappedCell(t *testing.T) {
+	table, wideCell := newWrapTestTable()
+	sentinel := New(WithText("SENTINEL"))
+
+	root := New(WithDisplay(DisplayFlex), WithDirection(Column), WithWidth(20))
+	root.AddChild(table)
+	root.AddChild(sentinel)
+
+	root.Calculate(20, 24)
+
+	cellW := wideCell.Rect().Width
+	if cellW >= stringWidth(tableWrapCellText) {
+		t.Fatalf("test setup: cell width %d must force wrapping", cellW)
+	}
+	wantLines := len(wrapText(tableWrapCellText, cellW))
+	if wantLines < 2 {
+		t.Fatalf("test setup: want >= 2 wrapped lines, got %d", wantLines)
+	}
+
+	if got := wideCell.Rect().Height; got != wantLines {
+		t.Errorf("cell height = %d, want %d (wrapped lines)", got, wantLines)
+	}
+	if got := table.Rect().Height; got != wantLines {
+		t.Errorf("table height = %d, want %d", got, wantLines)
+	}
+	if got := sentinel.Rect().Y; got != wantLines {
+		t.Errorf("sentinel Y = %d, want %d (below the table)", got, wantLines)
+	}
+}
+
+// HeightForWidth on a table must account for column shrinking and cell
+// wrapping instead of falling into the generic row-container branch.
+func TestTableHeightForWidthWrapAware(t *testing.T) {
+	table, _ := newWrapTestTable()
+
+	// At full intrinsic width nothing wraps.
+	intrW, intrH := table.IntrinsicSize()
+	if got := table.HeightForWidth(intrW); got != intrH {
+		t.Errorf("HeightForWidth(%d) = %d, want intrinsic %d", intrW, got, intrH)
+	}
+
+	// Narrow width: columns shrink, the wide cell wraps. Column math: id
+	// column keeps 2, the auto wide column absorbs the overflow.
+	got := table.HeightForWidth(20)
+	if got < 2 {
+		t.Errorf("HeightForWidth(20) = %d, want >= 2 (wrapped cell)", got)
+	}
+}
+
+// An explicit row height still wins over wrapped cell growth.
+func TestTableExplicitRowHeightWinsOverWrap(t *testing.T) {
+	idCell := New(WithTag("td"), WithText("id"))
+	wideCell := New(WithTag("td"), WithText(tableWrapCellText))
+	row := New(WithTag("tr"), WithHeight(1))
+	row.AddChild(idCell)
+	row.AddChild(wideCell)
+	table := New(WithTag("table"))
+	table.AddChild(row)
+
+	root := New(WithDisplay(DisplayFlex), WithDirection(Column), WithWidth(20))
+	root.AddChild(table)
+
+	root.Calculate(20, 24)
+
+	if got := wideCell.Rect().Height; got != 1 {
+		t.Errorf("cell height = %d, want explicit 1", got)
+	}
+}

--- a/internal/layout/calculate.go
+++ b/internal/layout/calculate.go
@@ -71,22 +71,7 @@ func calculateNode(node Layoutable, available Rect, absoluteX, absoluteY float64
 
 			// Quick Phase 1: compute base sizes
 			children := node.LayoutChildren()
-			preItems := make([]flexItem, len(children))
-			for i, child := range children {
-				childStyle := child.LayoutStyle()
-				var mainMargin int
-				if isRow {
-					mainMargin = childStyle.Margin.Horizontal()
-				} else {
-					mainMargin = childStyle.Margin.Vertical()
-				}
-				childIntrinsicW, childIntrinsicH := child.IntrinsicSize()
-				if isRow {
-					preItems[i].baseSize = childStyle.Width.Resolve(mainSz, childIntrinsicW) + mainMargin
-				} else {
-					preItems[i].baseSize = childStyle.Height.Resolve(mainSz, childIntrinsicH) + mainMargin
-				}
-			}
+			preItems := buildFlexItems(children, isRow, mainSz)
 
 			// Break into lines
 			preLines := breakIntoLines(preItems, mainSz, style.Gap)
@@ -94,6 +79,11 @@ func calculateNode(node Layoutable, available Rect, absoluteX, absoluteY float64
 			// Measure cross size per line
 			totalCross := 0
 			for _, pl := range preLines {
+				// Distribute the main axis so row children are measured at
+				// their post-flex widths, matching the final layout pass.
+				if isRow {
+					distributeLineMainAxis(preItems[pl.startIdx:pl.endIdx], mainSz, style.Gap, style.JustifyContent, isRow)
+				}
 				maxCross := 0
 				for j := pl.startIdx; j < pl.endIdx; j++ {
 					child := children[j]
@@ -102,7 +92,7 @@ func calculateNode(node Layoutable, available Rect, absoluteX, absoluteY float64
 
 					var cross int
 					if isRow {
-						childWidth := preItems[j].baseSize - childStyle.Margin.Horizontal()
+						childWidth := preItems[j].mainSize - childStyle.Margin.Horizontal()
 						wrappedH := child.HeightForWidth(childWidth)
 						cross = max(wrappedH, childIntrinsicH)
 						cross += childStyle.Margin.Vertical()

--- a/internal/layout/calculate.go
+++ b/internal/layout/calculate.go
@@ -76,7 +76,9 @@ func calculateNode(node Layoutable, available Rect, absoluteX, absoluteY float64
 			// Break into lines
 			preLines := breakIntoLines(preItems, mainSz, style.Gap)
 
-			// Measure cross size per line
+			// Measure cross size per line. Keep in sync with
+			// RowContentHeight in flex.go, which runs the same measurement
+			// without the explicit cross-size override below.
 			totalCross := 0
 			for _, pl := range preLines {
 				// Distribute the main axis so row children are measured at

--- a/internal/layout/flex.go
+++ b/internal/layout/flex.go
@@ -144,6 +144,73 @@ func distributeLineMainAxis(items []flexItem, mainSize, gap int, justify Justify
 	}
 }
 
+// buildFlexItems computes base sizes and flex factors for children (Phase 1).
+func buildFlexItems(children []Layoutable, isRow bool, mainSize int) []flexItem {
+	items := make([]flexItem, len(children))
+	for i, child := range children {
+		item := &items[i]
+		item.node = child
+
+		childStyle := child.LayoutStyle()
+		var mainMargin int
+		if isRow {
+			mainMargin = childStyle.Margin.Horizontal()
+		} else {
+			mainMargin = childStyle.Margin.Vertical()
+		}
+
+		childIntrinsicW, childIntrinsicH := child.IntrinsicSize()
+		if isRow {
+			item.baseSize = childStyle.Width.Resolve(mainSize, childIntrinsicW) + mainMargin
+		} else {
+			item.baseSize = childStyle.Height.Resolve(mainSize, childIntrinsicH) + mainMargin
+		}
+
+		item.grow = childStyle.FlexGrow
+		item.shrink = childStyle.FlexShrink
+	}
+	return items
+}
+
+// RowContentHeight measures the content height a row flex container needs at
+// the given content width. It runs the same main-axis distribution as
+// layoutChildren so each child is measured at its final post-flex width, then
+// sums the tallest child of each flex line. Measuring at pre-flex widths
+// underestimates wrapped text heights (issue #126).
+func RowContentHeight(children []Layoutable, style Style, contentWidth int) int {
+	if len(children) == 0 {
+		return 0
+	}
+	items := buildFlexItems(children, true, contentWidth)
+
+	var lines []flexLine
+	if style.FlexWrap == WrapNone {
+		lines = []flexLine{{startIdx: 0, endIdx: len(items)}}
+	} else {
+		lines = breakIntoLines(items, contentWidth, style.Gap)
+	}
+
+	total := 0
+	for _, line := range lines {
+		lineItems := items[line.startIdx:line.endIdx]
+		distributeLineMainAxis(lineItems, contentWidth, style.Gap, style.JustifyContent, true)
+
+		lineH := 0
+		for i := range lineItems {
+			child := lineItems[i].node
+			childStyle := child.LayoutStyle()
+			childWidth := lineItems[i].mainSize - childStyle.Margin.Horizontal()
+			_, intrinsicH := child.IntrinsicSize()
+			h := max(child.HeightForWidth(childWidth), intrinsicH) + childStyle.Margin.Vertical()
+			if h > lineH {
+				lineH = h
+			}
+		}
+		total += lineH
+	}
+	return total
+}
+
 // recomputeTextWrapping runs Phase 3.5 for a slice of items.
 // It calls HeightForWidth to determine if text wrapping changes cross-axis sizes.
 func recomputeTextWrapping(items []flexItem, parentStyle Style, isRow bool, mainSize, crossSize int) {
@@ -256,29 +323,7 @@ func layoutChildren(node Layoutable, contentRect Rect, parentAbsX, parentAbsY fl
 	}
 
 	// Phase 1: Compute base sizes and flex factors
-	items := make([]flexItem, len(children))
-	for i, child := range children {
-		item := &items[i]
-		item.node = child
-
-		childStyle := child.LayoutStyle()
-		var mainMargin int
-		if isRow {
-			mainMargin = childStyle.Margin.Horizontal()
-		} else {
-			mainMargin = childStyle.Margin.Vertical()
-		}
-
-		childIntrinsicW, childIntrinsicH := child.IntrinsicSize()
-		if isRow {
-			item.baseSize = childStyle.Width.Resolve(mainSize, childIntrinsicW) + mainMargin
-		} else {
-			item.baseSize = childStyle.Height.Resolve(mainSize, childIntrinsicH) + mainMargin
-		}
-
-		item.grow = childStyle.FlexGrow
-		item.shrink = childStyle.FlexShrink
-	}
+	items := buildFlexItems(children, isRow, mainSize)
 
 	// Determine lines
 	var lines []flexLine

--- a/internal/layout/flex.go
+++ b/internal/layout/flex.go
@@ -177,6 +177,12 @@ func buildFlexItems(children []Layoutable, isRow bool, mainSize int) []flexItem 
 // layoutChildren so each child is measured at its final post-flex width, then
 // sums the tallest child of each flex line. Measuring at pre-flex widths
 // underestimates wrapped text heights (issue #126).
+//
+// contentWidth must already exclude the container's padding and border; style
+// is consulted only for FlexWrap, Gap, and JustifyContent, never Padding.
+// Keep the per-line measurement in sync with the wrap pre-sizing pass in
+// calculateNode, which additionally resolves explicit cross sizes against the
+// parent-allocated slot (unknowable here, where the height is indefinite).
 func RowContentHeight(children []Layoutable, style Style, contentWidth int) int {
 	if len(children) == 0 {
 		return 0

--- a/internal/layout/flex.go
+++ b/internal/layout/flex.go
@@ -206,8 +206,16 @@ func RowContentHeight(children []Layoutable, style Style, contentWidth int) int 
 			child := lineItems[i].node
 			childStyle := child.LayoutStyle()
 			childWidth := lineItems[i].mainSize - childStyle.Margin.Horizontal()
-			_, intrinsicH := child.IntrinsicSize()
-			h := max(child.HeightForWidth(childWidth), intrinsicH) + childStyle.Margin.Vertical()
+			h := child.HeightForWidth(childWidth)
+			// Floor at intrinsic height only for auto-height children: text
+			// elements report intrinsic height without the fixed-height
+			// override, so applying the floor to an explicitly sized child
+			// would inflate it past its fixed height.
+			if childStyle.Height.IsAuto() {
+				_, intrinsicH := child.IntrinsicSize()
+				h = max(h, intrinsicH)
+			}
+			h += childStyle.Margin.Vertical()
 			if h > lineH {
 				lineH = h
 			}

--- a/internal/layout/table.go
+++ b/internal/layout/table.go
@@ -217,12 +217,10 @@ func tableRowHeights(rows []Layoutable, colWidths []int, availableHeight int) []
 			var cellHeight int
 			if !cellStyle.Height.IsAuto() {
 				cellHeight = cellStyle.Height.Resolve(availableHeight, intrH)
-			} else if ci < len(colWidths) {
+			} else {
 				// HeightForWidth equals intrH when nothing wraps, so this
 				// only grows rows whose cells wrap at the shrunk width.
 				cellHeight = max(intrH, cell.HeightForWidth(colWidths[ci]))
-			} else {
-				cellHeight = intrH
 			}
 
 			// Include cell padding in row height calculation

--- a/internal/layout/table.go
+++ b/internal/layout/table.go
@@ -12,125 +12,14 @@ func layoutTable(table Layoutable, contentRect Rect, parentAbsX, parentAbsY floa
 		return
 	}
 
-	// 1. Collect grid dimensions: determine number of columns and gather cells.
-	numCols := 0
-	for _, row := range rows {
-		cells := row.LayoutChildren()
-		if len(cells) > numCols {
-			numCols = len(cells)
-		}
-	}
+	// 1-3. Compute grid dimensions and column widths (shrunk to fit).
+	numCols, colWidths := tableColumnWidths(rows, contentRect.Width)
 	if numCols == 0 {
 		return
 	}
 
-	// 2. Compute column widths: max intrinsic width per column.
-	// An explicit (non-Auto) width on a cell overrides its intrinsic width.
-	colWidths := make([]int, numCols)
-	colIsAuto := make([]bool, numCols) // track which columns are auto-sized
-	for i := range colIsAuto {
-		colIsAuto[i] = true
-	}
-
-	for _, row := range rows {
-		cells := row.LayoutChildren()
-		for ci, cell := range cells {
-			cellStyle := cell.LayoutStyle()
-			intrW, _ := cell.IntrinsicSize()
-
-			var cellWidth int
-			if !cellStyle.Width.IsAuto() {
-				// Explicit width overrides intrinsic
-				cellWidth = cellStyle.Width.Resolve(contentRect.Width, intrW)
-				colIsAuto[ci] = false
-			} else {
-				cellWidth = intrW
-			}
-
-			// Include cell padding in column width calculation
-			cellWidth += cellStyle.Padding.Horizontal()
-
-			if cellWidth > colWidths[ci] {
-				colWidths[ci] = cellWidth
-			}
-		}
-	}
-
-	// 3. Shrink auto columns proportionally if total > available width.
-	// Include 1-character gap between columns in total width.
-	columnGap := max(0, numCols-1) // 1 char gap between each pair of columns
-	totalWidth := columnGap
-	for _, w := range colWidths {
-		totalWidth += w
-	}
-
-	if totalWidth > contentRect.Width {
-		// Compute total auto-column width for proportional shrinking
-		totalAutoWidth := 0
-		for ci, w := range colWidths {
-			if colIsAuto[ci] {
-				totalAutoWidth += w
-			}
-		}
-
-		overflow := totalWidth - contentRect.Width
-		if totalAutoWidth > 0 && overflow > 0 {
-			// Shrink auto columns proportionally
-			shrunk := 0
-			lastAutoCol := -1
-			for ci := range colWidths {
-				if colIsAuto[ci] {
-					lastAutoCol = ci
-				}
-			}
-
-			for ci := range colWidths {
-				if colIsAuto[ci] {
-					reduction := int(float64(overflow) * float64(colWidths[ci]) / float64(totalAutoWidth))
-					if ci == lastAutoCol {
-						// Give the remainder to the last auto column to avoid rounding errors
-						reduction = overflow - shrunk
-					}
-					colWidths[ci] = max(1, colWidths[ci]-reduction)
-					shrunk += reduction
-				}
-			}
-		}
-	}
-
-	// 4. Compute row heights: max intrinsic height per row.
-	// Explicit h-N on <tr> overrides the computed max.
-	rowHeights := make([]int, len(rows))
-	for ri, row := range rows {
-		rowStyle := row.LayoutStyle()
-		if !rowStyle.Height.IsAuto() {
-			// Explicit row height overrides cell-based calculation
-			rowHeights[ri] = rowStyle.Height.Resolve(contentRect.Height, 1)
-			continue
-		}
-
-		cells := row.LayoutChildren()
-		maxH := 1 // minimum row height is 1
-		for _, cell := range cells {
-			cellStyle := cell.LayoutStyle()
-			_, intrH := cell.IntrinsicSize()
-
-			var cellHeight int
-			if !cellStyle.Height.IsAuto() {
-				cellHeight = cellStyle.Height.Resolve(contentRect.Height, intrH)
-			} else {
-				cellHeight = intrH
-			}
-
-			// Include cell padding in row height calculation
-			cellHeight += cellStyle.Padding.Vertical()
-
-			if cellHeight > maxH {
-				maxH = cellHeight
-			}
-		}
-		rowHeights[ri] = maxH
-	}
+	// 4. Compute row heights from cells at their final column widths.
+	rowHeights := tableRowHeights(rows, colWidths, contentRect.Height)
 
 	// 5. Position rows top-to-bottom, cells left-to-right at column offsets.
 	// Precompute column X offsets with 1-character gap between columns.
@@ -213,6 +102,157 @@ func layoutTable(table Layoutable, contentRect Rect, parentAbsX, parentAbsY floa
 
 		rowAbsY += float64(rowH)
 	}
+}
+
+// tableColumnWidths computes the number of columns and the final column
+// widths for a table. Each column starts at the max intrinsic (or explicit)
+// cell width in that column; auto columns are then shrunk proportionally when
+// the total exceeds availableWidth. Widths include cell padding.
+func tableColumnWidths(rows []Layoutable, availableWidth int) (numCols int, colWidths []int) {
+	for _, row := range rows {
+		cells := row.LayoutChildren()
+		if len(cells) > numCols {
+			numCols = len(cells)
+		}
+	}
+	if numCols == 0 {
+		return 0, nil
+	}
+
+	colWidths = make([]int, numCols)
+	colIsAuto := make([]bool, numCols) // track which columns are auto-sized
+	for i := range colIsAuto {
+		colIsAuto[i] = true
+	}
+
+	for _, row := range rows {
+		cells := row.LayoutChildren()
+		for ci, cell := range cells {
+			cellStyle := cell.LayoutStyle()
+			intrW, _ := cell.IntrinsicSize()
+
+			var cellWidth int
+			if !cellStyle.Width.IsAuto() {
+				// Explicit width overrides intrinsic
+				cellWidth = cellStyle.Width.Resolve(availableWidth, intrW)
+				colIsAuto[ci] = false
+			} else {
+				cellWidth = intrW
+			}
+
+			// Include cell padding in column width calculation
+			cellWidth += cellStyle.Padding.Horizontal()
+
+			if cellWidth > colWidths[ci] {
+				colWidths[ci] = cellWidth
+			}
+		}
+	}
+
+	// Shrink auto columns proportionally if total > available width.
+	// Include 1-character gap between columns in total width.
+	columnGap := max(0, numCols-1) // 1 char gap between each pair of columns
+	totalWidth := columnGap
+	for _, w := range colWidths {
+		totalWidth += w
+	}
+
+	if totalWidth > availableWidth {
+		// Compute total auto-column width for proportional shrinking
+		totalAutoWidth := 0
+		for ci, w := range colWidths {
+			if colIsAuto[ci] {
+				totalAutoWidth += w
+			}
+		}
+
+		overflow := totalWidth - availableWidth
+		if totalAutoWidth > 0 && overflow > 0 {
+			// Shrink auto columns proportionally
+			shrunk := 0
+			lastAutoCol := -1
+			for ci := range colWidths {
+				if colIsAuto[ci] {
+					lastAutoCol = ci
+				}
+			}
+
+			for ci := range colWidths {
+				if colIsAuto[ci] {
+					reduction := int(float64(overflow) * float64(colWidths[ci]) / float64(totalAutoWidth))
+					if ci == lastAutoCol {
+						// Give the remainder to the last auto column to avoid rounding errors
+						reduction = overflow - shrunk
+					}
+					colWidths[ci] = max(1, colWidths[ci]-reduction)
+					shrunk += reduction
+				}
+			}
+		}
+	}
+
+	return numCols, colWidths
+}
+
+// tableRowHeights computes per-row heights from cells measured at their final
+// column widths. Explicit heights on a <tr> or cell win; auto-height cells
+// grow to their wrapped height when the shrunk column forces text to wrap
+// (issue #127).
+func tableRowHeights(rows []Layoutable, colWidths []int, availableHeight int) []int {
+	rowHeights := make([]int, len(rows))
+	for ri, row := range rows {
+		rowStyle := row.LayoutStyle()
+		if !rowStyle.Height.IsAuto() {
+			// Explicit row height overrides cell-based calculation
+			rowHeights[ri] = rowStyle.Height.Resolve(availableHeight, 1)
+			continue
+		}
+
+		cells := row.LayoutChildren()
+		maxH := 1 // minimum row height is 1
+		for ci, cell := range cells {
+			cellStyle := cell.LayoutStyle()
+			_, intrH := cell.IntrinsicSize()
+
+			var cellHeight int
+			if !cellStyle.Height.IsAuto() {
+				cellHeight = cellStyle.Height.Resolve(availableHeight, intrH)
+			} else if ci < len(colWidths) {
+				// HeightForWidth equals intrH when nothing wraps, so this
+				// only grows rows whose cells wrap at the shrunk width.
+				cellHeight = max(intrH, cell.HeightForWidth(colWidths[ci]))
+			} else {
+				cellHeight = intrH
+			}
+
+			// Include cell padding in row height calculation
+			cellHeight += cellStyle.Padding.Vertical()
+
+			if cellHeight > maxH {
+				maxH = cellHeight
+			}
+		}
+		rowHeights[ri] = maxH
+	}
+	return rowHeights
+}
+
+// TableHeightForWidth measures the content height a table needs at the given
+// content width: column widths are resolved (including proportional
+// shrinking) and rows are measured at those final widths. availableHeight is
+// indefinite in this context, so explicit percent heights resolve against 0,
+// matching TableIntrinsicSize.
+func TableHeightForWidth(table Layoutable, contentWidth int) int {
+	rows := table.LayoutChildren()
+	numCols, colWidths := tableColumnWidths(rows, contentWidth)
+	if numCols == 0 {
+		return 0
+	}
+	total := 0
+	for _, h := range tableRowHeights(rows, colWidths, 0) {
+		total += h
+	}
+	return total
 }
 
 // TableIntrinsicSize computes the intrinsic size of a table.


### PR DESCRIPTION
## Summary

Sizing a row with wrapping text is a two-pass problem. The parent asks the row how tall it will be at a given width before flex has divided that width among the row's children, and `HeightForWidth` answered by measuring every child at the full row width. A wrapping child that flex later narrows needs more lines than that estimate reserved, nothing feeds the taller height back, and the extra lines get clipped while the next sibling renders one row too high. The flex-wrap pre-sizing pass in `calculateNode` had the same flaw with base sizes: an item pushed to its own wrap line and shrunk to the row width was still measured at its unshrunk width.

## The fix

The estimator now runs the same math as the layout pass. Phase 1 base-size computation moved into a shared `buildFlexItems`, and a new `layout.RowContentHeight` breaks children into flex lines, runs the existing `distributeLineMainAxis` on each line, measures every child with `HeightForWidth` at its post-flex width, and sums the per-line maxima. Both the row branch of `Element.HeightForWidth` and the wrap pre-sizing pass go through this distribution, so the estimate matches the final layout by construction, including grow/shrink rounding.

The single-line case in `layoutChildren` still assigns the parent-allocated cross size to the line. That is correct once the allocation itself is right, and growing the line independently would overflow the slot the parent reserved.

Tests reproduce the issue at both levels (plain row and flex-wrap row, asserting the sibling below lands in the right place) and pin the boundaries: gaps are accounted for in the post-flex widths, rows keep height 1 when nothing wraps, explicit heights still win, and degenerate zero widths do not panic.

As in CSS, `min-width: auto` resolves to the unwrapped text width, so shrink-induced wrapping still needs `min-w-0` (`WithMinWidth(0)`) on the text child. The repro in the issue already sets this.

## Tables (#127)

Tables had the same bug in spirit, in two places, so the fix is included here. `layoutTable` shrinks auto columns to fit the container but computed row heights from unwrapped intrinsic cell sizes, clipping any cell whose text wraps at the shrunk width. Column-width resolution and row-height measurement now live in shared helpers (`tableColumnWidths`, `tableRowHeights`), and auto-height cells are measured with `HeightForWidth` at their final column width. Since that equals the intrinsic height when nothing wraps, non-wrapping tables lay out exactly as before, and explicit row and cell heights still win.

`Element.HeightForWidth` also had no table branch, so a `<table>` (default direction Row) fell into the flex row measurement path. That was roughly harmless before, but with the row branch now running real flex distribution the generic estimate diverged from `layoutTable`'s actual row heights, misplacing content below a squeezed table. A new `layout.TableHeightForWidth` measures tables the same way `layoutTable` lays them out, and `HeightForWidth` dispatches to it.

## Scope notes

`RowContentHeight` re-walks `IntrinsicSize` up to three times per child per measurement. Fine at TUI tree sizes and consistent with the existing Phase 3.5 pattern, so caching intrinsics on `flexItem` can wait until deep row nesting shows up in a profile.

Fixes #126
Fixes #127
