### PR TITLE
fix(lsp): highlight the component name on go-to-definition

### DIFF
--- a/internal/lsp/context_resolve.go
+++ b/internal/lsp/context_resolve.go
@@ -64,8 +64,12 @@ func resolveFromAST(ctx *CursorContext, file *tuigen.File) {
 	// precise match regardless of component ordering.
 	for _, comp := range file.Components {
 		if line == comp.Position.Line {
-			// Check if cursor is on the component name
-			nameStart := comp.Position.Column
+			// Check if cursor is on the component name (NamePos accounts for
+			// the receiver in method templs; older ASTs fall back to the keyword)
+			nameStart := comp.NamePos.Column
+			if comp.NamePos.Line == 0 {
+				nameStart = comp.Position.Column
+			}
 			nameEnd := nameStart + len(comp.Name)
 			if col >= nameStart && col <= nameEnd {
 				ctx.Node = comp

--- a/internal/lsp/index.go
+++ b/internal/lsp/index.go
@@ -74,21 +74,9 @@ func (idx *ComponentIndex) Add(uri string, comp *tuigen.Component) {
 	defer idx.mu.Unlock()
 
 	info := &ComponentInfo{
-		Name:   comp.Name,
-		Params: comp.Params,
-		Location: Location{
-			URI: uri,
-			Range: Range{
-				Start: Position{
-					Line:      comp.Position.Line - 1, // tuigen is 1-indexed, LSP is 0-indexed
-					Character: comp.Position.Column - 1,
-				},
-				End: Position{
-					Line:      comp.Position.Line - 1,
-					Character: comp.Position.Column - 1 + len("@component") + 1 + len(comp.Name),
-				},
-			},
-		},
+		Name:     comp.Name,
+		Params:   comp.Params,
+		Location: componentNameLocation(uri, comp),
 	}
 
 	idx.Components[comp.Name] = info
@@ -370,4 +358,18 @@ func parseFuncSignature(code string) (name, signature string, params []FuncParam
 	}
 
 	return name, signature, params, returns
+}
+
+// componentNameLocation spans the component's name (tuigen is 1-indexed, LSP
+// is 0-indexed). Falls back to the templ keyword for ASTs without NamePos.
+func componentNameLocation(uri string, comp *tuigen.Component) Location {
+	pos := comp.NamePos
+	if pos.Line == 0 {
+		pos = comp.Position
+	}
+	start := Position{Line: pos.Line - 1, Character: pos.Column - 1}
+	return Location{
+		URI:   uri,
+		Range: Range{Start: start, End: Position{Line: start.Line, Character: start.Character + len(comp.Name)}},
+	}
 }

--- a/internal/lsp/index.go
+++ b/internal/lsp/index.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/grindlemire/go-tui/internal/tuigen"
 )
@@ -361,7 +362,8 @@ func parseFuncSignature(code string) (name, signature string, params []FuncParam
 }
 
 // componentNameLocation spans the component's name (tuigen is 1-indexed, LSP
-// is 0-indexed). Falls back to the templ keyword for ASTs without NamePos.
+// is 0-indexed, both count runes). Falls back to the templ keyword for ASTs
+// without NamePos.
 func componentNameLocation(uri string, comp *tuigen.Component) Location {
 	pos := comp.NamePos
 	if pos.Line == 0 {
@@ -370,6 +372,6 @@ func componentNameLocation(uri string, comp *tuigen.Component) Location {
 	start := Position{Line: pos.Line - 1, Character: pos.Column - 1}
 	return Location{
 		URI:   uri,
-		Range: Range{Start: start, End: Position{Line: start.Line, Character: start.Character + len(comp.Name)}},
+		Range: Range{Start: start, End: Position{Line: start.Line, Character: start.Character + utf8.RuneCountInString(comp.Name)}},
 	}
 }

--- a/internal/lsp/index.go
+++ b/internal/lsp/index.go
@@ -191,19 +191,7 @@ func (idx *ComponentIndex) AddFunc(uri string, fn *tuigen.GoFunc) {
 		Signature: sig,
 		Params:    params,
 		Returns:   returns,
-		Location: Location{
-			URI: uri,
-			Range: Range{
-				Start: Position{
-					Line:      fn.Position.Line - 1,
-					Character: fn.Position.Column - 1,
-				},
-				End: Position{
-					Line:      fn.Position.Line - 1,
-					Character: fn.Position.Column - 1 + len("func") + 1 + len(name),
-				},
-			},
-		},
+		Location:  funcNameLocation(uri, fn, name),
 	}
 
 	idx.Functions[name] = info
@@ -305,7 +293,7 @@ func (idx *ComponentIndex) AllFunctions() []string {
 // parseFuncSignature extracts function name, signature, params and return type from Go code.
 func parseFuncSignature(code string) (name, signature string, params []FuncParam, returns string) {
 	// Match: func name(params) returns
-	re := regexp.MustCompile(`func\s+(\w+)\s*\(([^)]*)\)\s*([^{]*)`)
+	re := regexp.MustCompile(`func\s+([\p{L}_][\p{L}\p{N}_]*)\s*\(([^)]*)\)\s*([^{]*)`)
 	matches := re.FindStringSubmatch(code)
 	if len(matches) < 2 {
 		return "", "", nil, ""
@@ -373,5 +361,22 @@ func componentNameLocation(uri string, comp *tuigen.Component) Location {
 	return Location{
 		URI:   uri,
 		Range: Range{Start: start, End: Position{Line: start.Line, Character: start.Character + utf8.RuneCountInString(comp.Name)}},
+	}
+}
+
+// funcNameRe locates the name in a func declaration's source.
+var funcNameRe = regexp.MustCompile(`func\s+([\p{L}_][\p{L}\p{N}_]*)`)
+
+// funcNameLocation spans the func's name on its first line (LSP columns are
+// 0-indexed runes). Falls back to the func keyword if the name is not found.
+func funcNameLocation(uri string, fn *tuigen.GoFunc, name string) Location {
+	offset := 0
+	if m := funcNameRe.FindStringSubmatchIndex(fn.Code); m != nil && fn.Code[m[2]:m[3]] == name {
+		offset = utf8.RuneCountInString(fn.Code[:m[2]])
+	}
+	start := Position{Line: fn.Position.Line - 1, Character: fn.Position.Column - 1 + offset}
+	return Location{
+		URI:   uri,
+		Range: Range{Start: start, End: Position{Line: start.Line, Character: start.Character + utf8.RuneCountInString(name)}},
 	}
 }

--- a/internal/lsp/index_coverage_test.go
+++ b/internal/lsp/index_coverage_test.go
@@ -227,3 +227,22 @@ func TestParseFuncSignature(t *testing.T) {
 		})
 	}
 }
+
+// The indexed location of a component spans its name so go-to-definition
+// highlights "Header", not "templ ".
+func TestComponentIndex_LocationSpansName(t *testing.T) {
+	idx := NewComponentIndex()
+	idx.Add("file:///w/a.gsx", &tuigen.Component{
+		Name:     "Header",
+		Position: tuigen.Position{Line: 3, Column: 1},
+		NamePos:  tuigen.Position{Line: 3, Column: 7},
+	})
+	info, ok := idx.Lookup("Header")
+	if !ok {
+		t.Fatal("component not indexed")
+	}
+	r := info.Location.Range
+	if r.Start.Line != 2 || r.Start.Character != 6 || r.End.Line != 2 || r.End.Character != 12 {
+		t.Errorf("range = %d:%d..%d:%d, want 2:6..2:12", r.Start.Line, r.Start.Character, r.End.Line, r.End.Character)
+	}
+}

--- a/internal/lsp/index_coverage_test.go
+++ b/internal/lsp/index_coverage_test.go
@@ -246,3 +246,18 @@ func TestComponentIndex_LocationSpansName(t *testing.T) {
 		t.Errorf("range = %d:%d..%d:%d, want 2:6..2:12", r.Start.Line, r.Start.Character, r.End.Line, r.End.Character)
 	}
 }
+
+// Columns are rune-based, so a non-ASCII name must not overshoot by its
+// extra UTF-8 bytes.
+func TestComponentIndex_LocationSpansUnicodeName(t *testing.T) {
+	idx := NewComponentIndex()
+	idx.Add("file:///w/a.gsx", &tuigen.Component{
+		Name:     "Café",
+		Position: tuigen.Position{Line: 1, Column: 1},
+		NamePos:  tuigen.Position{Line: 1, Column: 7},
+	})
+	info, _ := idx.Lookup("Café")
+	if got := info.Location.Range.End.Character; got != 10 {
+		t.Errorf("end = %d, want 10 (4 runes after column 6)", got)
+	}
+}

--- a/internal/lsp/index_coverage_test.go
+++ b/internal/lsp/index_coverage_test.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/grindlemire/go-tui/internal/tuigen"
@@ -259,5 +260,38 @@ func TestComponentIndex_LocationSpansUnicodeName(t *testing.T) {
 	info, _ := idx.Lookup("Café")
 	if got := info.Location.Range.End.Character; got != 10 {
 		t.Errorf("end = %d, want 10 (4 runes after column 6)", got)
+	}
+}
+
+// A func's indexed location spans its name, so @Sidebar(...) highlights
+// "Sidebar" rather than "func Sidebar".
+func TestComponentIndex_FuncLocationSpansName(t *testing.T) {
+	type tc struct {
+		code      string
+		wantStart int
+		wantEnd   int
+	}
+
+	tests := map[string]tc{
+		"plain func":       {code: "func Sidebar(cat *tui.State[string]) *sidebar {\n\treturn nil\n}", wantStart: 5, wantEnd: 12},
+		"extra whitespace": {code: "func   Sidebar(x int) *sidebar {}", wantStart: 7, wantEnd: 14},
+		"unicode name":     {code: "func Café() *sidebar {}", wantStart: 5, wantEnd: 9},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			idx := NewComponentIndex()
+			idx.AddFunc("file:///w/a.gsx", &tuigen.GoFunc{Code: tt.code, Position: tuigen.Position{Line: 10, Column: 1}})
+			fnName := strings.Fields(strings.TrimPrefix(tt.code, "func"))[0]
+			fnName = fnName[:strings.IndexAny(fnName, "([")]
+			info, ok := idx.LookupFunc(fnName)
+			if !ok {
+				t.Fatalf("func %q not indexed", fnName)
+			}
+			r := info.Location.Range
+			if r.Start.Line != 9 || r.Start.Character != tt.wantStart || r.End.Character != tt.wantEnd {
+				t.Errorf("range = %d:%d..%d, want 9:%d..%d", r.Start.Line, r.Start.Character, r.End.Character, tt.wantStart, tt.wantEnd)
+			}
+		})
 	}
 }

--- a/internal/lsp/provider/definition.go
+++ b/internal/lsp/provider/definition.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/grindlemire/go-tui/internal/lsp/gopls"
 	"github.com/grindlemire/go-tui/internal/lsp/log"
@@ -755,14 +756,14 @@ func (d *definitionProvider) locateInWorkspaceGsx(tuiURI, name string) *Location
 			if pos.Line == 0 {
 				pos = comp.Position
 			}
-			return locationAt(tuiURI, pos, 0, len(name))
+			return locationAt(tuiURI, pos, 0, utf8.RuneCountInString(name))
 		}
 	}
 	for _, fn := range ast.Funcs {
 		// The name is on the func's first line, so its byte offset into Code
 		// is its column offset from the func keyword.
 		if m := goFuncName.FindStringSubmatchIndex(fn.Code); m != nil && fn.Code[m[2]:m[3]] == name {
-			return locationAt(tuiURI, fn.Position, m[2], len(name))
+			return locationAt(tuiURI, fn.Position, utf8.RuneCountInString(fn.Code[:m[2]]), utf8.RuneCountInString(name))
 		}
 	}
 	return nil
