### PR TITLE
fix(editor): highlight package-qualified component calls in VS Code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,19 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           fail_ci_if_error: true
+
+  vscode-grammar:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: editor/vscode
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      - name: Grammar tests
+        run: bun test

--- a/editor/vscode/bun.lock
+++ b/editor/vscode/bun.lock
@@ -11,6 +11,8 @@
         "@types/node": "^25.0.10",
         "@types/vscode": "^1.75.0",
         "typescript": "^5.0.0",
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.3.2",
       },
     },
   },
@@ -38,5 +40,9 @@
     "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
 
     "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-oniguruma": ["vscode-oniguruma@2.0.1", "", {}, "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ=="],
+
+    "vscode-textmate": ["vscode-textmate@9.3.2", "", {}, "sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q=="],
   }
 }

--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -94,7 +94,8 @@
     "vscode:prepublish": "bun run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "package": "bunx @vscode/vsce package --allow-missing-repository"
+    "package": "bunx @vscode/vsce package --allow-missing-repository",
+    "test": "bun test"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"
@@ -102,6 +103,8 @@
   "devDependencies": {
     "@types/node": "^25.0.10",
     "@types/vscode": "^1.75.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vscode-oniguruma": "^2.0.1",
+    "vscode-textmate": "^9.3.2"
   }
 }

