### PR TITLE
feat(gsx): add options attribute for forwarding option slices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,6 +442,7 @@ func helper(s string) string {
 | `ref` | expression | Bind element to a `tui.Ref`/`RefList`/`RefMap` variable |
 | `key` | expression | Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): mount cache key for component elements, RefMap key with `ref`; a key on a container element keys the components mounted inside it |
 | `deps` | expression | Explicit state dependencies for reactive bindings |
+| `options` | expression | Option slice forwarded to the element constructor after attribute-derived options, so it can override them; the type follows the tag (`[]tui.Option` for plain elements, `[]tui.ModalOption`/`[]tui.TextAreaOption`/`[]tui.InputOption`/`[]tui.MarkdownOption` for component elements) |
 
 ### Layout Attributes
 

--- a/cmd/tui/testdata/modal.gsx
+++ b/cmd/tui/testdata/modal.gsx
@@ -7,6 +7,7 @@ type myModal struct {
 	showModal  *tui.State[bool]
 	gameOver   *tui.State[bool]
 	confirmBtn tui.Ref
+	modalOpts  []tui.ModalOption
 }
 
 func MyModal() *myModal {
@@ -26,7 +27,7 @@ func (c *myModal) gameOverKeys() tui.KeyMap {
 templ (c *myModal) Render() {
 	<div class="flex-col">
 		<span>Background content</span>
-		<modal open={c.showModal} class="justify-center items-center" backdrop="dim">
+		<modal open={c.showModal} class="justify-center items-center" backdrop="dim" options={c.modalOpts}>
 			<div class="w-40 border-rounded p-2 flex-col gap-1">
 				<span class="font-bold">Are you sure?</span>
 				<button ref={c.confirmBtn}>OK</button>

--- a/cmd/tui/testdata/modal_gsx.go
+++ b/cmd/tui/testdata/modal_gsx.go
@@ -12,6 +12,7 @@ type myModal struct {
 	showModal  *tui.State[bool]
 	gameOver   *tui.State[bool]
 	confirmBtn tui.Ref
+	modalOpts  []tui.ModalOption
 }
 
 func MyModal() *myModal {
@@ -37,11 +38,11 @@ func (c *myModal) Render(app *tui.App) *tui.Element {
 	)
 	__tui_0.AddChild(__tui_1)
 	__tui_2 := app.MountPersistent(c, 0, func() tui.Component {
-		return tui.NewModal(
+		return tui.NewModal(append([]tui.ModalOption{
 			tui.WithModalOpen(c.showModal),
 			tui.WithModalBackdrop("dim"),
 			tui.WithModalElementOptions(tui.WithJustify(tui.JustifyCenter), tui.WithAlign(tui.AlignCenter)),
-		)
+		}, c.modalOpts...)...)
 	})
 	__tui_3 := tui.New(
 		tui.WithWidth(40),
@@ -92,6 +93,7 @@ func (c *myModal) updatePropsFields(fresh tui.Component) {
 		return
 	}
 	c.app = f.app
+	c.modalOpts = f.modalOpts
 }
 
 func (c *myModal) UpdateProps(fresh tui.Component) {

--- a/cmd/tui/testdata/simple.gsx
+++ b/cmd/tui/testdata/simple.gsx
@@ -13,3 +13,9 @@ templ Footer() {
 		<span>Footer content</span>
 	</div>
 }
+
+templ Card(title string, opts ...tui.Option) {
+	<div class="border-rounded p-1" options={opts}>
+		<span>{title}</span>
+	</div>
+}

--- a/cmd/tui/testdata/simple_gsx.go
+++ b/cmd/tui/testdata/simple_gsx.go
@@ -145,3 +145,73 @@ func Footer() *FooterView {
 	}
 	return &view
 }
+
+type CardView struct {
+	Root      *tui.Element
+	watchers  []tui.Watcher
+	bindApp   func(*tui.App)
+	unbindApp func()
+}
+
+func (v *CardView) UnbindApp() {
+	if v.unbindApp != nil {
+		v.unbindApp()
+	}
+}
+
+func (v *CardView) GetRoot() *tui.Element { return v.Root }
+
+func (v *CardView) GetWatchers() []tui.Watcher { return v.watchers }
+
+func (v *CardView) Render(app *tui.App) *tui.Element { return v.Root }
+
+func (v *CardView) BindApp(app *tui.App) {
+	if v.bindApp != nil {
+		v.bindApp(app)
+	}
+}
+
+func (v *CardView) UpdateProps(fresh tui.Component) {
+	f, ok := fresh.(*CardView)
+	if !ok {
+		return
+	}
+	v.Root = f.Root
+	v.watchers = f.watchers
+	v.bindApp = f.bindApp
+	v.unbindApp = f.unbindApp
+}
+
+var _ tui.AppBinder = (*CardView)(nil)
+
+var _ tui.AppUnbinder = (*CardView)(nil)
+
+var _ tui.PropsUpdater = (*CardView)(nil)
+
+func Card(title string, opts ...tui.Option) *CardView {
+	var view CardView
+	var watchers []tui.Watcher
+
+	__tui_0 := tui.New(append([]tui.Option{
+		tui.WithBorder(tui.BorderRounded),
+		tui.WithPadding(1),
+	}, opts...)...)
+	__tui_1 := tui.New(
+		tui.WithText(title),
+	)
+	__tui_0.AddChild(__tui_1)
+
+	__bindApp := func(app *tui.App) {
+	}
+
+	__unbindApp := func() {
+	}
+
+	view = CardView{
+		Root:      __tui_0,
+		watchers:  watchers,
+		bindApp:   __bindApp,
+		unbindApp: __unbindApp,
+	}
+	return &view
+}

--- a/docs/content/llm.md
+++ b/docs/content/llm.md
@@ -281,6 +281,7 @@ tui.WithPrintWidth(w int)  // Explicit width; default: auto-detect, fallback 80
 | `disabled` | `bool` | Disable interaction |
 | `ref` | `*tui.Ref` | Bind to a reference |
 | `deps` | expression | Explicit state dependencies |
+| `options` | expression | Option slice forwarded to the constructor after attribute options (`[]tui.Option`, or the component's option type such as `[]tui.ModalOption`) |
 | `focusable` | `bool` | Enable focus |
 | `onFocus` / `onBlur` | `func(*tui.Element)` | Focus callbacks |
 | `onActivate` | `func()` | Enter activation callback |

--- a/docs/content/reference/built-in-components.md
+++ b/docs/content/reference/built-in-components.md
@@ -663,6 +663,7 @@ All `<modal>` attributes and their types:
 | `trapFocus` | `bool` | Tab/Shift+Tab restricted to modal children; also blocks unhandled keys from parents (default true) |
 | `keyMap` | `expression` | Custom `KeyMap` bindings for the modal |
 | `class` | `string` | Tailwind classes for positioning (e.g. `"justify-center items-center"`) |
+| `options` | `[]ModalOption` | Extra `ModalOption` values applied after the attributes above, so they can override them |
 
 ### Behavior
 
@@ -713,6 +714,36 @@ When closed, it returns a hidden placeholder element with no key bindings.
 ```
 
 The `class` attribute on `<modal>` controls how the dialog is positioned within the full-screen overlay. Use `justify-center items-center` for a centered dialog or `justify-end items-stretch` for a bottom sheet.
+
+To build a reusable dialog that callers can still customize, accept a `[]ModalOption` and forward it with the `options` attribute. The slice is applied after the modal's own attributes, so a caller's `WithModalBackdrop` wins over the wrapper's default. The modal mounts once, so the forwarded options take effect on first mount like the other attributes. The constructor takes a slice rather than a variadic because `{children...}` arrives as its final parameter.
+
+```gsx
+type dialog struct {
+    open     *tui.State[bool]
+    title    string
+    opts     []tui.ModalOption
+    children []*tui.Element
+}
+
+func Dialog(open *tui.State[bool], title string, opts []tui.ModalOption, children []*tui.Element) *dialog {
+    return &dialog{open: open, title: title, opts: opts, children: children}
+}
+
+templ (d *dialog) Render() {
+    <modal open={d.open} class="justify-center items-center" backdrop="dim" options={d.opts}>
+        <div class="border-rounded p-1 flex-col gap-1">
+            <span class="font-bold">{d.title}</span>
+            {children...}
+        </div>
+    </modal>
+}
+```
+
+```gsx
+@Dialog(s.confirm, "Delete file?", []tui.ModalOption{tui.WithModalBackdrop("blank"), tui.WithModalCloseOnEscape(false)}) {
+    <button class="focusable" onActivate={s.delete}>Delete</button>
+}
+```
 
 ### Inline Mode
 

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -41,7 +41,7 @@ templ Greeting(name string) {
 }
 ```
 
-Parameters use standard Go function parameter syntax. Any valid Go type works:
+Parameters use standard Go function parameter syntax, including grouped names that share a type (`x, y int`). Any valid Go type works:
 
 ```gsx
 templ UserList(users []string, maxVisible int) {

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -322,6 +322,56 @@ for _, msg := range s.messages {
 
 Keys compose by depth. A `key` replaces the loop position at its own level, loops nested inside a keyed wrapper still contribute their own identity, and a `key` nested under another `key` appends to it rather than erasing it. One caveat: components passed into a children slot are mounted at the caller's site, so a keyed wrapper inside the receiving component does not re-key them.
 
+### Options attribute
+
+The `options` attribute forwards a slice of option funcs to the element's constructor. It is how a reusable component wraps a built-in element and still lets callers tune it without redeclaring every attribute:
+
+```gsx
+type dialog struct {
+    open     *tui.State[bool]
+    title    string
+    opts     []tui.ModalOption
+    children []*tui.Element
+}
+
+func Dialog(open *tui.State[bool], title string, opts []tui.ModalOption, children []*tui.Element) *dialog {
+    return &dialog{open: open, title: title, opts: opts, children: children}
+}
+
+templ (d *dialog) Render() {
+    <modal open={d.open} class="justify-center items-center" options={d.opts}>
+        <div class="border-rounded p-1 flex-col gap-1">
+            <span class="font-bold">{d.title}</span>
+            {children...}
+        </div>
+    </modal>
+}
+
+templ Card(title string, opts ...tui.Option) {
+    <div class="border-rounded p-1" options={opts}>
+        <span>{title}</span>
+    </div>
+}
+```
+
+A caller then writes `@Card("Stats", tui.WithBorder(tui.BorderDouble))`, or for the dialog:
+
+```gsx
+@Dialog(s.confirm, "Delete?", []tui.ModalOption{tui.WithModalBackdrop("blank")}) {
+    <button class="focusable" onActivate={s.delete}>Delete</button>
+}
+```
+
+`Card` can take a variadic `...tui.Option` because it has no children slot. A templ or constructor that accepts `{children...}` receives the children as its final parameter, so declare the options there as a slice (`opts []tui.ModalOption`) and pass a slice literal at the call site.
+
+Three rules apply:
+
+1. The value must be a Go expression. `options="x"` and `options=1` are compile errors.
+2. The slice type follows the tag. Plain elements take `[]tui.Option`; component elements take their constructor's option type: `[]tui.ModalOption` for `<modal>`, `[]tui.TextAreaOption` for `<textarea>`, `[]tui.InputOption` for `<input>`, and `[]tui.MarkdownOption` for `<markdown>`. Nothing is annotated in the `.gsx` file; the Go compiler checks the generated code.
+3. The slice is applied after the attribute-derived options, so an entry in the slice overrides the matching attribute. The generated code has the shape `tui.New(append([]tui.Option{...attribute options...}, opts...)...)`.
+
+An element accepts one `options` attribute; a second is a compile error. Component elements are mounted once, so like their other attributes the forwarded options take effect on first mount.
+
 ## Attribute reference
 
 ### Generic attributes (all elements)
@@ -334,6 +384,7 @@ Keys compose by depth. A `key` replaces the loop position at its own level, loop
 | `ref` | expression | `ref.Set(el)` | Binds element to a ref |
 | `deps` | expression | -- | Explicit state dependencies |
 | `key` | expression | -- | Loop item identity: component cache key, RefMap key with `ref` |
+| `options` | expression | `append([]tui.Option{...}, opts...)...` | Option slice forwarded to the constructor after attribute options; type follows the tag |
 
 ### Layout attributes
 

--- a/docs/content/reference/gsx-syntax.md
+++ b/docs/content/reference/gsx-syntax.md
@@ -80,6 +80,8 @@ Call it with children:
 
 `{children...}` is only available in pure `templ` components, not in struct method components.
 
+Because the children are passed as the trailing argument, a templ with a children slot cannot declare a variadic last parameter. Take options as a slice (`opts []tui.Option`) instead of `opts ...tui.Option`; `tui check` reports a variadic parameter here as an error.
+
 ### Struct method components
 
 A struct component has its own state and lifecycle. Define the render method with `templ` using a receiver:

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -584,6 +584,29 @@ templ Test() {
 }
 `,
 		},
+		"options attribute single line": {
+			input: `package main
+
+templ Card(opts []tui.Option) {
+	<div class="border-rounded p-1" options={opts}>
+		<span>Content</span>
+	</div>
+}
+`,
+		},
+		"options attribute multi-line": {
+			input: `package main
+
+templ Card(opts []tui.Option) {
+	<div
+		class="border-rounded p-1"
+		options={opts}
+	>
+		<span>Content</span>
+	</div>
+}
+`,
+		},
 		"closing bracket on own line": {
 			input: `package main
 
@@ -798,6 +821,48 @@ templ Test() {
 
 templ Test() {
 	<div class="very-long-class-name-that-exceeds-100-chars" id="also-very-long-identifier">
+		<span>Content</span>
+	</div>
+}
+`,
+		},
+		"options attribute prints unchanged on a single line": {
+			input: `package main
+
+templ Card(opts []tui.Option) {
+	<div class="border-rounded p-1" options={opts}>
+		<span>Content</span>
+	</div>
+}
+`,
+			want: `package main
+
+templ Card(opts []tui.Option) {
+	<div class="border-rounded p-1" options={opts}>
+		<span>Content</span>
+	</div>
+}
+`,
+		},
+		"options attribute prints unchanged across multi-line attrs": {
+			input: `package main
+
+templ Card(opts []tui.Option) {
+	<div
+		class="border-rounded p-1"
+		options={opts}
+	>
+		<span>Content</span>
+	</div>
+}
+`,
+			want: `package main
+
+templ Card(opts []tui.Option) {
+	<div
+		class="border-rounded p-1"
+		options={opts}
+	>
 		<span>Content</span>
 	</div>
 }

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -35,6 +35,20 @@ templ Hello() {
 }
 `,
 		},
+		"grouped params are preserved": {
+			input: `package main
+
+templ Grp(x, y int, opts ...tui.Option) {
+<div options={opts}>{x + y}</div>
+}
+`,
+			want: `package main
+
+templ Grp(x, y int, opts ...tui.Option) {
+	<div options={opts}>{x + y}</div>
+}
+`,
+		},
 		"single import": {
 			input: `package main
 

--- a/internal/formatter/printer.go
+++ b/internal/formatter/printer.go
@@ -148,12 +148,7 @@ func (p *printer) printComponent(comp *tuigen.Component) {
 			if i > 0 {
 				p.write(", ")
 			}
-			p.write(param.Name)
-			if param.Grouped {
-				continue
-			}
-			p.write(" ")
-			p.write(param.Type)
+			p.write(param.String())
 		}
 
 		p.write(")")

--- a/internal/formatter/printer.go
+++ b/internal/formatter/printer.go
@@ -149,6 +149,9 @@ func (p *printer) printComponent(comp *tuigen.Component) {
 				p.write(", ")
 			}
 			p.write(param.Name)
+			if param.Grouped {
+				continue
+			}
 			p.write(" ")
 			p.write(param.Type)
 		}

--- a/internal/lsp/context_resolve.go
+++ b/internal/lsp/context_resolve.go
@@ -705,7 +705,8 @@ func isOffsetInElementTag(content string, offset int) bool {
 }
 
 // findFuncParamAtColumn checks if the cursor column (1-indexed) is on a parameter
-// name in a function declaration. Returns the parameter name if found, empty string otherwise.
+// name on the first line of a function declaration. Returns the parameter name if
+// found, empty string otherwise.
 func findFuncParamAtColumn(fn *tuigen.GoFunc, col int) string {
 	code := fn.Code
 	if !strings.HasPrefix(strings.TrimSpace(code), "func ") {
@@ -716,59 +717,20 @@ func findFuncParamAtColumn(fn *tuigen.GoFunc, col int) string {
 	if parenIdx < 0 {
 		return ""
 	}
-
-	// Find matching close paren (depth-aware for nested parens in types)
-	depth := 0
-	closeIdx := -1
-	for i := parenIdx; i < len(code); i++ {
-		switch code[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-			if depth == 0 {
-				closeIdx = i
-			}
-		}
-		if closeIdx >= 0 {
-			break
-		}
-	}
+	closeIdx := matchingParen(code, parenIdx)
 	if closeIdx < 0 {
 		return ""
 	}
 
-	paramStr := code[parenIdx+1 : closeIdx]
 	// Column where param content starts (1-indexed, matching col)
 	paramStartCol := fn.Position.Column + parenIdx + 1
-
-	// Split params at top level (depth-aware for nested parens/brackets in types)
-	depth = 0
-	paramBegin := 0
-	for i := 0; i <= len(paramStr); i++ {
-		if i < len(paramStr) {
-			switch paramStr[i] {
-			case '(', '[':
-				depth++
-			case ')', ']':
-				depth--
-			}
+	for _, p := range tuigen.ParseParamList(code[parenIdx+1 : closeIdx]) {
+		if p.Position.Line != 1 {
+			continue
 		}
-
-		if (i == len(paramStr)) || (paramStr[i] == ',' && depth == 0) {
-			param := paramStr[paramBegin:i]
-			trimmed := strings.TrimSpace(param)
-			fields := strings.Fields(trimmed)
-			if len(fields) >= 2 {
-				paramName := fields[0]
-				// Find name position within the raw param substring
-				nameInParam := strings.Index(param, paramName)
-				nameCol := paramStartCol + paramBegin + nameInParam
-				if col >= nameCol && col < nameCol+len(paramName) {
-					return paramName
-				}
-			}
-			paramBegin = i + 1
+		nameCol := paramStartCol + p.Position.Column - 1
+		if col >= nameCol && col < nameCol+len(p.Name) {
+			return p.Name
 		}
 	}
 

--- a/internal/lsp/context_resolve_coverage_test.go
+++ b/internal/lsp/context_resolve_coverage_test.go
@@ -393,13 +393,16 @@ func TestFindFuncParamAtColumn(t *testing.T) {
 	}
 
 	tests := map[string]tc{
-		"not a func":   {code: "var x = 1", col: 1, want: ""},
-		"no paren":     {code: "func f", col: 1, want: ""},
-		"unbalanced":   {code: "func f(a int", col: 8, want: ""},
-		"first param":  {code: "func f(a int, b string) {}", col: 8, want: "a"},
-		"second param": {code: "func f(a int, b string) {}", col: 15, want: "b"},
-		"nested types": {code: "func g(m map[string]int, fn func(int) bool) {}", col: 26, want: "fn"},
-		"miss":         {code: "func f(a int) {}", col: 11, want: ""},
+		"not a func":          {code: "var x = 1", col: 1, want: ""},
+		"no paren":            {code: "func f", col: 1, want: ""},
+		"unbalanced":          {code: "func f(a int", col: 8, want: ""},
+		"first param":         {code: "func f(a int, b string) {}", col: 8, want: "a"},
+		"second param":        {code: "func f(a int, b string) {}", col: 15, want: "b"},
+		"nested types":        {code: "func g(m map[string]int, fn func(int) bool) {}", col: 26, want: "fn"},
+		"miss":                {code: "func f(a int) {}", col: 11, want: ""},
+		"grouped first name":  {code: "func sum(a, b int) int {}", col: 10, want: "a"},
+		"grouped second name": {code: "func sum(a, b int) int {}", col: 13, want: "b"},
+		"blank identifier":    {code: "func f(_ int, b string) {}", col: 8, want: "_"},
 	}
 
 	for name, tt := range tests {

--- a/internal/lsp/gopls/generate.go
+++ b/internal/lsp/gopls/generate.go
@@ -199,9 +199,16 @@ func (g *generator) generateElement(el *tuigen.Element, indent string) {
 	}
 	// Generate attribute expressions
 	for _, attr := range el.Attributes {
-		if expr, ok := attr.Value.(*tuigen.GoExpr); ok {
-			g.generateGoExpr(expr, indent)
+		expr, ok := attr.Value.(*tuigen.GoExpr)
+		if !ok {
+			continue
 		}
+		if attr.Name == "options" {
+			// Spread into the tag's constructor so gopls checks the slice type.
+			g.generateGoExprWrapped(expr, indent, tuigen.ElementConstructor(el.Tag)+"(", "...)")
+			continue
+		}
+		g.generateGoExpr(expr, indent)
 	}
 
 	// Generate children
@@ -212,6 +219,11 @@ func (g *generator) generateElement(el *tuigen.Element, indent string) {
 
 // generateGoExpr generates a Go expression and records the position mapping.
 func (g *generator) generateGoExpr(expr *tuigen.GoExpr, indent string) {
+	g.generateGoExprWrapped(expr, indent, "", "")
+}
+
+// generateGoExprWrapped emits "_ = <prefix><code><suffix>", mapping only code.
+func (g *generator) generateGoExprWrapped(expr *tuigen.GoExpr, indent, prefix, suffix string) {
 	if expr == nil {
 		return
 	}
@@ -222,13 +234,13 @@ func (g *generator) generateGoExpr(expr *tuigen.GoExpr, indent string) {
 	}
 
 	// Record position mapping before writing
-	// The expression starts after "_ = " (4 characters + indent)
+	// The expression starts after "_ = " (4 characters + indent) and the prefix
 	tuiLine := expr.Position.Line - 1 // convert to 0-indexed
 	// Position.Column is 1-indexed and points to the '{' delimiter.
 	// The expression content starts at Column+1 (1-indexed) = Column (0-indexed).
 	tuiCol := expr.Position.Column
 
-	goExprStartCol := len(indent) + 4 // "_ = " is 4 chars
+	goExprStartCol := len(indent) + 4 + len(prefix) // "_ = " is 4 chars
 
 	m := Mapping{
 		TuiLine: tuiLine,
@@ -242,7 +254,7 @@ func (g *generator) generateGoExpr(expr *tuigen.GoExpr, indent string) {
 	g.sourceMap.AddMapping(m)
 
 	// Write dummy assignment
-	g.writeLine(fmt.Sprintf("%s_ = %s", indent, code))
+	g.writeLine(fmt.Sprintf("%s_ = %s%s%s", indent, prefix, code, suffix))
 }
 
 // generateGoCode generates Go code for a GoCode node (non-tui.NewState code).

--- a/internal/lsp/gopls/generate.go
+++ b/internal/lsp/gopls/generate.go
@@ -92,7 +92,7 @@ func (g *generator) generateComponent(comp *tuigen.Component) {
 	// Build parameter list and track positions
 	var params []string
 	for _, p := range comp.Params {
-		params = append(params, paramText(p))
+		params = append(params, p.String())
 	}
 
 	// Function signature
@@ -115,7 +115,7 @@ func (g *generator) generateComponent(comp *tuigen.Component) {
 
 	// Add mappings for each parameter
 	for _, p := range comp.Params {
-		width := len(paramText(p))
+		width := len(p.String())
 		if p.Position.Line > 0 && p.Position.Column > 0 {
 			// Map the parameter text ("name type", or just "name" for a
 			// grouped name) from .gsx to .go so gopls can resolve types
@@ -157,15 +157,6 @@ func (g *generator) generateComponent(comp *tuigen.Component) {
 	// Return nil to make the function valid
 	g.writeLine("\treturn nil")
 	g.writeLine("}")
-}
-
-// paramText returns the parameter as written in a Go signature: a grouped
-// name (a in "a, b T") is just the name, otherwise "name type".
-func paramText(p *tuigen.Param) string {
-	if p.Grouped {
-		return p.Name
-	}
-	return fmt.Sprintf("%s %s", p.Name, p.Type)
 }
 
 // generateNodes generates Go code for a list of nodes.

--- a/internal/lsp/gopls/generate.go
+++ b/internal/lsp/gopls/generate.go
@@ -92,7 +92,7 @@ func (g *generator) generateComponent(comp *tuigen.Component) {
 	// Build parameter list and track positions
 	var params []string
 	for _, p := range comp.Params {
-		params = append(params, fmt.Sprintf("%s %s", p.Name, p.Type))
+		params = append(params, paramText(p))
 	}
 
 	// Function signature
@@ -115,22 +115,23 @@ func (g *generator) generateComponent(comp *tuigen.Component) {
 
 	// Add mappings for each parameter
 	for _, p := range comp.Params {
+		width := len(paramText(p))
 		if p.Position.Line > 0 && p.Position.Column > 0 {
-			// Map the full parameter (name + space + type) from .gsx to .go
-			// so gopls can resolve types in component signatures
+			// Map the parameter text ("name type", or just "name" for a
+			// grouped name) from .gsx to .go so gopls can resolve types
 			m := Mapping{
 				TuiLine: p.Position.Line - 1,
 				TuiCol:  p.Position.Column - 1,
 				GoLine:  g.goLine,
 				GoCol:   goParamStartCol,
-				Length:  len(p.Name) + 1 + len(p.Type),
+				Length:  width,
 			}
 			log.Generate("PARAM mapping: %s -> TuiLine=%d TuiCol=%d GoLine=%d GoCol=%d Len=%d (pos.Line=%d pos.Col=%d)",
 				p.Name, m.TuiLine, m.TuiCol, m.GoLine, m.GoCol, m.Length, p.Position.Line, p.Position.Column)
 			g.sourceMap.AddMapping(m)
 		}
-		// Move past this param: "name type, "
-		goParamStartCol += len(p.Name) + 1 + len(p.Type) + 2 // +1 for space, +2 for ", "
+		// Move past this param and the ", " separator
+		goParamStartCol += width + 2
 	}
 
 	// Write function/method signature
@@ -156,6 +157,15 @@ func (g *generator) generateComponent(comp *tuigen.Component) {
 	// Return nil to make the function valid
 	g.writeLine("\treturn nil")
 	g.writeLine("}")
+}
+
+// paramText returns the parameter as written in a Go signature: a grouped
+// name (a in "a, b T") is just the name, otherwise "name type".
+func paramText(p *tuigen.Param) string {
+	if p.Grouped {
+		return p.Name
+	}
+	return fmt.Sprintf("%s %s", p.Name, p.Type)
 }
 
 // generateNodes generates Go code for a list of nodes.

--- a/internal/lsp/gopls/generate_coverage_test.go
+++ b/internal/lsp/gopls/generate_coverage_test.go
@@ -472,8 +472,9 @@ func TestGenerateVirtualGo_OptionsAttribute(t *testing.T) {
 			// The mapping must point at "opts" inside the wrapper, not at the constructor.
 			goLine := strings.Count(source[:strings.Index(source, tt.wantLine)], "\n")
 			goCol := strings.Index(tt.wantLine, "opts")
-			if _, _, ok := sourceMap.GoToTui(goLine, goCol); !ok {
-				t.Errorf("no mapping at Go %d:%d (start of opts): %+v", goLine, goCol, sourceMap.AllMappings())
+			tuiLine, tuiCol, ok := sourceMap.GoToTui(goLine, goCol)
+			if !ok || tuiLine != 3 || tuiCol != 20 {
+				t.Errorf("GoToTui(%d, %d) = (%d, %d, %v), want (3, 20, true)", goLine, goCol, tuiLine, tuiCol, ok)
 			}
 			gotLine, gotCol, ok := sourceMap.TuiToGo(3, 20)
 			if !ok || gotLine != goLine || gotCol != goCol {

--- a/internal/lsp/gopls/generate_coverage_test.go
+++ b/internal/lsp/gopls/generate_coverage_test.go
@@ -417,6 +417,72 @@ func TestGenerateVirtualGo_ElementAttributesAndReceiver(t *testing.T) {
 	}
 }
 
+func TestGenerateVirtualGo_OptionsAttribute(t *testing.T) {
+	type tc struct {
+		tag      string
+		wantLine string
+	}
+
+	tests := map[string]tc{
+		"plain element spreads into tui.New": {
+			tag:      "div",
+			wantLine: "\t_ = tui.New(opts...)\n",
+		},
+		"modal spreads into tui.NewModal": {
+			tag:      "modal",
+			wantLine: "\t_ = tui.NewModal(opts...)\n",
+		},
+		"textarea spreads into tui.NewTextArea": {
+			tag:      "textarea",
+			wantLine: "\t_ = tui.NewTextArea(opts...)\n",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			file := &tuigen.File{
+				Package: "main",
+				Components: []*tuigen.Component{
+					{
+						Name:       "App",
+						ReturnType: "*element.Element",
+						Position:   tuigen.Position{Line: 3, Column: 1},
+						Body: []tuigen.Node{
+							&tuigen.Element{
+								Tag:      tt.tag,
+								Position: tuigen.Position{Line: 4, Column: 2},
+								Attributes: []*tuigen.Attribute{
+									{
+										Name:  "options",
+										Value: &tuigen.GoExpr{Code: "opts", Position: tuigen.Position{Line: 4, Column: 20}},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			source, sourceMap := GenerateVirtualGo(file)
+
+			if !strings.Contains(source, tt.wantLine) {
+				t.Fatalf("missing wrapped options expression %q in:\n%s", tt.wantLine, source)
+			}
+
+			// The mapping must point at "opts" inside the wrapper, not at the constructor.
+			goLine := strings.Count(source[:strings.Index(source, tt.wantLine)], "\n")
+			goCol := strings.Index(tt.wantLine, "opts")
+			if _, _, ok := sourceMap.GoToTui(goLine, goCol); !ok {
+				t.Errorf("no mapping at Go %d:%d (start of opts): %+v", goLine, goCol, sourceMap.AllMappings())
+			}
+			gotLine, gotCol, ok := sourceMap.TuiToGo(3, 20)
+			if !ok || gotLine != goLine || gotCol != goCol {
+				t.Errorf("TuiToGo(3, 20) = (%d, %d, %v), want (%d, %d, true)", gotLine, gotCol, ok, goLine, goCol)
+			}
+		})
+	}
+}
+
 func TestGenerateVirtualGo_DefaultReturnType(t *testing.T) {
 	file := &tuigen.File{
 		Package: "main",

--- a/internal/lsp/gopls/generate_test.go
+++ b/internal/lsp/gopls/generate_test.go
@@ -225,6 +225,62 @@ func TestGenerateVirtualGo_ExistingFunctionality(t *testing.T) {
 	}
 }
 
+// Grouped names (a, b T) are emitted as written so the .gsx and Go parameter
+// text line up, and each name maps to its own Go column.
+func TestGenerateVirtualGo_GroupedParams(t *testing.T) {
+	type tc struct {
+		params  []*tuigen.Param
+		wantSig string
+		// tui column (1-based) -> expected Go column (0-based) for each name
+		wantGoCol map[int]int
+	}
+
+	tests := map[string]tc{
+		"pair shares a type": {
+			params: []*tuigen.Param{
+				{Name: "a", Type: "string", Grouped: true, Position: tuigen.Position{Line: 3, Column: 12}},
+				{Name: "b", Type: "string", Position: tuigen.Position{Line: 3, Column: 15}},
+			},
+			wantSig:   "func Hello(a, b string) *element.Element",
+			wantGoCol: map[int]int{12: 11, 15: 14},
+		},
+		"grouped then variadic": {
+			params: []*tuigen.Param{
+				{Name: "x", Type: "int", Grouped: true, Position: tuigen.Position{Line: 3, Column: 12}},
+				{Name: "y", Type: "int", Position: tuigen.Position{Line: 3, Column: 15}},
+				{Name: "opts", Type: "...tui.Option", Position: tuigen.Position{Line: 3, Column: 22}},
+			},
+			wantSig:   "func Hello(x, y int, opts ...tui.Option) *element.Element",
+			wantGoCol: map[int]int{12: 11, 15: 14, 22: 21},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			file := &tuigen.File{
+				Package: "main",
+				Components: []*tuigen.Component{{
+					Name:       "Hello",
+					Position:   tuigen.Position{Line: 3, Column: 1},
+					ReturnType: "*element.Element",
+					Params:     tt.params,
+				}},
+			}
+
+			source, sourceMap := GenerateVirtualGo(file)
+			if !strings.Contains(source, tt.wantSig) {
+				t.Errorf("expected signature %q, got:\n%s", tt.wantSig, source)
+			}
+			for tuiCol, wantGoCol := range tt.wantGoCol {
+				_, goCol, ok := sourceMap.TuiToGo(2, tuiCol-1)
+				if !ok || goCol != wantGoCol {
+					t.Errorf("TuiToGo(2, %d) = (%d, %v), want (%d, true)", tuiCol-1, goCol, ok, wantGoCol)
+				}
+			}
+		})
+	}
+}
+
 // The component call name must be mapped so gopls can resolve definition and
 // hover on a package-qualified call such as @widgets.Header(...).
 func TestGenerateVirtualGo_ComponentCallNameMapping(t *testing.T) {

--- a/internal/lsp/index.go
+++ b/internal/lsp/index.go
@@ -180,10 +180,10 @@ func (idx *ComponentIndex) AddFunc(uri string, fn *tuigen.GoFunc) {
 
 	// Adjust param positions from code-relative to document-absolute (0-indexed)
 	for i := range params {
-		params[i].Position = Position{
-			Line:      fn.Position.Line - 1,
-			Character: fn.Position.Column - 1 + params[i].Position.Character,
+		if params[i].Position.Line == 0 {
+			params[i].Position.Character += fn.Position.Column - 1
 		}
+		params[i].Position.Line += fn.Position.Line - 1
 	}
 
 	info := &FuncInfo{
@@ -320,12 +320,13 @@ func parseFuncSignature(code string) (name, signature string, params []FuncParam
 	}
 
 	for _, p := range tuigen.ParseParamList(code[listStart:listEnd]) {
-		params = append(params, FuncParam{
-			Name: p.Name,
-			Type: p.Type,
-			// Relative to code start; adjusted to absolute in AddFunc.
-			Position: Position{Character: listStart + p.Position.Column - 1},
-		})
+		// Relative to code start; adjusted to absolute in AddFunc. Lines after
+		// the first are whole source lines, so only line 0 is offset by listStart.
+		pos := Position{Line: p.Position.Line - 1, Character: p.Position.Column - 1}
+		if pos.Line == 0 {
+			pos.Character += listStart
+		}
+		params = append(params, FuncParam{Name: p.Name, Type: p.Type, Position: pos})
 	}
 
 	return name, signature, params, returns

--- a/internal/lsp/index.go
+++ b/internal/lsp/index.go
@@ -290,63 +290,62 @@ func (idx *ComponentIndex) AllFunctions() []string {
 	return names
 }
 
+// funcSigRe locates a plain func declaration's name and opening paren.
+var funcSigRe = regexp.MustCompile(`func\s+([\p{L}_][\p{L}\p{N}_]*)\s*\(`)
+
 // parseFuncSignature extracts function name, signature, params and return type from Go code.
 func parseFuncSignature(code string) (name, signature string, params []FuncParam, returns string) {
-	// Match: func name(params) returns
-	re := regexp.MustCompile(`func\s+([\p{L}_][\p{L}\p{N}_]*)\s*\(([^)]*)\)\s*([^{]*)`)
-	matches := re.FindStringSubmatch(code)
-	if len(matches) < 2 {
+	m := funcSigRe.FindStringSubmatchIndex(code)
+	if m == nil {
 		return "", "", nil, ""
 	}
+	name = code[m[2]:m[3]]
 
-	name = matches[1]
-	paramStr := ""
-	if len(matches) > 2 {
-		paramStr = strings.TrimSpace(matches[2])
+	// The list runs to the matching paren so commas inside func(int, int)
+	// or generic types do not end it early.
+	listStart := m[1]
+	listEnd := matchingParen(code, listStart-1)
+	if listEnd < 0 {
+		return "", "", nil, ""
 	}
-	if len(matches) > 3 {
-		returns = strings.TrimSpace(matches[3])
+	paramStr := strings.TrimSpace(code[listStart:listEnd])
+	returns = strings.TrimSpace(code[listEnd+1:])
+	if brace := strings.Index(returns, "{"); brace >= 0 {
+		returns = strings.TrimSpace(returns[:brace])
 	}
 
-	// Build signature
 	signature = "func " + name + "(" + paramStr + ")"
 	if returns != "" {
 		signature += " " + returns
 	}
 
-	// Parse params with positions relative to code start
-	if paramStr != "" {
-		// Find the opening paren in the original code to calculate positions
-		parenIdx := strings.Index(code, "(")
-		paramContentStart := parenIdx + 1
-
-		paramParts := strings.Split(paramStr, ",")
-		offset := 0
-		for _, rawPart := range paramParts {
-			trimmed := strings.TrimSpace(rawPart)
-			fields := strings.Fields(trimmed)
-			if len(fields) >= 2 {
-				// Find where the name starts within the raw part
-				nameInPart := strings.Index(rawPart, fields[0])
-				charPos := paramContentStart + offset + nameInPart
-				params = append(params, FuncParam{
-					Name: fields[0],
-					Type: strings.Join(fields[1:], " "),
-					Position: Position{
-						Character: charPos, // relative to code start; adjusted to absolute in AddFunc
-					},
-				})
-			} else if len(fields) == 1 {
-				// Type only, no name (or name only)
-				params = append(params, FuncParam{
-					Name: fields[0],
-				})
-			}
-			offset += len(rawPart) + 1 // +1 for comma
-		}
+	for _, p := range tuigen.ParseParamList(code[listStart:listEnd]) {
+		params = append(params, FuncParam{
+			Name: p.Name,
+			Type: p.Type,
+			// Relative to code start; adjusted to absolute in AddFunc.
+			Position: Position{Character: listStart + p.Position.Column - 1},
+		})
 	}
 
 	return name, signature, params, returns
+}
+
+// matchingParen returns the index of the ')' closing the '(' at open, or -1.
+func matchingParen(s string, open int) int {
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
 }
 
 // componentNameLocation spans the component's name (tuigen is 1-indexed, LSP

--- a/internal/lsp/index_coverage_test.go
+++ b/internal/lsp/index_coverage_test.go
@@ -222,6 +222,26 @@ func TestParseFuncSignature(t *testing.T) {
 				{Name: "fn", Type: "func(int, int) bool", Position: Position{Character: 25}},
 			},
 		},
+		"blank identifier": {
+			code:     "func f(_ int, b string) {",
+			wantName: "f",
+			wantSig:  "func f(_ int, b string)",
+			wantRet:  "",
+			wantParams: []FuncParam{
+				{Name: "_", Type: "int", Position: Position{Character: 7}},
+				{Name: "b", Type: "string", Position: Position{Character: 14}},
+			},
+		},
+		"multi-line list": {
+			code:     "func f(\n\ta int,\n\tb string,\n) {",
+			wantName: "f",
+			wantSig:  "func f(a int,\n\tb string,)",
+			wantRet:  "",
+			wantParams: []FuncParam{
+				{Name: "a", Type: "int", Position: Position{Line: 1, Character: 1}},
+				{Name: "b", Type: "string", Position: Position{Line: 2, Character: 1}},
+			},
+		},
 		"not a function": {
 			code:     "var x = 1",
 			wantName: "",
@@ -251,8 +271,8 @@ func TestParseFuncSignature(t *testing.T) {
 				if got.Name != want.Name || got.Type != want.Type {
 					t.Errorf("param[%d] = %+v, want %+v", i, got, want)
 				}
-				if want.Position.Character != 0 && got.Position.Character != want.Position.Character {
-					t.Errorf("param[%d] position = %d, want %d", i, got.Position.Character, want.Position.Character)
+				if want.Position.Character != 0 && got.Position != want.Position {
+					t.Errorf("param[%d] position = %+v, want %+v", i, got.Position, want.Position)
 				}
 			}
 		})
@@ -323,5 +343,25 @@ func TestComponentIndex_FuncLocationSpansName(t *testing.T) {
 				t.Errorf("range = %d:%d..%d, want 9:%d..%d", r.Start.Line, r.Start.Character, r.End.Character, tt.wantStart, tt.wantEnd)
 			}
 		})
+	}
+}
+
+// Params on later lines of a multi-line signature keep their own line and
+// column so go-to-definition lands on the right name.
+func TestComponentIndex_AddFuncMultiLineParams(t *testing.T) {
+	idx := NewComponentIndex()
+	idx.AddFunc("file:///w/a.gsx", &tuigen.GoFunc{
+		Code:     "func f(\n\ta int,\n\tb string,\n) {\n}",
+		Position: tuigen.Position{Line: 10, Column: 1},
+	})
+	info, ok := idx.LookupFunc("f")
+	if !ok {
+		t.Fatal("func f not indexed")
+	}
+	want := []Position{{Line: 10, Character: 1}, {Line: 11, Character: 1}}
+	for i, p := range info.Params {
+		if p.Position != want[i] {
+			t.Errorf("param %s = %+v, want %+v", p.Name, p.Position, want[i])
+		}
 	}
 }

--- a/internal/lsp/index_coverage_test.go
+++ b/internal/lsp/index_coverage_test.go
@@ -183,13 +183,43 @@ func TestParseFuncSignature(t *testing.T) {
 				{Name: "items", Type: "...string", Position: Position{Character: 10}},
 			},
 		},
-		"type only param": {
-			code:     "func cb(int) {",
-			wantName: "cb",
-			wantSig:  "func cb(int)",
+		"type only param is not a named param": {
+			code:       "func cb(int) {",
+			wantName:   "cb",
+			wantSig:    "func cb(int)",
+			wantRet:    "",
+			wantParams: nil,
+		},
+		"grouped names share a type": {
+			code:     "func sum(a, b int) int { return a + b }",
+			wantName: "sum",
+			wantSig:  "func sum(a, b int) int",
+			wantRet:  "int",
+			wantParams: []FuncParam{
+				{Name: "a", Type: "int", Position: Position{Character: 9}},
+				{Name: "b", Type: "int", Position: Position{Character: 12}},
+			},
+		},
+		"mixed grouped and variadic": {
+			code:     "func f(a string, b, c int, opts ...tui.Option) {",
+			wantName: "f",
+			wantSig:  "func f(a string, b, c int, opts ...tui.Option)",
 			wantRet:  "",
 			wantParams: []FuncParam{
-				{Name: "int"},
+				{Name: "a", Type: "string", Position: Position{Character: 7}},
+				{Name: "b", Type: "int", Position: Position{Character: 17}},
+				{Name: "c", Type: "int", Position: Position{Character: 20}},
+				{Name: "opts", Type: "...tui.Option", Position: Position{Character: 27}},
+			},
+		},
+		"commas nested in types": {
+			code:     "func g(m map[string]int, fn func(int, int) bool) bool {",
+			wantName: "g",
+			wantSig:  "func g(m map[string]int, fn func(int, int) bool) bool",
+			wantRet:  "bool",
+			wantParams: []FuncParam{
+				{Name: "m", Type: "map[string]int", Position: Position{Character: 7}},
+				{Name: "fn", Type: "func(int, int) bool", Position: Position{Character: 25}},
 			},
 		},
 		"not a function": {

--- a/internal/lsp/provider/completion_test.go
+++ b/internal/lsp/provider/completion_test.go
@@ -257,6 +257,43 @@ templ Page() {
 	}
 }
 
+func TestCompletion_OptionsAttribute(t *testing.T) {
+	type tc struct {
+		tag string
+	}
+
+	tests := map[string]tc{
+		"div":   {tag: "div"},
+		"modal": {tag: "modal"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			doc := parseTestDoc("package test\n\ntempl Page() {\n\t<div >\n\t</div>\n}\n")
+			cp := newTestCompletionProvider(newStubIndex())
+
+			ctx := makeCtx(doc, NodeKindUnknown, "")
+			ctx.InElement = true
+			ctx.AttrTag = tt.tag
+
+			result, err := cp.Complete(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, item := range result.Items {
+				if item.Label != "options" {
+					continue
+				}
+				if item.InsertText != "options={$1}" {
+					t.Errorf("insert text = %q, want %q", item.InsertText, "options={$1}")
+				}
+				return
+			}
+			t.Errorf("expected 'options' in attribute completions for <%s>", tt.tag)
+		})
+	}
+}
+
 func TestCompletion_EventHandlerAttributes(t *testing.T) {
 	src := `package test
 

--- a/internal/lsp/provider/semantic.go
+++ b/internal/lsp/provider/semantic.go
@@ -414,10 +414,14 @@ func (s *semanticTokensProvider) collectSemanticTokens(doc *Document) []Semantic
 				paramStart = nameStart + len(name) + len(typeParamStr) + 1 // +1 for '('
 			}
 			for _, p := range params {
-				// Parameter name; p.Position.Column is 1-based within the list
-				nameStart := paramStart + p.Position.Column - 1
+				// p.Position is 1-based within the list; lines after the first
+				// are whole source lines, so their column is already absolute.
+				pLine, nameStart := line, paramStart+p.Position.Column-1
+				if p.Position.Line > 1 {
+					pLine, nameStart = line+p.Position.Line-1, p.Position.Column-1
+				}
 				tokens = append(tokens, SemanticToken{
-					Line:      line,
+					Line:      pLine,
 					StartChar: nameStart,
 					Length:    len(p.Name),
 					TokenType: TokenTypeParameter,
@@ -425,7 +429,7 @@ func (s *semanticTokensProvider) collectSemanticTokens(doc *Document) []Semantic
 				})
 				// Parameter type; a grouped name (a in "a, b T") has none of its own
 				if !p.Grouped {
-					emitGoTypeTokens(p.Type, line, nameStart+len(p.Name)+1, &tokens)
+					emitGoTypeTokens(p.Type, pLine, nameStart+len(p.Name)+1, &tokens)
 				}
 			}
 

--- a/internal/lsp/provider/semantic.go
+++ b/internal/lsp/provider/semantic.go
@@ -414,18 +414,19 @@ func (s *semanticTokensProvider) collectSemanticTokens(doc *Document) []Semantic
 				paramStart = nameStart + len(name) + len(typeParamStr) + 1 // +1 for '('
 			}
 			for _, p := range params {
-				// Parameter name
+				// Parameter name; p.Position.Column is 1-based within the list
+				nameStart := paramStart + p.Position.Column - 1
 				tokens = append(tokens, SemanticToken{
 					Line:      line,
-					StartChar: paramStart,
+					StartChar: nameStart,
 					Length:    len(p.Name),
 					TokenType: TokenTypeParameter,
 					Modifiers: TokenModDeclaration,
 				})
-				// Parameter type
-				typeStart := paramStart + len(p.Name) + 1 // +1 for space
-				emitGoTypeTokens(p.Type, line, typeStart, &tokens)
-				paramStart += len(p.Name) + 1 + len(p.Type) + 2 // +2 for ", "
+				// Parameter type; a grouped name (a in "a, b T") has none of its own
+				if !p.Grouped {
+					emitGoTypeTokens(p.Type, line, nameStart+len(p.Name)+1, &tokens)
+				}
 			}
 
 			// Return type
@@ -434,12 +435,10 @@ func (s *semanticTokensProvider) collectSemanticTokens(doc *Document) []Semantic
 				if typeParamStr != "" {
 					returnStart = nameStart + len(name) + len(typeParamStr) + 1 // "name[...]("
 				}
-				if len(params) > 0 {
-					for i, p := range params {
-						returnStart += len(p.Name) + 1 + len(p.Type)
-						if i < len(params)-1 {
-							returnStart += 2 // ", "
-						}
+				for i, p := range params {
+					returnStart += len(p.String())
+					if i < len(params)-1 {
+						returnStart += 2 // ", "
 					}
 				}
 				returnStart += 2 // ") " — close paren + space

--- a/internal/lsp/provider/semantic.go
+++ b/internal/lsp/provider/semantic.go
@@ -319,6 +319,9 @@ func (s *semanticTokensProvider) collectSemanticTokens(doc *Document) []Semantic
 				TokenType: TokenTypeParameter,
 				Modifiers: TokenModDeclaration,
 			})
+			if param.Grouped {
+				continue
+			}
 			// Parameter type
 			typeStart := param.Position.Column - 1 + len(param.Name) + 1 // +1 for space
 			emitGoTypeTokens(param.Type, param.Position.Line-1, typeStart, &tokens)

--- a/internal/lsp/provider/semantic_coverage_test.go
+++ b/internal/lsp/provider/semantic_coverage_test.go
@@ -626,7 +626,7 @@ func TestParseFuncSignatureForTokens(t *testing.T) {
 		wantName       string
 		wantReceiver   string
 		wantTypeParams string
-		wantParams     []funcParam
+		wantParams     []*tuigen.Param
 		wantReturns    string
 	}
 
@@ -634,22 +634,44 @@ func TestParseFuncSignatureForTokens(t *testing.T) {
 		"plain function": {
 			code:        "func helper(s string) string {\n\treturn s\n}",
 			wantName:    "helper",
-			wantParams:  []funcParam{{Name: "s", Type: "string"}},
+			wantParams:  []*tuigen.Param{{Name: "s", Type: "string"}},
 			wantReturns: "string",
 		},
 		"method with receiver": {
 			code:         "func (c *chat) update(h int) int {\n\treturn h\n}",
 			wantName:     "update",
 			wantReceiver: "c *chat",
-			wantParams:   []funcParam{{Name: "h", Type: "int"}},
+			wantParams:   []*tuigen.Param{{Name: "h", Type: "int"}},
 			wantReturns:  "int",
 		},
 		"generic function": {
 			code:           "func pick[T any](a T) T {\n\treturn a\n}",
 			wantName:       "pick",
 			wantTypeParams: "[T any]",
-			wantParams:     []funcParam{{Name: "a", Type: "T"}},
+			wantParams:     []*tuigen.Param{{Name: "a", Type: "T"}},
 			wantReturns:    "T",
+		},
+		"grouped names share a type": {
+			code:        "func sum(a, b int) int {\n\treturn a + b\n}",
+			wantName:    "sum",
+			wantParams:  []*tuigen.Param{{Name: "a", Type: "int", Grouped: true}, {Name: "b", Type: "int"}},
+			wantReturns: "int",
+		},
+		"mixed grouped and variadic": {
+			code:     "func f(a string, b, c int, opts ...tui.Option) {}",
+			wantName: "f",
+			wantParams: []*tuigen.Param{
+				{Name: "a", Type: "string"},
+				{Name: "b", Type: "int", Grouped: true},
+				{Name: "c", Type: "int"},
+				{Name: "opts", Type: "...tui.Option"},
+			},
+		},
+		"commas nested in types": {
+			code:        "func g(m map[string]int, fn func(int, int) bool) bool {}",
+			wantName:    "g",
+			wantParams:  []*tuigen.Param{{Name: "m", Type: "map[string]int"}, {Name: "fn", Type: "func(int, int) bool"}},
+			wantReturns: "bool",
 		},
 		"not a function": {
 			code: "var x = 1",
@@ -689,9 +711,10 @@ func TestParseFuncSignatureForTokens(t *testing.T) {
 			if len(gotParams) != len(tt.wantParams) {
 				t.Fatalf("params = %+v, want %+v", gotParams, tt.wantParams)
 			}
-			for i := range gotParams {
-				if gotParams[i] != tt.wantParams[i] {
-					t.Errorf("param %d = %+v, want %+v", i, gotParams[i], tt.wantParams[i])
+			for i, want := range tt.wantParams {
+				got := gotParams[i]
+				if got.Name != want.Name || got.Type != want.Type || got.Grouped != want.Grouped {
+					t.Errorf("param %d = %+v, want %+v", i, got, want)
 				}
 			}
 			if gotReturns != tt.wantReturns {

--- a/internal/lsp/provider/semantic_gocode.go
+++ b/internal/lsp/provider/semantic_gocode.go
@@ -491,17 +491,11 @@ func extractVarDeclarationsWithPositions(code string) []varDecl {
 	return decls
 }
 
-// funcParam represents a function parameter for semantic tokenization.
-type funcParam struct {
-	Name string
-	Type string
-}
-
 // parseFuncSignatureForTokens extracts function name, receiver, type params, params, and return type from code.
 // For methods like "func (s *Type) Name(...) RetType { ... }", receiver will be "s *Type".
 // For generic functions like "func foo[T any](...)", typeParams will be "[T any]".
 // For plain functions, receiver and typeParams will be "".
-func parseFuncSignatureForTokens(code string) (name, receiver, typeParams string, params []funcParam, returns string) {
+func parseFuncSignatureForTokens(code string) (name, receiver, typeParams string, params []*tuigen.Param, returns string) {
 	code = strings.TrimSpace(code)
 	if !strings.HasPrefix(code, "func ") {
 		return "", "", "", nil, ""
@@ -590,18 +584,7 @@ func parseFuncSignatureForTokens(code string) (name, receiver, typeParams string
 		return name, receiver, typeParams, nil, ""
 	}
 
-	paramStr := rest[1:closeIdx]
-
-	// Parse parameters
-	if paramStr != "" {
-		for p := range strings.SplitSeq(paramStr, ",") {
-			p = strings.TrimSpace(p)
-			parts := strings.SplitN(p, " ", 2)
-			if len(parts) == 2 {
-				params = append(params, funcParam{Name: parts[0], Type: parts[1]})
-			}
-		}
-	}
+	params = tuigen.ParseParamList(rest[1:closeIdx])
 
 	// Return type
 	after := strings.TrimSpace(rest[closeIdx+1:])

--- a/internal/lsp/provider/semantic_test.go
+++ b/internal/lsp/provider/semantic_test.go
@@ -508,3 +508,66 @@ templ Hello() {
 		})
 	}
 }
+
+// Grouped parameter names (a, b int) get one parameter token each and a
+// single type token on the shared type.
+func TestSemanticTokens_GroupedFuncParams(t *testing.T) {
+	type token struct {
+		line, col, length, typ int
+	}
+	type tc struct {
+		content   string
+		want      []token
+		wantNoTyp []token // positions that must not carry a type token
+	}
+
+	tests := map[string]tc{
+		"two names share a type": {
+			content: "package main\n\nfunc sum(a, b int) int {\n\treturn a + b\n}\n",
+			want: []token{
+				{2, 5, 3, TokenTypeFunction},
+				{2, 9, 1, TokenTypeParameter},
+				{2, 12, 1, TokenTypeParameter},
+				{2, 14, 3, TokenTypeType},
+				{2, 19, 3, TokenTypeType}, // return type
+				{3, 8, 1, TokenTypeParameter},
+				{3, 12, 1, TokenTypeParameter},
+			},
+			wantNoTyp: []token{{2, 12, 1, TokenTypeType}},
+		},
+		"mixed grouped and variadic": {
+			content: "package main\n\nfunc f(a string, b, c int, opts ...tui.Option) {}\n",
+			want: []token{
+				{2, 7, 1, TokenTypeParameter},
+				{2, 9, 6, TokenTypeType},
+				{2, 17, 1, TokenTypeParameter},
+				{2, 20, 1, TokenTypeParameter},
+				{2, 22, 3, TokenTypeType},
+				{2, 27, 4, TokenTypeParameter},
+			},
+			wantNoTyp: []token{{2, 20, 1, TokenTypeType}},
+		},
+	}
+
+	sp := newTestSemanticProvider()
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := sp.SemanticTokensFull(parseTestDoc(tt.content))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tokens := decodeTokens(result.Data)
+			for _, w := range tt.want {
+				if !hasTokenAt(tokens, w.line, w.col, w.length, w.typ) {
+					t.Errorf("missing token %+v in %+v", w, tokens)
+				}
+			}
+			for _, w := range tt.wantNoTyp {
+				if hasTokenAt(tokens, w.line, w.col, w.length, w.typ) {
+					t.Errorf("unexpected type token %+v", w)
+				}
+			}
+		})
+	}
+}

--- a/internal/lsp/provider/semantic_test.go
+++ b/internal/lsp/provider/semantic_test.go
@@ -68,6 +68,17 @@ func countByType(tokens []SemanticToken, tokenType int) int {
 }
 
 // hasTokenAt checks if a token exists at the given position with the given type and length.
+// countTokensAt reports how many tokens start at line:col, whatever their type.
+func countTokensAt(tokens []SemanticToken, line, col int) int {
+	n := 0
+	for _, tok := range tokens {
+		if tok.Line == line && tok.StartChar == col {
+			n++
+		}
+	}
+	return n
+}
+
 func hasTokenAt(tokens []SemanticToken, line, col, length, tokenType int) bool {
 	for _, tok := range tokens {
 		if tok.Line == line && tok.StartChar == col && tok.Length == length && tok.TokenType == tokenType {
@@ -547,6 +558,15 @@ func TestSemanticTokens_GroupedFuncParams(t *testing.T) {
 			},
 			wantNoTyp: []token{{2, 20, 1, TokenTypeType}},
 		},
+		"multi-line list": {
+			content: "package x\n\nfunc f(\n\ta int,\n\tb string,\n) {\n}\n",
+			want: []token{
+				{3, 1, 1, TokenTypeParameter},
+				{3, 3, 3, TokenTypeType},
+				{4, 1, 1, TokenTypeParameter},
+				{4, 3, 6, TokenTypeType},
+			},
+		},
 	}
 
 	sp := newTestSemanticProvider()
@@ -561,6 +581,9 @@ func TestSemanticTokens_GroupedFuncParams(t *testing.T) {
 			for _, w := range tt.want {
 				if !hasTokenAt(tokens, w.line, w.col, w.length, w.typ) {
 					t.Errorf("missing token %+v in %+v", w, tokens)
+				}
+				if n := countTokensAt(tokens, w.line, w.col); n > 1 {
+					t.Errorf("token %+v emitted %d times", w, n)
 				}
 			}
 			for _, w := range tt.wantNoTyp {

--- a/internal/lsp/provider/semantic_test.go
+++ b/internal/lsp/provider/semantic_test.go
@@ -108,6 +108,17 @@ templ Greeting(name string, count int) {
 			wantClassName: true,
 			wantParams:    2,
 		},
+		"component with grouped params": {
+			content: `package main
+
+templ Pair(a, b string) {
+	<span>{a}</span>
+}
+`,
+			wantKeyword:   true,
+			wantClassName: true,
+			wantParams:    2,
+		},
 	}
 
 	sp := newTestSemanticProvider()
@@ -170,6 +181,30 @@ templ Greeting(name string, count int) {
 		}
 		if !hasTokenAt(tokens, 2, 6, 8, TokenTypeClass) {
 			t.Error("expected Greeting class token at 2:6 with length 8")
+		}
+	})
+
+	// Grouped params: "templ Pair(a, b string)" has a at col 11, b at col 14,
+	// and a single "string" type token at col 17 (owned by b).
+	t.Run("component with grouped params positions", func(t *testing.T) {
+		doc := parseTestDoc(tests["component with grouped params"].content)
+		result, err := sp.SemanticTokensFull(doc)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tokens := decodeTokens(result.Data)
+
+		if !hasTokenAt(tokens, 2, 11, 1, TokenTypeParameter) {
+			t.Error("expected parameter token for a at 2:11")
+		}
+		if !hasTokenAt(tokens, 2, 14, 1, TokenTypeParameter) {
+			t.Error("expected parameter token for b at 2:14")
+		}
+		if !hasTokenAt(tokens, 2, 16, 6, TokenTypeType) {
+			t.Error("expected string type token at 2:16 after b")
+		}
+		if hasTokenAt(tokens, 2, 13, 6, TokenTypeType) {
+			t.Error("grouped name a must not emit a type token at 2:13")
 		}
 	})
 }

--- a/internal/lsp/schema/schema.go
+++ b/internal/lsp/schema/schema.go
@@ -118,6 +118,7 @@ var Elements = map[string]*ElementDef{
 		Attributes: []AttributeDef{
 			{Name: "id", Type: "string", Description: "Unique identifier for the element", Category: "generic"},
 			{Name: "class", Type: "string", Description: "Tailwind-style CSS classes", Category: "generic"},
+			optionsAttr("[]tui.Option"),
 		},
 	},
 	"br": {
@@ -128,6 +129,7 @@ var Elements = map[string]*ElementDef{
 		Attributes: []AttributeDef{
 			{Name: "id", Type: "string", Description: "Unique identifier for the element", Category: "generic"},
 			{Name: "class", Type: "string", Description: "Tailwind-style CSS classes", Category: "generic"},
+			optionsAttr("[]tui.Option"),
 		},
 	},
 	"modal": {
@@ -243,6 +245,17 @@ func genericAttrs() []AttributeDef {
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable (tui.NewRef/NewRefList/NewRefMap)", Category: "ref"},
 		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref; on a container element it keys descendant component mounts", Category: "generic"},
+		optionsAttr("[]tui.Option"),
+	}
+}
+
+// optionsAttr returns the options attribute; the slice type follows the tag's constructor.
+func optionsAttr(sliceType string) AttributeDef {
+	return AttributeDef{
+		Name:        "options",
+		Type:        "expression",
+		Description: "A " + sliceType + " forwarded to the element constructor after the attribute-derived options, so entries in the slice override attributes",
+		Category:    "generic",
 	}
 }
 
@@ -386,6 +399,7 @@ func inputAttrs() []AttributeDef {
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
 		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref; on a container element it keys descendant component mounts", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
+		optionsAttr("[]tui.InputOption"),
 	}
 }
 
@@ -411,6 +425,7 @@ func textareaAttrs() []AttributeDef {
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
 		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref; on a container element it keys descendant component mounts", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
+		optionsAttr("[]tui.TextAreaOption"),
 	}
 }
 
@@ -428,6 +443,7 @@ func modalAttrs() []AttributeDef {
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
 		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref; on a container element it keys descendant component mounts", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
+		optionsAttr("[]tui.ModalOption"),
 	}
 }
 
@@ -443,6 +459,7 @@ func markdownAttrs() []AttributeDef {
 		{Name: "ref", Type: "expression", Description: "Bind this element to a ref variable", Category: "ref"},
 		{Name: "key", Type: "expression", Description: "Stable identity for a loop item, unique among siblings of the innermost loop (like React keys): used as the mount cache key for component elements and as the RefMap key when combined with ref; on a container element it keys descendant component mounts", Category: "generic"},
 		{Name: "deps", Type: "expression", Description: "Explicit state dependencies for reactive bindings", Category: "generic"},
+		optionsAttr("[]tui.MarkdownOption"),
 	}
 }
 
@@ -454,5 +471,6 @@ func progressAttrs() []AttributeDef {
 		{Name: "value", Type: "int", Description: "Current progress value (0 to max)", Category: "generic"},
 		{Name: "max", Type: "int", Description: "Maximum progress value", Category: "generic"},
 		{Name: "width", Type: "int", Description: "Progress bar width in characters", Category: "layout"},
+		optionsAttr("[]tui.Option"),
 	}
 }

--- a/internal/lsp/schema/schema_test.go
+++ b/internal/lsp/schema/schema_test.go
@@ -135,6 +135,21 @@ func TestGetAttribute(t *testing.T) {
 			attr:    "value",
 			wantCat: "generic",
 		},
+		"div has options": {
+			tag:     "div",
+			attr:    "options",
+			wantCat: "generic",
+		},
+		"modal has options": {
+			tag:     "modal",
+			attr:    "options",
+			wantCat: "generic",
+		},
+		"textarea has options": {
+			tag:     "textarea",
+			attr:    "options",
+			wantCat: "generic",
+		},
 		"unknown tag returns nil": {
 			tag:     "foobar",
 			attr:    "id",

--- a/internal/lsp/schema/schema_test.go
+++ b/internal/lsp/schema/schema_test.go
@@ -140,16 +140,6 @@ func TestGetAttribute(t *testing.T) {
 			attr:    "options",
 			wantCat: "generic",
 		},
-		"modal has options": {
-			tag:     "modal",
-			attr:    "options",
-			wantCat: "generic",
-		},
-		"textarea has options": {
-			tag:     "textarea",
-			attr:    "options",
-			wantCat: "generic",
-		},
 		"unknown tag returns nil": {
 			tag:     "foobar",
 			attr:    "id",
@@ -426,5 +416,18 @@ func TestContainerHasEventAttrs(t *testing.T) {
 	}
 	if !hasOnBlur {
 		t.Error("div should have onBlur attribute")
+	}
+}
+
+func TestEveryElementHasOptions(t *testing.T) {
+	for tag := range Elements {
+		attr := GetAttribute(tag, "options")
+		if attr == nil {
+			t.Errorf("%s: missing options attribute", tag)
+			continue
+		}
+		if attr.Category != "generic" {
+			t.Errorf("%s: options category = %q, want %q", tag, attr.Category, "generic")
+		}
 	}
 }

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -280,17 +280,15 @@ func (a *Analyzer) Analyze(file *File) error {
 	// analyzeComponentCall can reject @Factory() calls in function templs.
 	a.structComponentFactories = collectStructComponentFactories(file, a.getTUIAlias())
 
-	// Validate method templs using {children...} have a children field on their struct
+	// {children...} needs a children field on method templs; on function templs
+	// it becomes a trailing param, so the declared last param cannot be variadic
 	for _, comp := range file.Components {
-		if comp.Receiver != "" && comp.AcceptsChildren {
-			a.validateChildrenField(comp, file.Decls)
+		if !comp.AcceptsChildren {
+			continue
 		}
-	}
-
-	// Function templs using {children...} get a trailing children param, so
-	// their own last param cannot be variadic
-	for _, comp := range file.Components {
-		if comp.Receiver == "" && comp.AcceptsChildren {
+		if comp.Receiver != "" {
+			a.validateChildrenField(comp, file.Decls)
+		} else {
 			a.validateChildrenParams(comp)
 		}
 	}
@@ -775,8 +773,8 @@ func (a *Analyzer) validateChildrenParams(comp *Component) {
 	elemType := strings.TrimSpace(strings.TrimPrefix(typ, "..."))
 	a.errors.Add(NewErrorWithHint(last.Position,
 		fmt.Sprintf("templ %s uses {children...} so its last parameter cannot be variadic", comp.Name),
-		fmt.Sprintf("declare it as a slice, for example %s []%s, and call it as @%s(..., %s) { ... }",
-			last.Name, elemType, comp.Name, last.Name)))
+		fmt.Sprintf("declare it as a slice (%s []%s) and pass a slice at the call site",
+			last.Name, elemType)))
 }
 
 // AnalyzeFile is a convenience function that parses and analyzes a .tui file.

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -287,6 +287,14 @@ func (a *Analyzer) Analyze(file *File) error {
 		}
 	}
 
+	// Function templs using {children...} get a trailing children param, so
+	// their own last param cannot be variadic
+	for _, comp := range file.Components {
+		if comp.Receiver == "" && comp.AcceptsChildren {
+			a.validateChildrenParams(comp)
+		}
+	}
+
 	// Second pass: collect := binding names from all components
 	for _, comp := range file.Components {
 		a.collectLetBindings(comp.Body)
@@ -751,6 +759,24 @@ func (a *Analyzer) validateChildrenField(comp *Component, decls []*GoDecl) {
 	a.errors.AddErrorf(comp.Position,
 		"method templ %s uses {children...} but struct %s has no `children` field; add `children []*tui.Element` to the struct",
 		comp.Name, typeName)
+}
+
+// validateChildrenParams rejects a variadic final parameter on a function templ
+// that uses {children...}, since the generator appends `children` after it.
+func (a *Analyzer) validateChildrenParams(comp *Component) {
+	if len(comp.Params) == 0 {
+		return
+	}
+	last := comp.Params[len(comp.Params)-1]
+	typ := strings.TrimSpace(last.Type)
+	if !strings.HasPrefix(typ, "...") {
+		return
+	}
+	elemType := strings.TrimSpace(strings.TrimPrefix(typ, "..."))
+	a.errors.Add(NewErrorWithHint(last.Position,
+		fmt.Sprintf("templ %s uses {children...} so its last parameter cannot be variadic", comp.Name),
+		fmt.Sprintf("declare it as a slice, for example %s []%s, and call it as @%s(..., %s) { ... }",
+			last.Name, elemType, comp.Name, last.Name)))
 }
 
 // AnalyzeFile is a convenience function that parses and analyzes a .tui file.

--- a/internal/tuigen/analyzer.go
+++ b/internal/tuigen/analyzer.go
@@ -200,6 +200,9 @@ var knownAttributes = map[string]bool{
 	"ref": true, // ref={varName} for element references
 	"key": true, // key={expr}: identity for mounts (own, or descendants' when on a container); RefMap key with ref
 
+	// Option slice forwarded to the element constructor, applied after attribute-derived options
+	"options": true,
+
 	// Modal
 	"open":                 true,
 	"backdrop":             true,
@@ -427,7 +430,15 @@ func (a *Analyzer) analyzeElement(elem *Element) {
 	}
 
 	// Check attributes
+	seenOptions := false
 	for _, attr := range elem.Attributes {
+		if attr.Name == "options" {
+			if seenOptions {
+				a.errors.AddError(attr.Position, "duplicate options attribute")
+				continue
+			}
+			seenOptions = true
+		}
 		a.analyzeAttribute(attr, elem.Tag)
 	}
 
@@ -458,6 +469,16 @@ func (a *Analyzer) analyzeAttribute(attr *Attribute, tagName string) {
 		err.Hint = "use " + attr.Name + "={...} with a Go expression, not a literal"
 		a.errors.Add(err)
 		return
+	}
+
+	// options forwards a Go slice, so a literal has no valid meaning.
+	if attr.Name == "options" {
+		if _, ok := attr.Value.(*GoExpr); !ok {
+			err := NewError(attr.Position, "options must be an expression")
+			err.Hint = "use options={...} with a Go expression of the element's option slice type"
+			a.errors.Add(err)
+			return
+		}
 	}
 
 	// Check if class attribute uses Tailwind classes that need imports

--- a/internal/tuigen/analyzer_test.go
+++ b/internal/tuigen/analyzer_test.go
@@ -419,6 +419,76 @@ templ (p *panel) Render() {
 	}
 }
 
+func TestAnalyzer_OptionsAttribute(t *testing.T) {
+	type tc struct {
+		input         string
+		wantError     bool
+		errorContains string
+	}
+
+	tests := map[string]tc{
+		"options expression on div is valid": {
+			input: `package x
+templ Card(opts []tui.Option) {
+	<div class="p-1" options={opts}></div>
+}`,
+		},
+		"options expression on modal is valid": {
+			input: `package x
+type dialog struct{}
+templ (d *dialog) Render() {
+	<modal open={d.open} options={d.opts}>
+		<span>hi</span>
+	</modal>
+}`,
+		},
+		"options string literal is rejected": {
+			input: `package x
+templ Card() {
+	<div options="opts"></div>
+}`,
+			wantError:     true,
+			errorContains: "options must be an expression",
+		},
+		"options int literal is rejected": {
+			input: `package x
+templ Card() {
+	<div options=1></div>
+}`,
+			wantError:     true,
+			errorContains: "options must be an expression",
+		},
+		"duplicate options is rejected": {
+			input: `package x
+templ Card(a, b []tui.Option) {
+	<div options={a} options={b}></div>
+}`,
+			wantError:     true,
+			errorContains: "duplicate options attribute",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := AnalyzeFile("test.gsx", tt.input)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error, got nil")
+					return
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errorContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestAnalyzer_KeyAndRefRequireExpressions(t *testing.T) {
 	type tc struct {
 		input         string

--- a/internal/tuigen/analyzer_validation_test.go
+++ b/internal/tuigen/analyzer_validation_test.go
@@ -529,7 +529,7 @@ templ Panel(title string, opts ...tui.Option) {
 }`,
 			wantError:     true,
 			errorContains: "templ Panel uses {children...} so its last parameter cannot be variadic",
-			hintContains:  "declare it as a slice, for example opts []tui.Option, and call it as @Panel(..., opts) { ... }",
+			hintContains:  "declare it as a slice (opts []tui.Option) and pass a slice at the call site",
 		},
 		"variadic last param with extra whitespace is rejected": {
 			input: `package x

--- a/internal/tuigen/analyzer_validation_test.go
+++ b/internal/tuigen/analyzer_validation_test.go
@@ -531,6 +531,18 @@ templ Panel(title string, opts ...tui.Option) {
 			errorContains: "templ Panel uses {children...} so its last parameter cannot be variadic",
 			hintContains:  "declare it as a slice (opts []tui.Option) and pass a slice at the call site",
 		},
+		"grouped params before variadic last param with children slot is rejected": {
+			input: `package x
+templ Panel(x, y int, opts ...tui.Option) {
+	<div options={opts}>
+		<span>{x + y}</span>
+		{children...}
+	</div>
+}`,
+			wantError:     true,
+			errorContains: "templ Panel uses {children...} so its last parameter cannot be variadic",
+			hintContains:  "declare it as a slice (opts []tui.Option) and pass a slice at the call site",
+		},
 		"variadic last param with extra whitespace is rejected": {
 			input: `package x
 templ Panel(opts ... tui.Option) {

--- a/internal/tuigen/analyzer_validation_test.go
+++ b/internal/tuigen/analyzer_validation_test.go
@@ -509,3 +509,89 @@ templ Test() {
 		t.Error("EndPos should be set for range-based highlighting")
 	}
 }
+
+func TestAnalyzer_VariadicParamWithChildrenSlot(t *testing.T) {
+	type tc struct {
+		input         string
+		wantError     bool
+		errorContains string
+		hintContains  string
+	}
+
+	tests := map[string]tc{
+		"variadic last param with children slot is rejected": {
+			input: `package x
+templ Panel(title string, opts ...tui.Option) {
+	<div options={opts}>
+		<span>{title}</span>
+		{children...}
+	</div>
+}`,
+			wantError:     true,
+			errorContains: "templ Panel uses {children...} so its last parameter cannot be variadic",
+			hintContains:  "declare it as a slice, for example opts []tui.Option, and call it as @Panel(..., opts) { ... }",
+		},
+		"variadic last param with extra whitespace is rejected": {
+			input: `package x
+templ Panel(opts ... tui.Option) {
+	<div options={opts}>
+		{children...}
+	</div>
+}`,
+			wantError:     true,
+			errorContains: "templ Panel uses {children...} so its last parameter cannot be variadic",
+			hintContains:  "opts []tui.Option",
+		},
+		"variadic last param without children slot is accepted": {
+			input: `package x
+templ Card(title string, opts ...tui.Option) {
+	<div options={opts}>
+		<span>{title}</span>
+	</div>
+}`,
+			wantError: false,
+		},
+		"slice param with children slot is accepted": {
+			input: `package x
+templ Panel(title string, opts []tui.Option) {
+	<div options={opts}>
+		<span>{title}</span>
+		{children...}
+	</div>
+}`,
+			wantError: false,
+		},
+		"no params with children slot is accepted": {
+			input: `package x
+templ Panel() {
+	<div>
+		{children...}
+	</div>
+}`,
+			wantError: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := AnalyzeFile("test.gsx", tt.input)
+
+			if !tt.wantError {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Error("expected error, got nil")
+				return
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.errorContains)
+			}
+			if tt.hintContains != "" && !strings.Contains(err.Error(), tt.hintContains) {
+				t.Errorf("error %q does not contain hint %q", err.Error(), tt.hintContains)
+			}
+		})
+	}
+}

--- a/internal/tuigen/ast.go
+++ b/internal/tuigen/ast.go
@@ -111,6 +111,15 @@ type Param struct {
 func (p *Param) node()         {}
 func (p *Param) Pos() Position { return p.Position }
 
+// String returns the param as written in a signature: a grouped name
+// (a in "a, b T") is just the name, otherwise "name type".
+func (p *Param) String() string {
+	if p.Grouped {
+		return p.Name
+	}
+	return p.Name + " " + p.Type
+}
+
 // Element represents an XML-like element: <tag attrs>children</tag> or <tag />
 type Element struct {
 	Tag        string

--- a/internal/tuigen/ast.go
+++ b/internal/tuigen/ast.go
@@ -103,6 +103,9 @@ type Param struct {
 	Name     string
 	Type     string
 	Position Position
+	// Grouped marks a name that shares the next param's type (a, b T);
+	// Type is still filled in, but printers emit only the name.
+	Grouped bool
 }
 
 func (p *Param) node()         {}

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -144,6 +144,10 @@ func (g *Generator) generateFunctionComponent(comp *Component) {
 		if i > 0 {
 			g.write(", ")
 		}
+		if param.Grouped {
+			g.write(param.Name)
+			continue
+		}
 		g.writef("%s %s", param.Name, param.Type)
 	}
 	// Add children parameter if component accepts children

--- a/internal/tuigen/generator_component.go
+++ b/internal/tuigen/generator_component.go
@@ -144,11 +144,7 @@ func (g *Generator) generateFunctionComponent(comp *Component) {
 		if i > 0 {
 			g.write(", ")
 		}
-		if param.Grouped {
-			g.write(param.Name)
-			continue
-		}
-		g.writef("%s %s", param.Name, param.Type)
+		g.write(param.String())
 	}
 	// Add children parameter if component accepts children
 	if comp.AcceptsChildren {

--- a/internal/tuigen/generator_control.go
+++ b/internal/tuigen/generator_control.go
@@ -31,19 +31,7 @@ func (g *Generator) generateLetBinding(let *LetBinding, parentVar string, inCond
 	}
 
 	// RHS is an element (existing behavior)
-	elemOpts := g.buildElementOptions(let.Element)
-
-	if len(elemOpts.options) == 0 {
-		g.writef("%s := tui.New()\n", let.Name)
-	} else {
-		g.writef("%s := tui.New(\n", let.Name)
-		g.indent++
-		for _, opt := range elemOpts.options {
-			g.writef("%s,\n", opt)
-		}
-		g.indent--
-		g.writeln(")")
-	}
+	g.writeOptionsCall(let.Name+" := ", "tui.New", "[]tui.Option", g.buildElementOptions(let.Element))
 
 	// Generate children for the let-bound element - skip if text element already has content in WithText
 	if !skipTextChildren(let.Element) {

--- a/internal/tuigen/generator_element.go
+++ b/internal/tuigen/generator_element.go
@@ -29,19 +29,7 @@ func (g *Generator) generateElementWithRefs(elem *Element, parentVar string, inL
 	varName := g.nextVar()
 
 	// Build options from attributes and tag
-	elemOpts := g.buildElementOptions(elem)
-
-	if len(elemOpts.options) == 0 {
-		g.writef("%s := tui.New()\n", varName)
-	} else {
-		g.writef("%s := tui.New(\n", varName)
-		g.indent++
-		for _, opt := range elemOpts.options {
-			g.writef("%s,\n", opt)
-		}
-		g.indent--
-		g.writeln(")")
-	}
+	g.writeOptionsCall(varName+" := ", "tui.New", "[]tui.Option", g.buildElementOptions(elem))
 
 	// Handle ref binding — emit the appropriate Set/Append/Put call
 	if elem.RefExpr != nil {
@@ -78,6 +66,35 @@ func (g *Generator) generateElementWithRefs(elem *Element, parentVar string, inL
 // elementOptions holds options for an element.
 type elementOptions struct {
 	options []string
+	// spread is the options={...} expression, appended after options so it can override them.
+	spread string
+}
+
+// writeOptionsCall emits "<lhs><ctor>(...)" for the element's options. With a
+// spread the attribute options are wrapped in append so the slice applies last.
+func (g *Generator) writeOptionsCall(lhs, ctor, sliceType string, opts elementOptions) {
+	switch {
+	case len(opts.options) == 0 && opts.spread == "":
+		g.writef("%s%s()\n", lhs, ctor)
+	case len(opts.options) == 0:
+		g.writef("%s%s(%s...)\n", lhs, ctor, opts.spread)
+	case opts.spread == "":
+		g.writef("%s%s(\n", lhs, ctor)
+		g.indent++
+		for _, opt := range opts.options {
+			g.writef("%s,\n", opt)
+		}
+		g.indent--
+		g.writeln(")")
+	default:
+		g.writef("%s%s(append(%s{\n", lhs, ctor, sliceType)
+		g.indent++
+		for _, opt := range opts.options {
+			g.writef("%s,\n", opt)
+		}
+		g.indent--
+		g.writef("}, %s...)...)\n", opts.spread)
+	}
 }
 
 // buildElementOptions generates option expressions for an element.
@@ -125,6 +142,11 @@ func (g *Generator) buildElementOptions(elem *Element) elementOptions {
 
 	// Generate options from attributes
 	for _, attr := range elem.Attributes {
+		if attr.Name == "options" {
+			result.spread = g.generateAttributeValue(attr.Value)
+			continue
+		}
+
 		// Handle class attribute specially - parse Tailwind classes
 		if attr.Name == "class" {
 			classValue := g.getClassAttributeValue(attr)
@@ -413,6 +435,32 @@ var markdownAttributeToOption = map[string]string{
 // markdownHandlerAttributes: markdown has no event handlers.
 var markdownHandlerAttributes = map[string]string{}
 
+// ElementConstructor returns the constructor a tag compiles to: tui.New for
+// plain elements or the component constructor for mounted component tags.
+func ElementConstructor(tag string) string {
+	if isComponentElement(tag) {
+		return componentConstructor(tag)
+	}
+	return "tui.New"
+}
+
+// componentOptionType returns the option slice type accepted by a component
+// element's constructor, used to type the options={...} append.
+func componentOptionType(tag string) string {
+	switch tag {
+	case "textarea":
+		return "[]tui.TextAreaOption"
+	case "input":
+		return "[]tui.InputOption"
+	case "modal":
+		return "[]tui.ModalOption"
+	case "markdown":
+		return "[]tui.MarkdownOption"
+	default:
+		return fmt.Sprintf("[]UNKNOWN_COMPONENT_OPTION_%s", tag)
+	}
+}
+
 // componentConstructor returns the tui.New* constructor for a component element tag.
 func componentConstructor(tag string) string {
 	switch tag {
@@ -464,19 +512,7 @@ func (g *Generator) generateComponentElementWithRefs(elem *Element, parentVar st
 	g.writef("%s := %s(%s, %s, func() tui.Component {\n", varName, mountFunc, g.currentReceiver, indexExpr)
 	g.indent++
 
-	constructor := componentConstructor(elem.Tag)
-
-	if len(elemOpts.options) == 0 {
-		g.writef("return %s()\n", constructor)
-	} else {
-		g.writef("return %s(\n", constructor)
-		g.indent++
-		for _, opt := range elemOpts.options {
-			g.writef("%s,\n", opt)
-		}
-		g.indent--
-		g.writef(")\n")
-	}
+	g.writeOptionsCall("return ", componentConstructor(elem.Tag), componentOptionType(elem.Tag), elemOpts)
 
 	g.indent--
 	g.writeln("})")
@@ -513,6 +549,11 @@ func (g *Generator) buildComponentElementOptions(elem *Element) elementOptions {
 	attrMap, handlerMap := componentAttributeMaps(elem.Tag)
 
 	for _, attr := range elem.Attributes {
+		if attr.Name == "options" {
+			result.spread = g.generateAttributeValue(attr.Value)
+			continue
+		}
+
 		// Skip generic attributes handled elsewhere
 		if attr.Name == "class" || attr.Name == "id" || attr.Name == "ref" ||
 			attr.Name == "key" || attr.Name == "deps" {

--- a/internal/tuigen/generator_element_coverage_test.go
+++ b/internal/tuigen/generator_element_coverage_test.go
@@ -191,6 +191,39 @@ templ App() {
 				"Foreground(tui.Red)",
 			},
 		},
+		"options alone spreads into the constructor": {
+			input: `package x
+templ App(opts []tui.Option) {
+	<div options={opts}></div>
+}`,
+			wantContains:    []string{"__tui_0 := tui.New(opts...)\n"},
+			wantNotContains: []string{"append("},
+		},
+		"options after attributes uses append so the slice applies last": {
+			input: `package x
+templ App(opts []tui.Option) {
+	<div class="border-rounded p-1" options={opts}></div>
+}`,
+			wantContains: []string{
+				"__tui_0 := tui.New(append([]tui.Option{\n" +
+					"\t\ttui.WithBorder(tui.BorderRounded),\n" +
+					"\t\ttui.WithPadding(1),\n" +
+					"\t}, opts...)...)\n",
+			},
+			wantNotContains: []string{"tui.WithOptions"},
+		},
+		"let-bound element with options uses append": {
+			input: `package x
+templ App(opts []tui.Option) {
+	card := <div class="p-1" options={opts}></div>
+	<div>{card}</div>
+}`,
+			wantContains: []string{
+				"card := tui.New(append([]tui.Option{\n" +
+					"\t\ttui.WithPadding(1),\n" +
+					"\t}, opts...)...)\n",
+			},
+		},
 	}
 
 	for name, tt := range tests {
@@ -371,6 +404,35 @@ templ (c *shell) Render() {
 				"tui.WithModalTrapFocus(true)",
 				`tui.WithText("content")`,
 				".AddChild(",
+			},
+		},
+		"modal with open, class, and options appends the slice last": {
+			input: `package x
+
+type shell struct{}
+
+templ (c *shell) Render() {
+	<modal open={c.showModal} class="justify-center items-center" options={c.modalOpts}>
+		<span>content</span>
+	</modal>
+}`,
+			wantContains: []string{
+				"return tui.NewModal(append([]tui.ModalOption{\n" +
+					"\t\t\ttui.WithModalOpen(c.showModal),\n" +
+					"\t\t\ttui.WithModalElementOptions(tui.WithJustify(tui.JustifyCenter), tui.WithAlign(tui.AlignCenter)),\n" +
+					"\t\t}, c.modalOpts...)...)\n",
+			},
+		},
+		"textarea with only options spreads directly": {
+			input: `package x
+
+type form struct{}
+
+templ (c *form) Render() {
+	<textarea options={c.taOpts} />
+}`,
+			wantContains: []string{
+				"return tui.NewTextArea(c.taOpts...)\n",
 			},
 		},
 		"modal open bool literal wrapped in NewState": {

--- a/internal/tuigen/generator_test.go
+++ b/internal/tuigen/generator_test.go
@@ -51,6 +51,16 @@ templ Greeting(name string, count int) {
 				"type GreetingView struct",
 			},
 		},
+		"component with grouped params": {
+			input: `package x
+templ Grp(x, y int, opts ...tui.Option) {
+	<div options={opts}>{fmt.Sprint(x + y)}</div>
+}`,
+			wantContains: []string{
+				"func Grp(x, y int, opts ...tui.Option) *GrpView",
+				"fmt.Sprint(x + y)",
+			},
+		},
 	}
 
 	for name, tt := range tests {

--- a/internal/tuigen/parser_component.go
+++ b/internal/tuigen/parser_component.go
@@ -388,15 +388,26 @@ func (p *Parser) parseMethodTempl(pos Position) *Component {
 	return comp
 }
 
-// parseParams parses function parameters.
+// parseParams parses function parameters, including Go-style grouped
+// names (a, b string) which all receive the shared type.
 func (p *Parser) parseParams() []*Param {
 	var params []*Param
+	var pending []*Param // bare names waiting for the group's type
 	p.skipNewlines()
 
 	for p.current.Type != TokenRParen && p.current.Type != TokenEOF {
 		param := p.parseParam()
 		if param != nil {
-			params = append(params, param)
+			if param.Type == "" {
+				param.Grouped = true
+				pending = append(pending, param)
+			} else {
+				for _, g := range pending {
+					g.Type = param.Type
+				}
+				params = append(append(params, pending...), param)
+				pending = nil
+			}
 		}
 		p.skipNewlines()
 
@@ -412,10 +423,16 @@ func (p *Parser) parseParams() []*Param {
 		}
 	}
 
+	if len(pending) > 0 {
+		last := pending[len(pending)-1]
+		p.errors.AddErrorf(last.Position, "parameter %s is missing a type", last.Name)
+	}
+
 	return params
 }
 
-// parseParam parses a single parameter: name Type
+// parseParam parses a single parameter: name Type. A bare name (a in
+// "a, b T") comes back with an empty Type for parseParams to resolve.
 func (p *Parser) parseParam() *Param {
 	pos := p.position()
 
@@ -428,14 +445,9 @@ func (p *Parser) parseParam() *Param {
 	p.advance()
 
 	// Parse type (could be complex like *element.Element, []string, func())
-	typeStr := p.parseType()
-	if typeStr == "" {
-		return nil
-	}
-
 	return &Param{
 		Name:     name,
-		Type:     typeStr,
+		Type:     p.parseType(),
 		Position: pos,
 	}
 }

--- a/internal/tuigen/parser_component.go
+++ b/internal/tuigen/parser_component.go
@@ -388,6 +388,13 @@ func (p *Parser) parseMethodTempl(pos Position) *Component {
 	return comp
 }
 
+// ParseParamList parses the raw text of a Go parameter list ("a, b int,
+// opts ...T") with the same grouped-name rules as templ signatures. Param
+// positions are 1-based line/column within list.
+func ParseParamList(list string) []*Param {
+	return NewParser(NewLexer("", list)).parseParams()
+}
+
 // parseParams parses function parameters, including Go-style grouped
 // names (a, b string) which all receive the shared type.
 func (p *Parser) parseParams() []*Param {

--- a/internal/tuigen/parser_component.go
+++ b/internal/tuigen/parser_component.go
@@ -390,7 +390,8 @@ func (p *Parser) parseMethodTempl(pos Position) *Component {
 
 // ParseParamList parses the raw text of a Go parameter list ("a, b int,
 // opts ...T") with the same grouped-name rules as templ signatures. Param
-// positions are 1-based line/column within list.
+// positions are 1-based line/column within list. Malformed input yields the
+// params parsed before the error.
 func ParseParamList(list string) []*Param {
 	return NewParser(NewLexer("", list)).parseParams()
 }
@@ -443,7 +444,10 @@ func (p *Parser) parseParams() []*Param {
 func (p *Parser) parseParam() *Param {
 	pos := p.position()
 
-	if p.current.Type != TokenIdent {
+	// _ and templ are lexer tokens but legal Go parameter names.
+	switch p.current.Type {
+	case TokenIdent, TokenUnderscore, TokenTempl:
+	default:
 		p.errors.AddError(p.position(), "expected parameter name")
 		return nil
 	}

--- a/internal/tuigen/parser_component_test.go
+++ b/internal/tuigen/parser_component_test.go
@@ -143,6 +143,118 @@ templ Test(name string, count int, items []string, handler func()) {
 	}
 }
 
+func TestParser_GroupedParams(t *testing.T) {
+	type wantParam struct {
+		name    string
+		typ     string
+		column  int
+		grouped bool
+	}
+	type tc struct {
+		input         string
+		want          []wantParam
+		errorContains string
+	}
+
+	tests := map[string]tc{
+		"single param unchanged": {
+			input: `package x
+templ P(a string) {
+	<span>{a}</span>
+}`,
+			want: []wantParam{{"a", "string", 9, false}},
+		},
+		"two names share a type": {
+			input: `package x
+templ P(a, b string) {
+	<span>{a + b}</span>
+}`,
+			want: []wantParam{{"a", "string", 9, true}, {"b", "string", 12, false}},
+		},
+		"grouped then variadic": {
+			input: `package x
+templ P(x, y int, opts ...tui.Option) {
+	<div options={opts}></div>
+}`,
+			want: []wantParam{
+				{"x", "int", 9, true},
+				{"y", "int", 12, false},
+				{"opts", "...tui.Option", 19, false},
+			},
+		},
+		"grouped variadic": {
+			input: `package x
+templ P(a, b ...tui.Option) {
+	<div options={a}></div>
+}`,
+			want: []wantParam{{"a", "...tui.Option", 9, true}, {"b", "...tui.Option", 12, false}},
+		},
+		"mixed grouped and ungrouped": {
+			input: `package x
+templ P(title string, x, y, z int, on func()) {
+	<span>{title}</span>
+}`,
+			want: []wantParam{
+				{"title", "string", 9, false},
+				{"x", "int", 23, true},
+				{"y", "int", 26, true},
+				{"z", "int", 29, false},
+				{"on", "func()", 36, false},
+			},
+		},
+		"multiline group with trailing comma": {
+			input: `package x
+templ P(
+	a, b string,
+	n int,
+) {
+	<span>{a}</span>
+}`,
+			want: []wantParam{
+				{"a", "string", 2, true},
+				{"b", "string", 5, false},
+				{"n", "int", 2, false},
+			},
+		},
+		"trailing name without a type is an error": {
+			input: `package x
+templ P(a, b) {
+	<span>{a}</span>
+}`,
+			errorContains: "parameter b is missing a type",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			file, err := NewParser(NewLexer("test.gsx", tt.input)).ParseFile()
+			if tt.errorContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errorContains) {
+					t.Fatalf("error = %v, want containing %q", err, tt.errorContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			params := file.Components[0].Params
+			if len(params) != len(tt.want) {
+				t.Fatalf("got %d params, want %d", len(params), len(tt.want))
+			}
+			for i, w := range tt.want {
+				got := params[i]
+				if got.Name != w.name || got.Type != w.typ || got.Grouped != w.grouped {
+					t.Errorf("param %d = {%s %q grouped=%v}, want {%s %q grouped=%v}",
+						i, got.Name, got.Type, got.Grouped, w.name, w.typ, w.grouped)
+				}
+				if got.Position.Column != w.column {
+					t.Errorf("param %s column = %d, want %d", w.name, got.Position.Column, w.column)
+				}
+			}
+		})
+	}
+}
+
 func TestParser_ComplexTypeSignatures(t *testing.T) {
 	type tc struct {
 		input     string

--- a/internal/tuigen/parser_component_test.go
+++ b/internal/tuigen/parser_component_test.go
@@ -255,6 +255,62 @@ templ P(a, b) {
 	}
 }
 
+// ParseParamList is the entry point the LSP uses for raw Go func
+// parameter text; it must resolve grouped names the same way templ does.
+func TestParseParamList(t *testing.T) {
+	type wantParam struct {
+		name    string
+		typ     string
+		column  int
+		grouped bool
+	}
+	type tc struct {
+		list string
+		want []wantParam
+	}
+
+	tests := map[string]tc{
+		"empty": {list: ""},
+		"grouped names share a type": {
+			list: "a, b int",
+			want: []wantParam{{"a", "int", 1, true}, {"b", "int", 4, false}},
+		},
+		"mixed grouped and variadic": {
+			list: "a string, b, c int, opts ...tui.Option",
+			want: []wantParam{
+				{"a", "string", 1, false},
+				{"b", "int", 11, true},
+				{"c", "int", 14, false},
+				{"opts", "...tui.Option", 21, false},
+			},
+		},
+		"commas nested in types": {
+			list: "m map[string]int, fn func(int, int) bool",
+			want: []wantParam{{"m", "map[string]int", 1, false}, {"fn", "func(int, int) bool", 19, false}},
+		},
+		"trailing bare name is dropped": {
+			list: "a int, b",
+			want: []wantParam{{"a", "int", 1, false}},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			params := ParseParamList(tt.list)
+			if len(params) != len(tt.want) {
+				t.Fatalf("got %d params, want %d", len(params), len(tt.want))
+			}
+			for i, w := range tt.want {
+				got := params[i]
+				if got.Name != w.name || got.Type != w.typ || got.Grouped != w.grouped || got.Position.Column != w.column {
+					t.Errorf("param %d = {%s %q col=%d grouped=%v}, want {%s %q col=%d grouped=%v}",
+						i, got.Name, got.Type, got.Position.Column, got.Grouped, w.name, w.typ, w.column, w.grouped)
+				}
+			}
+		})
+	}
+}
+
 func TestParser_ComplexTypeSignatures(t *testing.T) {
 	type tc struct {
 		input     string

--- a/internal/tuigen/parser_component_test.go
+++ b/internal/tuigen/parser_component_test.go
@@ -171,6 +171,20 @@ templ P(a, b string) {
 }`,
 			want: []wantParam{{"a", "string", 9, true}, {"b", "string", 12, false}},
 		},
+		"blank identifier": {
+			input: `package x
+templ P(_ int, b string) {
+	<span>{b}</span>
+}`,
+			want: []wantParam{{"_", "int", 9, false}, {"b", "string", 16, false}},
+		},
+		"templ keyword as a name": {
+			input: `package x
+templ P(templ string) {
+	<span>{templ}</span>
+}`,
+			want: []wantParam{{"templ", "string", 9, false}},
+		},
 		"grouped then variadic": {
 			input: `package x
 templ P(x, y int, opts ...tui.Option) {
@@ -291,6 +305,14 @@ func TestParseParamList(t *testing.T) {
 		"trailing bare name is dropped": {
 			list: "a int, b",
 			want: []wantParam{{"a", "int", 1, false}},
+		},
+		"blank identifier": {
+			list: "a int, _ string, c bool",
+			want: []wantParam{{"a", "int", 1, false}, {"_", "string", 8, false}, {"c", "bool", 18, false}},
+		},
+		"templ keyword as a name": {
+			list: "templ string, x int",
+			want: []wantParam{{"templ", "string", 1, false}, {"x", "int", 15, false}},
 		},
 	}
 

--- a/internal/tuigen/parser_component_test.go
+++ b/internal/tuigen/parser_component_test.go
@@ -221,7 +221,7 @@ templ P(
 templ P(a, b) {
 	<span>{a}</span>
 }`,
-			errorContains: "parameter b is missing a type",
+			errorContains: "test.gsx:2:12: error: parameter b is missing a type",
 		},
 	}
 


### PR DESCRIPTION
A reusable gsx component that wraps a built-in element such as `<modal>` had no way to let callers customize the underlying element short of redeclaring every attribute; there was no way to forward a slice of option funcs.

This adds an `options` attribute usable on every gsx element. The value must be a Go expression, its type follows the tag (`[]tui.Option` for plain elements, the constructor's option type such as `[]tui.ModalOption` for component elements), and it is applied after the attribute-derived options so entries in the slice override attributes.

```gsx
templ (d *dialog) Render() {
    <modal open={d.open} class="justify-center items-center" options={d.opts}>
        <div class="border-rounded p-1 flex-col gap-1">
            <span class="font-bold">{d.title}</span>
            {children...}
        </div>
    </modal>
}

templ Card(title string, opts ...tui.Option) {
    <div class="border-rounded p-1" options={opts}>
        <span>{title}</span>
    </div>
}
```

The generated call takes the form `tui.New(append([]tui.Option{...}, opts...)...)`, or `tui.New(opts...)` when there are no attribute options. Output without `options` is unchanged. The LSP schema lists the attribute for completion and hover, and the gopls virtual file spreads the expression into the tag's constructor so the slice type is checked in the editor.

Two related parser fixes ride along. A templ with a `{children...}` slot now gets an analyzer error if its last parameter is variadic, since children is passed as the trailing argument; before, `tui generate` failed with a Go parser error pointing into generated code. Grouped parameter names like `a, b string` are now parsed as Go does; before, the first name was silently dropped from the generated signature and `tui fmt` deleted it from the source. The same grouped-name handling now covers plain Go helper functions in `.gsx` files for LSP indexing and semantic tokens, which also fixes parameter types containing parentheses there.

Closes #138