@@ -783,8 +784,8 @@ func (d *definitionProvider) gsxAST(uri string) *tuigen.File {
 	return nil
 }
 
-// locationAt converts a 1-indexed tuigen position plus a same-line offset into
-// a single-line LSP location of the given length.
+// locationAt converts a 1-indexed tuigen position plus a same-line rune offset
+// into a single-line LSP location of the given rune length.
 func locationAt(uri string, pos tuigen.Position, offset, length int) *Location {
 	start := Position{Line: pos.Line - 1, Character: pos.Column - 1 + offset}
 	return &Location{

--- a/internal/lsp/provider/definition.go
+++ b/internal/lsp/provider/definition.go
@@ -751,12 +751,18 @@ func (d *definitionProvider) locateInWorkspaceGsx(tuiURI, name string) *Location
 	}
 	for _, comp := range ast.Components {
 		if comp.Name == name {
-			return locationAt(tuiURI, comp.Position, len(name))
+			pos := comp.NamePos
+			if pos.Line == 0 {
+				pos = comp.Position
+			}
+			return locationAt(tuiURI, pos, 0, len(name))
 		}
 	}
 	for _, fn := range ast.Funcs {
-		if m := goFuncName.FindStringSubmatch(fn.Code); m != nil && m[1] == name {
-			return locationAt(tuiURI, fn.Position, len(name))
+		// The name is on the func's first line, so its byte offset into Code
+		// is its column offset from the func keyword.
+		if m := goFuncName.FindStringSubmatchIndex(fn.Code); m != nil && fn.Code[m[2]:m[3]] == name {
+			return locationAt(tuiURI, fn.Position, m[2], len(name))
 		}
 	}
 	return nil
@@ -777,9 +783,10 @@ func (d *definitionProvider) gsxAST(uri string) *tuigen.File {
 	return nil
 }
 
-// locationAt converts a 1-indexed tuigen position into a single-line LSP location.
-func locationAt(uri string, pos tuigen.Position, length int) *Location {
-	start := Position{Line: pos.Line - 1, Character: pos.Column - 1}
+// locationAt converts a 1-indexed tuigen position plus a same-line offset into
+// a single-line LSP location of the given length.
+func locationAt(uri string, pos tuigen.Position, offset, length int) *Location {
+	start := Position{Line: pos.Line - 1, Character: pos.Column - 1 + offset}
 	return &Location{
 		URI:   uri,
 		Range: Range{Start: start, End: Position{Line: start.Line, Character: start.Character + length}},

--- a/internal/lsp/provider/definition.go
+++ b/internal/lsp/provider/definition.go
@@ -88,6 +88,16 @@ func (d *definitionProvider) Definition(ctx *CursorContext) ([]Location, error) 
 		}
 		// Fall through to gopls
 	case NodeKindFunction, NodeKindComponent, NodeKindGoDecl:
+		// The cursor on a component's own name is its definition. Resolving
+		// by name instead would land on any other templ called the same
+		// thing, and every method templ is called Render.
+		if comp, ok := ctx.Node.(*tuigen.Component); ok && comp != nil && comp.Name == word {
+			pos := comp.NamePos
+			if pos.Line == 0 {
+				pos = comp.Position
+			}
+			return []Location{*locationAt(ctx.Document.URI, pos, 0, utf8.RuneCountInString(comp.Name))}, nil
+		}
 		// Try local AST-based lookup first (avoids gopls offset issues)
 		if ctx.Document.AST != nil && word != "" {
 			if loc := d.findGoDeclNameInAST(ctx.Document.AST, word, ctx.Document.URI); loc != nil {

--- a/internal/lsp/provider/definition.go
+++ b/internal/lsp/provider/definition.go
@@ -737,7 +737,7 @@ func offsetToLineChar(content string, offset int) (int, int) {
 
 // goFuncName matches the name of a top-level (receiver-less) func declaration,
 // generic or not.
-var goFuncName = regexp.MustCompile(`^func\s+(\w+)\s*[\[(]`)
+var goFuncName = regexp.MustCompile(`^func\s+([\p{L}_][\p{L}\p{N}_]*)\s*[\[(]`)
 
 // locateInWorkspaceGsx finds the templ or top-level func named name in the
 // workspace .gsx file at tuiURI. Used to turn a gopls hit inside a generated

--- a/internal/lsp/provider/definition_test.go
+++ b/internal/lsp/provider/definition_test.go
@@ -505,13 +505,14 @@ func TestDefinition_LocateInWorkspaceGsx(t *testing.T) {
 		uri      string
 		name     string
 		wantLine int // -1 means no location
+		wantChar int // 0-indexed start of the name; the range must span exactly the name
 	}
 
 	const widgets = "file:///w/widgets.gsx"
 	ws := &stubWorkspaceAST{asts: map[string]*tuigen.File{
 		widgets: {
 			Components: []*tuigen.Component{
-				{Name: "Header", Position: tuigen.Position{Line: 5, Column: 1}},
+				{Name: "Header", Position: tuigen.Position{Line: 5, Column: 1}, NamePos: tuigen.Position{Line: 5, Column: 7}},
 			},
 			Funcs: []*tuigen.GoFunc{
 				{Code: "func NewCard(label string) *Card {\n\treturn &Card{}\n}", Position: tuigen.Position{Line: 12, Column: 1}},
@@ -522,9 +523,9 @@ func TestDefinition_LocateInWorkspaceGsx(t *testing.T) {
 	}}
 
 	tests := map[string]tc{
-		"function templ":        {uri: widgets, name: "Header", wantLine: 4},
-		"struct factory func":   {uri: widgets, name: "NewCard", wantLine: 11},
-		"generic factory func":  {uri: widgets, name: "NewList", wantLine: 29},
+		"function templ":        {uri: widgets, name: "Header", wantLine: 4, wantChar: 6},
+		"struct factory func":   {uri: widgets, name: "NewCard", wantLine: 11, wantChar: 5},
+		"generic factory func":  {uri: widgets, name: "NewList", wantLine: 29, wantChar: 5},
 		"method is not a match": {uri: widgets, name: "helper", wantLine: -1},
 		"unknown name":          {uri: widgets, name: "Nope", wantLine: -1},
 		"file not in workspace": {uri: "file:///w/other.gsx", name: "Header", wantLine: -1},
@@ -547,6 +548,10 @@ func TestDefinition_LocateInWorkspaceGsx(t *testing.T) {
 			}
 			if loc.URI != tt.uri || loc.Range.Start.Line != tt.wantLine {
 				t.Errorf("got %s:%d, want %s:%d", loc.URI, loc.Range.Start.Line, tt.uri, tt.wantLine)
+			}
+			if loc.Range.Start.Character != tt.wantChar || loc.Range.End.Character != tt.wantChar+len(tt.name) {
+				t.Errorf("range = %d..%d, want %d..%d (the name itself)",
+					loc.Range.Start.Character, loc.Range.End.Character, tt.wantChar, tt.wantChar+len(tt.name))
 			}
 		})
 	}

--- a/internal/lsp/provider/definition_test.go
+++ b/internal/lsp/provider/definition_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/grindlemire/go-tui/internal/lsp/gopls"
 
@@ -513,6 +514,7 @@ func TestDefinition_LocateInWorkspaceGsx(t *testing.T) {
 		widgets: {
 			Components: []*tuigen.Component{
 				{Name: "Header", Position: tuigen.Position{Line: 5, Column: 1}, NamePos: tuigen.Position{Line: 5, Column: 7}},
+				{Name: "Café", Position: tuigen.Position{Line: 40, Column: 1}, NamePos: tuigen.Position{Line: 40, Column: 7}},
 			},
 			Funcs: []*tuigen.GoFunc{
 				{Code: "func NewCard(label string) *Card {\n\treturn &Card{}\n}", Position: tuigen.Position{Line: 12, Column: 1}},
@@ -526,6 +528,7 @@ func TestDefinition_LocateInWorkspaceGsx(t *testing.T) {
 		"function templ":        {uri: widgets, name: "Header", wantLine: 4, wantChar: 6},
 		"struct factory func":   {uri: widgets, name: "NewCard", wantLine: 11, wantChar: 5},
 		"generic factory func":  {uri: widgets, name: "NewList", wantLine: 29, wantChar: 5},
+		"unicode templ name":    {uri: widgets, name: "Café", wantLine: 39, wantChar: 6},
 		"method is not a match": {uri: widgets, name: "helper", wantLine: -1},
 		"unknown name":          {uri: widgets, name: "Nope", wantLine: -1},
 		"file not in workspace": {uri: "file:///w/other.gsx", name: "Header", wantLine: -1},
@@ -549,9 +552,10 @@ func TestDefinition_LocateInWorkspaceGsx(t *testing.T) {
 			if loc.URI != tt.uri || loc.Range.Start.Line != tt.wantLine {
 				t.Errorf("got %s:%d, want %s:%d", loc.URI, loc.Range.Start.Line, tt.uri, tt.wantLine)
 			}
-			if loc.Range.Start.Character != tt.wantChar || loc.Range.End.Character != tt.wantChar+len(tt.name) {
+			wantEnd := tt.wantChar + utf8.RuneCountInString(tt.name)
+			if loc.Range.Start.Character != tt.wantChar || loc.Range.End.Character != wantEnd {
 				t.Errorf("range = %d..%d, want %d..%d (the name itself)",
-					loc.Range.Start.Character, loc.Range.End.Character, tt.wantChar, tt.wantChar+len(tt.name))
+					loc.Range.Start.Character, loc.Range.End.Character, tt.wantChar, wantEnd)
 			}
 		})
 	}

--- a/internal/lsp/provider/definition_test.go
+++ b/internal/lsp/provider/definition_test.go
@@ -660,3 +660,36 @@ func TestDefinition_QualifiedCallNotShadowedByLocalFunc(t *testing.T) {
 		}
 	}
 }
+
+// Definition on a component's own declaration name resolves to that
+// declaration, not to another file's component that shares the name (every
+// method templ is called Render).
+func TestDefinition_ComponentDeclarationResolvesToItself(t *testing.T) {
+	index := newStubIndex()
+	index.components["Render"] = &ComponentInfo{
+		Name:     "Render",
+		Location: Location{URI: "file:///w/widgets/header.gsx", Range: Range{Start: Position{Line: 16, Character: 16}}},
+	}
+	dp := newTestDefinitionProvider(index)
+
+	doc := parseTestDoc("package test")
+	ctx := makeCtx(doc, NodeKindComponent, "Render")
+	ctx.Node = &tuigen.Component{
+		Name:     "Render",
+		Receiver: "a *app",
+		Position: tuigen.Position{Line: 9, Column: 1},
+		NamePos:  tuigen.Position{Line: 9, Column: 17},
+	}
+
+	result, err := dp.Definition(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 location, got %d: %+v", len(result), result)
+	}
+	got := result[0]
+	if got.URI != doc.URI || got.Range.Start.Line != 8 || got.Range.Start.Character != 16 || got.Range.End.Character != 22 {
+		t.Errorf("got %s %d:%d..%d, want %s 8:16..22", got.URI, got.Range.Start.Line, got.Range.Start.Character, got.Range.End.Character, doc.URI)
+	}
+}

--- a/internal/lsp/provider/references.go
+++ b/internal/lsp/provider/references.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/grindlemire/go-tui/internal/lsp/log"
 	"github.com/grindlemire/go-tui/internal/tuigen"
@@ -33,7 +34,15 @@ func (r *referencesProvider) References(ctx *CursorContext, includeDecl bool) ([
 
 	// Dispatch based on NodeKind when available
 	switch ctx.NodeKind {
-	case NodeKindComponentCall, NodeKindComponent:
+	case NodeKindComponent:
+		// The declaration under the cursor is the one to report; a by-name
+		// index lookup would pick any templ with the same name, and every
+		// method templ is called Render.
+		if comp, ok := ctx.Node.(*tuigen.Component); ok && comp != nil && comp.Name == word {
+			return r.findDeclaredComponentReferences(ctx.Document.URI, comp, includeDecl), nil
+		}
+		return r.findComponentReferences(strings.TrimPrefix(word, "@"), includeDecl), nil
+	case NodeKindComponentCall:
 		componentName := strings.TrimPrefix(word, "@")
 		return r.findComponentReferences(componentName, includeDecl), nil
 	case NodeKindFunction:
@@ -125,6 +134,33 @@ func (r *referencesProvider) findComponentReferences(name string, includeDecl bo
 	// Search workspace ASTs for files not open in editor
 	r.searchWorkspaceForComponentRefs(name, &refs)
 
+	return refs
+}
+
+// findDeclaredComponentReferences lists references for the component declared
+// at comp in uri. Method templs are mounted through their struct, never called
+// by name, so they have no call sites.
+func (r *referencesProvider) findDeclaredComponentReferences(uri string, comp *tuigen.Component, includeDecl bool) []Location {
+	var refs []Location
+	if includeDecl {
+		pos := comp.NamePos
+		if pos.Line == 0 {
+			pos = comp.Position
+		}
+		refs = append(refs, *locationAt(uri, pos, 0, utf8.RuneCountInString(comp.Name)))
+	}
+	if comp.Receiver != "" {
+		return refs
+	}
+	for _, doc := range r.docs.AllDocuments() {
+		if doc.AST == nil {
+			continue
+		}
+		for _, c := range doc.AST.Components {
+			findComponentCallsInNodes(c.Body, comp.Name, doc.URI, &refs)
+		}
+	}
+	r.searchWorkspaceForComponentRefs(comp.Name, &refs)
 	return refs
 }
 

--- a/internal/lsp/provider/references_test.go
+++ b/internal/lsp/provider/references_test.go
@@ -374,3 +374,42 @@ templ List(items []string) {
 		t.Errorf("expected 2 references (decl + usage) for loop variable, got %d", len(result))
 	}
 }
+
+// A method templ is never called by name, so references for Render must be
+// its own declaration only, not another file's Render (VS Code runs
+// references when definition lands on the cursor, so a wrong hit here is a
+// wrong jump).
+func TestReferences_MethodTemplDoesNotMatchOtherRenders(t *testing.T) {
+	src := `package test
+
+type app struct{}
+
+templ (a *app) Render() {
+	<div>x</div>
+}
+`
+	doc := parseTestDoc(src)
+	comp := doc.AST.Components[0]
+
+	index := newStubIndex()
+	index.components["Render"] = &ComponentInfo{
+		Name:     "Render",
+		Location: Location{URI: "file:///w/widgets/header.gsx", Range: Range{Start: Position{Line: 16, Character: 16}}},
+	}
+	rp := newTestReferencesProvider(index, &stubDocAccessor{docs: []*Document{doc}})
+
+	ctx := makeCtx(doc, NodeKindComponent, "Render")
+	ctx.Node = comp
+
+	result, err := rp.References(ctx, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected only the declaration, got %d: %+v", len(result), result)
+	}
+	got := result[0]
+	if got.URI != doc.URI || got.Range.Start.Line != 4 || got.Range.Start.Character != 15 {
+		t.Errorf("got %s %d:%d, want %s 4:15 (the name in its own declaration)", got.URI, got.Range.Start.Line, got.Range.Start.Character, doc.URI)
+	}
+}

--- a/internal/tuigen/ast.go
+++ b/internal/tuigen/ast.go
@@ -84,6 +84,7 @@ type Component struct {
 	Body            []Node // Element, GoCode, LetBinding, ForLoop, IfStmt
 	AcceptsChildren bool   // true if body contains {children...}
 	Position        Position
+	NamePos         Position // where Name starts (after the receiver for method templs)
 	// Method receiver fields (for templ (recv) Render() syntax)
 	Receiver     string // Full receiver text, e.g. "s *sidebar" (empty for function components)
 	ReceiverName string // Receiver variable name, e.g. "s" (empty for function components)

--- a/internal/tuigen/parser_component.go
+++ b/internal/tuigen/parser_component.go
@@ -26,6 +26,7 @@ func (p *Parser) parseFuncOrComponent() Node {
 		return nil
 	}
 
+	namePos := p.position()
 	name := p.current.Literal
 	p.advance()
 
@@ -62,6 +63,7 @@ func (p *Parser) parseFuncOrComponent() Node {
 	if returnType == "Element" {
 		comp := &Component{
 			Name:       name,
+			NamePos:    namePos,
 			Params:     params,
 			ReturnType: "*element.Element", // Internal representation stays the same
 			Position:   pos,
@@ -243,6 +245,7 @@ func (p *Parser) parseTempl() *Component {
 		return nil
 	}
 
+	namePos := p.position()
 	name := p.current.Literal
 	p.advance()
 
@@ -261,6 +264,7 @@ func (p *Parser) parseTempl() *Component {
 
 	comp := &Component{
 		Name:       name,
+		NamePos:    namePos,
 		Params:     params,
 		ReturnType: "*element.Element",
 		Position:   pos,
@@ -327,6 +331,7 @@ func (p *Parser) parseMethodTempl(pos Position) *Component {
 		p.errors.AddError(p.position(), "expected method name after receiver")
 		return nil
 	}
+	namePos := p.position()
 	name := p.current.Literal
 	if name != "Render" {
 		p.errors.AddErrorf(p.position(), "method templ name must be 'Render', got %q", name)
@@ -352,6 +357,7 @@ func (p *Parser) parseMethodTempl(pos Position) *Component {
 
 	comp := &Component{
 		Name:         name,
+		NamePos:      namePos,
 		ReturnType:   "*element.Element",
 		Position:     pos,
 		Receiver:     receiver,

--- a/internal/tuigen/parser_component_test.go
+++ b/internal/tuigen/parser_component_test.go
@@ -881,3 +881,44 @@ func TestParser_ComponentCallMissingParen(t *testing.T) {
 		})
 	}
 }
+
+// NamePos points at the component name itself, not the templ keyword, so
+// editors can highlight the name on go-to-definition.
+func TestParser_ComponentNamePos(t *testing.T) {
+	type tc struct {
+		input    string
+		wantName string
+		wantLine int
+		wantCol  int
+	}
+
+	tests := map[string]tc{
+		"function templ": {
+			input:    "package x\n\ntempl Header(title string) {\n\t<span>{title}</span>\n}",
+			wantName: "Header", wantLine: 3, wantCol: 7,
+		},
+		"method templ": {
+			input:    "package x\n\ntype Card struct{}\n\ntempl (c *Card) Render() {\n\t<span>x</span>\n}",
+			wantName: "Render", wantLine: 5, wantCol: 17,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			file, err := NewParser(NewLexer("test.gsx", tt.input)).ParseFile()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(file.Components) != 1 {
+				t.Fatalf("expected 1 component, got %d", len(file.Components))
+			}
+			c := file.Components[0]
+			if c.Name != tt.wantName {
+				t.Fatalf("Name = %q, want %q", c.Name, tt.wantName)
+			}
+			if c.NamePos.Line != tt.wantLine || c.NamePos.Column != tt.wantCol {
+				t.Errorf("NamePos = %d:%d, want %d:%d", c.NamePos.Line, c.NamePos.Column, tt.wantLine, tt.wantCol)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Cmd+click on a component landed on the right line but highlighted `templ ` instead of the name. The location ranges started at the `templ` keyword: the workspace index used the component's position with an odd end offset, and the cross-package lookup from #132 used the same start with the name's length.

The parser now records where the name starts (after the receiver for method templs) and both lookups return a range spanning exactly the name. Same-package struct calls such as `@Sidebar(a.category)` go through the index's func table, which had the same keyword start; it now spans the name too, and the func-name regexes accept Unicode identifiers. Pinned by parser, index, and provider tests and checked through a real LSP session.

Cmd+click on the name in a declaration such as `templ (a *app) Render()` also went wrong: it fell through to a by-name index lookup, and since every method templ is called `Render` it landed in whichever file was indexed last. A declaration's own name now resolves to itself.

After that fix the click could still jump to another file's `Render`, through a different route: when Go to Definition lands on the cursor, VS Code runs Go to References instead, and the references provider took the declaration from the same by-name index lookup. The component under the cursor now supplies its own declaration, and a method templ, which is never called by name, has no call sites to search.