--- a/editor/vscode/syntaxes/gsx.tmLanguage.json
+++ b/editor/vscode/syntaxes/gsx.tmLanguage.json
@@ -224,14 +224,14 @@
       ]
     },
     "component-call": {
-      "comment": "@Name(args) or @pkg.Name(args); the paren must be adjacent (matching the lexer), args are Go, and like pkg.Func() only the last segment is coloured",
+      "comment": "@Name(args) or @pkg.Name(args); the paren must be adjacent (matching the lexer) and args are Go",
       "name": "meta.component-call.gsx",
-      "begin": "(@)((?:[a-zA-Z_][a-zA-Z0-9_]*\\.)*)([a-zA-Z_][a-zA-Z0-9_]*)(\\()",
+      "begin": "(@)((?:[a-zA-Z_][a-zA-Z0-9_]*\\.)*[a-zA-Z_][a-zA-Z0-9_]*)(\\()",
       "end": "\\)",
       "beginCaptures": {
         "1": { "name": "punctuation.definition.component-call.gsx" },
-        "3": { "name": "entity.name.function.component-call.gsx" },
-        "4": { "name": "punctuation.definition.arguments.begin.gsx" }
+        "2": { "name": "entity.name.function.component-call.gsx" },
+        "3": { "name": "punctuation.definition.arguments.begin.gsx" }
       },
       "endCaptures": {
         "0": { "name": "punctuation.definition.arguments.end.gsx" }

--- a/editor/vscode/syntaxes/gsx.tmLanguage.json
+++ b/editor/vscode/syntaxes/gsx.tmLanguage.json
@@ -224,14 +224,14 @@
       ]
     },
     "component-call": {
-      "comment": "@Name(args) or @pkg.Name(args); the paren must be adjacent (matching the lexer) and args are Go",
+      "comment": "@Name(args) or @pkg.Name(args); the paren must be adjacent (matching the lexer), args are Go, and like pkg.Func() only the last segment is coloured",
       "name": "meta.component-call.gsx",
-      "begin": "(@)((?:[a-zA-Z_][a-zA-Z0-9_]*\\.)*[a-zA-Z_][a-zA-Z0-9_]*)(\\()",
+      "begin": "(@)((?:[a-zA-Z_][a-zA-Z0-9_]*\\.)*)([a-zA-Z_][a-zA-Z0-9_]*)(\\()",
       "end": "\\)",
       "beginCaptures": {
         "1": { "name": "punctuation.definition.component-call.gsx" },
-        "2": { "name": "entity.name.function.component-call.gsx" },
-        "3": { "name": "punctuation.definition.arguments.begin.gsx" }
+        "3": { "name": "entity.name.function.component-call.gsx" },
+        "4": { "name": "punctuation.definition.arguments.begin.gsx" }
       },
       "endCaptures": {
         "0": { "name": "punctuation.definition.arguments.end.gsx" }

--- a/editor/vscode/syntaxes/gsx.tmLanguage.json
+++ b/editor/vscode/syntaxes/gsx.tmLanguage.json
@@ -200,9 +200,9 @@
           }
         },
         {
-          "comment": "Short binding: name := <element> or name := @Component()",
+          "comment": "Short binding: name := <element> or name := @Component() / @pkg.Component()",
           "name": "meta.control.binding.gsx",
-          "match": "([a-zA-Z_][a-zA-Z0-9_]*)\\s*(:=)\\s*(?=<|@[A-Z])",
+          "match": "([a-zA-Z_][a-zA-Z0-9_]*)\\s*(:=)\\s*(?=<|@[a-zA-Z_])",
           "captures": {
             "1": { "name": "variable.other.gsx" },
             "2": { "name": "keyword.operator.assignment.gsx" }
@@ -225,7 +225,7 @@
     },
     "component-call": {
       "name": "meta.component-call.gsx",
-      "match": "(@)([A-Z][a-zA-Z0-9_]*)\\s*\\(",
+      "match": "(@)((?:[a-zA-Z_][a-zA-Z0-9_]*\\.)*[a-zA-Z_][a-zA-Z0-9_]*)\\(",
       "captures": {
         "1": { "name": "punctuation.definition.component-call.gsx" },
         "2": { "name": "entity.name.function.component-call.gsx" }

--- a/editor/vscode/syntaxes/gsx.tmLanguage.json
+++ b/editor/vscode/syntaxes/gsx.tmLanguage.json
@@ -224,12 +224,24 @@
       ]
     },
     "component-call": {
+      "comment": "@Name(args) or @pkg.Name(args); the paren must be adjacent (matching the lexer) and args are Go",
       "name": "meta.component-call.gsx",
-      "match": "(@)((?:[a-zA-Z_][a-zA-Z0-9_]*\\.)*[a-zA-Z_][a-zA-Z0-9_]*)\\(",
-      "captures": {
+      "begin": "(@)((?:[a-zA-Z_][a-zA-Z0-9_]*\\.)*[a-zA-Z_][a-zA-Z0-9_]*)(\\()",
+      "end": "\\)",
+      "beginCaptures": {
         "1": { "name": "punctuation.definition.component-call.gsx" },
-        "2": { "name": "entity.name.function.component-call.gsx" }
-      }
+        "2": { "name": "entity.name.function.component-call.gsx" },
+        "3": { "name": "punctuation.definition.arguments.begin.gsx" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.arguments.end.gsx" }
+      },
+      "contentName": "meta.embedded.block.go",
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#go-nested-parens" },
+        { "include": "#go-expression-content" }
+      ]
     },
     "element": {
       "patterns": [
@@ -627,6 +639,17 @@
         { "include": "#comments" },
         { "include": "#strings" },
         { "include": "#go-nested-block" },
+        { "include": "#go-expression-content" }
+      ]
+    },
+    "go-nested-parens": {
+      "comment": "Recursive paren matching inside call arguments",
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#strings" },
+        { "include": "#go-nested-parens" },
         { "include": "#go-expression-content" }
       ]
     },

