### PR TITLE
fix(lsp): find a .gsx declaration when the target file is open in the editor

### DIFF
--- a/internal/lsp/provider/definition.go
+++ b/internal/lsp/provider/definition.go
@@ -635,7 +635,7 @@ func (d *definitionProvider) translateGoplsLocations(ctx *CursorContext, goplsLo
 		// passes through like any other external file.
 		if gopls.IsGeneratedGoFile(gl.URI) {
 			tuiURI := gopls.GeneratedGoURIToTuiURI(gl.URI)
-			if d.workspace != nil && d.workspace.GetWorkspaceAST(tuiURI) != nil {
+			if d.gsxAST(tuiURI) != nil {
 				if loc := d.locateInWorkspaceGsx(tuiURI, ctx.Word); loc != nil {
 					locs = append(locs, *loc)
 				} else {
@@ -742,10 +742,10 @@ var goFuncName = regexp.MustCompile(`^func\s+(\w+)\s*[\[(]`)
 // workspace .gsx file at tuiURI. Used to turn a gopls hit inside a generated
 // _gsx.go file into a location in the source the user edits.
 func (d *definitionProvider) locateInWorkspaceGsx(tuiURI, name string) *Location {
-	if d.workspace == nil || name == "" {
+	if name == "" {
 		return nil
 	}
-	ast := d.workspace.GetWorkspaceAST(tuiURI)
+	ast := d.gsxAST(tuiURI)
 	if ast == nil {
 		return nil
 	}
@@ -758,6 +758,21 @@ func (d *definitionProvider) locateInWorkspaceGsx(tuiURI, name string) *Location
 		if m := goFuncName.FindStringSubmatch(fn.Code); m != nil && m[1] == name {
 			return locationAt(tuiURI, fn.Position, len(name))
 		}
+	}
+	return nil
+}
+
+// gsxAST returns the parsed AST for a .gsx in this workspace. An open file
+// lives in the document manager (the server drops it from the workspace cache
+// on didOpen), so both are consulted.
+func (d *definitionProvider) gsxAST(uri string) *tuigen.File {
+	if d.docs != nil {
+		if doc := d.docs.GetDocument(uri); doc != nil && doc.AST != nil {
+			return doc.AST
+		}
+	}
+	if d.workspace != nil {
+		return d.workspace.GetWorkspaceAST(uri)
 	}
 	return nil
 }

--- a/internal/lsp/provider/definition_test.go
+++ b/internal/lsp/provider/definition_test.go
@@ -587,12 +587,24 @@ func TestDefinition_TranslateGoplsLocations(t *testing.T) {
 			goURI: "file:///usr/local/go/src/fmt/print.go", word: "Println",
 			wantURI: "file:///usr/local/go/src/fmt/print.go", wantLine: 57,
 		},
+		"open document maps to its .gsx even though the workspace cache dropped it": {
+			goURI: "file:///w/open_gsx.go", word: "Panel",
+			wantURI: "file:///w/open.gsx", wantLine: 2,
+		},
 	}
+
+	// Opening a file moves its AST from the workspace cache to the document
+	// manager, so the provider must consult both.
+	openDocs := &stubDocAccessor{docs: []*Document{{
+		URI: "file:///w/open.gsx",
+		AST: &tuigen.File{Components: []*tuigen.Component{{Name: "Panel", Position: tuigen.Position{Line: 3, Column: 1}}}},
+	}}}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			dp := newTestDefinitionProvider(newStubIndex())
 			dp.workspace = ws
+			dp.docs = openDocs
 			ctx := makeCtx(parseTestDoc("package test"), NodeKindComponentCall, tt.word)
 
 			got := dp.translateGoplsLocations(ctx, []gopls.Location{{


### PR DESCRIPTION
## Summary

Go-to-definition on `@widgets.Header(...)` jumped to `widgets/header.gsx` the first time and to the generated `header_gsx.go` every time after.

The server drops a file's AST from the workspace cache on `didOpen` and serves it from the document manager until `didClose`. The definition provider only looked at the workspace cache, so once the first jump had opened `header.gsx` the file looked like a module-cache dependency and its gopls location was passed through untranslated.

The provider now checks open documents before the workspace cache. Reproduced with an LSP session that opens the target file before the second request, and pinned by a test.