--- a/editor/vscode/test/grammar.test.ts
+++ b/editor/vscode/test/grammar.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import * as oniguruma from "vscode-oniguruma";
+import * as vsctm from "vscode-textmate";
+
+// GRAMMAR_PATH lets the same test run against another grammar file, which is
+// how a change is checked to fail against the previous version.
+const grammarPath = process.env.GRAMMAR_PATH ?? path.join(import.meta.dir, "..", "syntaxes", "gsx.tmLanguage.json");
+
+const wasm = fs.readFileSync(path.join(path.dirname(require.resolve("vscode-oniguruma")), "onig.wasm")).buffer;
+const onigLib = oniguruma.loadWASM(wasm).then(() => ({
+  createOnigScanner: (patterns: string[]) => new oniguruma.OnigScanner(patterns),
+  createOnigString: (s: string) => new oniguruma.OnigString(s),
+}));
+const registry = new vsctm.Registry({
+  onigLib,
+  loadGrammar: async () => vsctm.parseRawGrammar(fs.readFileSync(grammarPath, "utf8"), grammarPath),
+});
+
+type Token = { text: string; scopes: string[] };
+
+async function tokenize(source: string): Promise<Token[][]> {
+  const grammar = await registry.loadGrammar("source.gsx");
+  if (!grammar) throw new Error("grammar failed to load");
+  let state = vsctm.INITIAL;
+  return source.split("\n").map((line) => {
+    const r = grammar.tokenizeLine(line, state);
+    state = r.ruleStack;
+    return r.tokens.map((t) => ({ text: line.slice(t.startIndex, t.endIndex), scopes: t.scopes }));
+  });
+}
+
+// innermost returns the last scope of the token whose text equals `text` on the given line.
+function innermost(lines: Token[][], line: number, text: string): string {
+  const tok = lines[line].find((t) => t.text === text);
+  if (!tok) throw new Error(`no token ${JSON.stringify(text)} on line ${line}: ${lines[line].map((t) => t.text).join("|")}`);
+  return tok.scopes[tok.scopes.length - 1];
+}
+
+const source = `package main
+
+templ App(items []int) {
+	<div class="flex-col">
+		@widgets.Header("hover or F12")
+		@Card(42) {
+			<span>@c.icon (beta)</span>
+		}
+		@widgets.Row(fmt.Sprintf("%d items", len(items)), true)
+		h := @widgets.Header("bound")
+		@widgets.Multi(
+			"first",
+			2,
+		)
+	</div>
+}`;
+
+const CALL = "entity.name.function.component-call.gsx";
+
+describe("component calls", () => {
+  test("qualified and bare names are function-scoped as a whole", async () => {
+    const lines = await tokenize(source);
+    expect(innermost(lines, 4, "widgets.Header")).toBe(CALL);
+    expect(innermost(lines, 5, "Card")).toBe(CALL);
+    expect(innermost(lines, 8, "widgets.Row")).toBe(CALL);
+  });
+
+  test("arguments are highlighted as Go", async () => {
+    const lines = await tokenize(source);
+    expect(innermost(lines, 4, "hover or F12")).toBe("string.quoted.double.gsx");
+    expect(innermost(lines, 5, "42")).toBe("constant.numeric.integer.gsx");
+    expect(innermost(lines, 8, "Sprintf")).toBe("entity.name.function.go.gsx");
+    expect(innermost(lines, 8, "%d")).toBe("constant.other.placeholder.gsx");
+    expect(innermost(lines, 8, "len")).toBe("support.function.builtin.go.gsx");
+    expect(innermost(lines, 8, "true")).toBe("constant.language.go.gsx");
+  });
+
+  test("multi-line arguments stay inside the call", async () => {
+    const lines = await tokenize(source);
+    expect(innermost(lines, 11, "first")).toBe("string.quoted.double.gsx");
+    expect(innermost(lines, 12, "2")).toBe("constant.numeric.integer.gsx");
+    expect(innermost(lines, 13, ")")).toBe("punctuation.definition.arguments.end.gsx");
+  });
+
+  test("a qualified call in a short binding keeps the binding scope", async () => {
+    const lines = await tokenize(source);
+    expect(innermost(lines, 9, "h")).toBe("variable.other.gsx");
+    expect(innermost(lines, 9, "widgets.Header")).toBe(CALL);
+  });
+
+  test("an expression followed by spaced paren text is not a call", async () => {
+    const lines = await tokenize(source);
+    // The lexer needs the paren adjacent; "@c.icon (beta)" is an expression plus text.
+    expect(innermost(lines, 6, "@c.icon (beta)")).toBe("meta.component.gsx");
+  });
+});


### PR DESCRIPTION
## Summary

VS Code highlights `.gsx` with the TextMate grammar, and its component-call rule only matched `@` followed by an uppercase name, so `@widgets.Header(...)` rendered plain white. Hover and go-to-definition already worked because they come from the language server.

The rule now accepts a dotted name and requires the `(` to be adjacent, the same rule the lexer applies. The whole dotted name takes the component-call colour. The short-binding lookahead accepts a lowercase package prefix for `h := @widgets.Header(...)`.

The rule also used to stop at the opening paren, so strings and numbers passed to any component call had no scope either. It is now a begin/end block whose contents reuse the existing Go expression patterns, so `@Card("title", 42)` and `@Row(fmt.Sprintf("%d", n))` colour like Go.

Verified by tokenizing a sample with vscode-textmate against the old and new grammar.
